### PR TITLE
Derive Club Continuity Explanations From Table Notes

### DIFF
--- a/data/club-metadata.json
+++ b/data/club-metadata.json
@@ -2,8 +2,8 @@
   "metadata": {
     "schemaVersion": 1,
     "generator": "club-metadata-seed",
-    "generatedAt": "2026-06-13T01:20:37.827Z",
-    "gitSha": "f62ed8b",
+    "generatedAt": "2026-06-13T01:55:02.779Z",
+    "gitSha": "b76157a",
     "sourceFiles": [
       "/Users/dsteele/repos/footy-data-kit/data-output/all-seasons.json"
     ],
@@ -13,7 +13,29 @@
   },
   "clubs": {
     "aberdare athletic": {
+      "clubId": "aberdare-athletic",
       "canonicalName": "Aberdare Athletic",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": 1926,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": 1926,
+            "tiers": [
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -75,7 +97,29 @@
       }
     },
     "accrington": {
+      "clubId": "accrington",
       "canonicalName": "Accrington",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1888,
+        "trackedToSeason": 1892,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1888,
+            "toSeason": 1892,
+            "tiers": [
+              "tier1"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -134,7 +178,30 @@
       }
     },
     "accrington stanley": {
+      "clubId": "accrington-stanley",
       "canonicalName": "Accrington Stanley",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2006,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2006,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -258,7 +325,37 @@
       }
     },
     "accrington stanley 1891": {
+      "clubId": "accrington-stanley-1891",
       "canonicalName": "Accrington Stanley (1891)",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": 1961,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": 1961,
+            "tiers": [
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -443,7 +540,39 @@
       }
     },
     "afc bournemouth": {
+      "clubId": "afc-bournemouth",
       "canonicalName": "AFC Bournemouth",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1923,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1923,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -865,7 +994,30 @@
       }
     },
     "afc fylde": {
+      "clubId": "afc-fylde",
       "canonicalName": "AFC Fylde",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2017,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2017,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -952,7 +1104,30 @@
       }
     },
     "afc telford united": {
+      "clubId": "afc-telford-united",
       "canonicalName": "AFC Telford United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -1050,7 +1225,29 @@
       }
     },
     "afc totton": {
+      "clubId": "afc-totton",
       "canonicalName": "AFC Totton",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2025,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2025,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -1097,7 +1294,30 @@
       }
     },
     "afc wimbledon": {
+      "clubId": "afc-wimbledon",
       "canonicalName": "AFC Wimbledon",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2011,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2011,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -1207,7 +1427,37 @@
       }
     },
     "aldershot": {
+      "clubId": "aldershot",
       "canonicalName": "Aldershot",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1932,
+        "trackedToSeason": 1991,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1932,
+            "toSeason": 1991,
+            "tiers": [
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -1442,7 +1692,30 @@
       }
     },
     "aldershot town": {
+      "clubId": "aldershot-town",
       "canonicalName": "Aldershot Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2008,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2008,
+            "toSeason": null,
+            "tiers": [
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -1560,7 +1833,30 @@
       }
     },
     "alfreton town": {
+      "clubId": "alfreton-town",
       "canonicalName": "Alfreton Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -1647,7 +1943,29 @@
       }
     },
     "altrincham": {
+      "clubId": "altrincham",
       "canonicalName": "Altrincham",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2014,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2014,
+            "toSeason": null,
+            "tiers": [
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -1727,7 +2045,43 @@
       }
     },
     "arsenal": {
+      "clubId": "arsenal",
       "canonicalName": "Arsenal",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1893,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1893,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -2190,7 +2544,29 @@
       }
     },
     "ashington": {
+      "clubId": "ashington",
       "canonicalName": "Ashington",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": 1928,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": 1928,
+            "tiers": [
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -2258,7 +2634,44 @@
       }
     },
     "aston villa": {
+      "clubId": "aston-villa",
       "canonicalName": "Aston Villa",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1888,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1888,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -2719,7 +3132,29 @@
       }
     },
     "aveley": {
+      "clubId": "aveley",
       "canonicalName": "Aveley",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2023,
+        "trackedToSeason": 2024,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2023,
+            "toSeason": 2024,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -2769,7 +3204,29 @@
       }
     },
     "banbury united": {
+      "clubId": "banbury-united",
       "canonicalName": "Banbury United",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2022,
+        "trackedToSeason": 2023,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2022,
+            "toSeason": 2023,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -2819,7 +3276,31 @@
       }
     },
     "barnet": {
+      "clubId": "barnet",
       "canonicalName": "Barnet",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1991,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1991,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -2982,7 +3463,45 @@
       }
     },
     "barnsley": {
+      "clubId": "barnsley",
       "canonicalName": "Barnsley",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1898,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1898,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -3420,7 +3939,38 @@
       }
     },
     "barrow": {
+      "clubId": "barrow",
       "canonicalName": "Barrow",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -3678,7 +4228,29 @@
       }
     },
     "bath city": {
+      "clubId": "bath-city",
       "canonicalName": "Bath City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -3737,7 +4309,29 @@
       }
     },
     "bedford town": {
+      "clubId": "bedford-town",
       "canonicalName": "Bedford Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2025,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2025,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -3784,7 +4378,29 @@
       }
     },
     "billericay town": {
+      "clubId": "billericay-town",
       "canonicalName": "Billericay Town",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": 2021,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": 2021,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -3831,7 +4447,44 @@
       }
     },
     "birmingham city": {
+      "clubId": "birmingham-city",
       "canonicalName": "Birmingham City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1890,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1890,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -4323,7 +4976,29 @@
       }
     },
     "birmingham st georges": {
+      "clubId": "birmingham-st-georges",
       "canonicalName": "Birmingham St George's",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1890,
+        "trackedToSeason": 1891,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1890,
+            "toSeason": 1891,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -4373,7 +5048,29 @@
       }
     },
     "bishops stortford": {
+      "clubId": "bishops-stortford",
       "canonicalName": "Bishop's Stortford",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2023,
+        "trackedToSeason": 2023,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2023,
+            "toSeason": 2023,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -4420,7 +5117,44 @@
       }
     },
     "blackburn rovers": {
+      "clubId": "blackburn-rovers",
       "canonicalName": "Blackburn Rovers",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1888,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1888,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -4881,7 +5615,45 @@
       }
     },
     "blackpool": {
+      "clubId": "blackpool",
       "canonicalName": "Blackpool",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1896,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1896,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -5332,7 +6104,29 @@
       }
     },
     "blyth spartans": {
+      "clubId": "blyth-spartans",
       "canonicalName": "Blyth Spartans",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": 2023,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": 2023,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -5385,7 +6179,45 @@
       }
     },
     "bolton wanderers": {
+      "clubId": "bolton-wanderers",
       "canonicalName": "Bolton Wanderers",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1888,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1888,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -5853,7 +6685,29 @@
       }
     },
     "bootle": {
+      "clubId": "bootle",
       "canonicalName": "Bootle",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1890,
+        "trackedToSeason": 1892,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1890,
+            "toSeason": 1892,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -5906,7 +6760,30 @@
       }
     },
     "boreham wood": {
+      "clubId": "boreham-wood",
       "canonicalName": "Boreham Wood",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2015,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2015,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -5990,7 +6867,31 @@
       }
     },
     "boston united": {
+      "clubId": "boston-united",
       "canonicalName": "Boston United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2002,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2002,
+            "toSeason": null,
+            "tiers": [
+              "tier4",
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -6090,7 +6991,30 @@
       }
     },
     "brackley town": {
+      "clubId": "brackley-town",
       "canonicalName": "Brackley Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -6156,7 +7080,45 @@
       }
     },
     "bradford city": {
+      "clubId": "bradford-city",
       "canonicalName": "Bradford City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1903,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1903,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -6579,7 +7541,46 @@
       }
     },
     "bradford park avenue": {
+      "clubId": "bradford-park-avenue",
       "canonicalName": "Bradford (Park Avenue)",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1908,
+        "trackedToSeason": 2022,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1908,
+            "toSeason": 2022,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -6842,7 +7843,30 @@
       }
     },
     "braintree town": {
+      "clubId": "braintree-town",
       "canonicalName": "Braintree Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -6948,7 +7972,39 @@
       }
     },
     "brentford": {
+      "clubId": "brentford",
       "canonicalName": "Brentford",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -7322,7 +8378,39 @@
       }
     },
     "brighton and hove albion": {
+      "clubId": "brighton-and-hove-albion",
       "canonicalName": "Brighton & Hove Albion",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -7696,7 +8784,45 @@
       }
     },
     "bristol city": {
+      "clubId": "bristol-city",
       "canonicalName": "Bristol City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1901,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1901,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -8125,7 +9251,39 @@
       }
     },
     "bristol rovers": {
+      "clubId": "bristol-rovers",
       "canonicalName": "Bristol Rovers",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -8499,7 +9657,30 @@
       }
     },
     "bromley": {
+      "clubId": "bromley",
       "canonicalName": "Bromley",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2015,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2015,
+            "toSeason": null,
+            "tiers": [
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -8583,7 +9764,45 @@
       }
     },
     "burnley": {
+      "clubId": "burnley",
       "canonicalName": "Burnley",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1888,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1888,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -9051,7 +10270,31 @@
       }
     },
     "burton albion": {
+      "clubId": "burton-albion",
       "canonicalName": "Burton Albion",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2009,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2009,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -9173,7 +10416,29 @@
       }
     },
     "burton swifts": {
+      "clubId": "burton-swifts",
       "canonicalName": "Burton Swifts",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1891,
+        "trackedToSeason": 1900,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1891,
+            "toSeason": 1900,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -9260,7 +10525,29 @@
       }
     },
     "burton united": {
+      "clubId": "burton-united",
       "canonicalName": "Burton United",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1901,
+        "trackedToSeason": 1906,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1901,
+            "toSeason": 1906,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -9357,7 +10644,29 @@
       }
     },
     "burton wanderers": {
+      "clubId": "burton-wanderers",
       "canonicalName": "Burton Wanderers",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1894,
+        "trackedToSeason": 1896,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1894,
+            "toSeason": 1896,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -9423,7 +10732,45 @@
       }
     },
     "bury": {
+      "clubId": "bury",
       "canonicalName": "Bury",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1894,
+        "trackedToSeason": 2019,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1894,
+            "toSeason": 2019,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -9855,7 +11202,29 @@
       }
     },
     "buxton": {
+      "clubId": "buxton",
       "canonicalName": "Buxton",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2022,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2022,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -9911,7 +11280,32 @@
       }
     },
     "cambridge united": {
+      "clubId": "cambridge-united",
       "canonicalName": "Cambridge United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1970,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1970,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -10135,7 +11529,39 @@
       }
     },
     "cardiff city": {
+      "clubId": "cardiff-city",
       "canonicalName": "Cardiff City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -10509,7 +11935,40 @@
       }
     },
     "carlisle united": {
+      "clubId": "carlisle-united",
       "canonicalName": "Carlisle United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1928,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1928,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -10873,7 +12332,39 @@
       }
     },
     "charlton athletic": {
+      "clubId": "charlton-athletic",
       "canonicalName": "Charlton Athletic",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -11244,7 +12735,29 @@
       }
     },
     "chelmsford city": {
+      "clubId": "chelmsford-city",
       "canonicalName": "Chelmsford City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -11303,7 +12816,43 @@
       }
     },
     "chelsea": {
+      "clubId": "chelsea",
       "canonicalName": "Chelsea",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1905,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1905,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -11706,7 +13255,31 @@
       }
     },
     "cheltenham town": {
+      "clubId": "cheltenham-town",
       "canonicalName": "Cheltenham Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1999,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1999,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -11845,7 +13418,29 @@
       }
     },
     "chesham united": {
+      "clubId": "chesham-united",
       "canonicalName": "Chesham United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2024,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2024,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -11895,7 +13490,29 @@
       }
     },
     "cheshunt": {
+      "clubId": "cheshunt",
       "canonicalName": "Cheshunt",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2022,
+        "trackedToSeason": 2022,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2022,
+            "toSeason": 2022,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -11942,7 +13559,30 @@
       }
     },
     "chester": {
+      "clubId": "chester",
       "canonicalName": "Chester",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2013,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2013,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -12048,7 +13688,37 @@
       }
     },
     "chester city": {
+      "clubId": "chester-city",
       "canonicalName": "Chester City",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1931,
+        "trackedToSeason": 2008,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1931,
+            "toSeason": 2008,
+            "tiers": [
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -12360,7 +14030,39 @@
       }
     },
     "chesterfield": {
+      "clubId": "chesterfield",
       "canonicalName": "Chesterfield",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -12731,7 +14433,29 @@
       }
     },
     "chesterfield town": {
+      "clubId": "chesterfield-town",
       "canonicalName": "Chesterfield Town",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1899,
+        "trackedToSeason": 1908,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1899,
+            "toSeason": 1908,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -12805,7 +14529,29 @@
       }
     },
     "chippenham town": {
+      "clubId": "chippenham-town",
       "canonicalName": "Chippenham Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -12864,7 +14610,30 @@
       }
     },
     "chorley": {
+      "clubId": "chorley",
       "canonicalName": "Chorley",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2019,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2019,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -12945,7 +14714,31 @@
       }
     },
     "colchester united": {
+      "clubId": "colchester-united",
       "canonicalName": "Colchester United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1950,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1950,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -13237,7 +15030,29 @@
       }
     },
     "concord rangers": {
+      "clubId": "concord-rangers",
       "canonicalName": "Concord Rangers",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": 2022,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": 2022,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -13287,7 +15102,39 @@
       }
     },
     "coventry city": {
+      "clubId": "coventry-city",
       "canonicalName": "Coventry City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1919,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1919,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -13664,7 +15511,30 @@
       }
     },
     "crawley town": {
+      "clubId": "crawley-town",
       "canonicalName": "Crawley Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2011,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2011,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -13760,7 +15630,38 @@
       }
     },
     "crewe alexandra": {
+      "clubId": "crewe-alexandra",
       "canonicalName": "Crewe Alexandra",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1890,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1890,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -14152,7 +16053,39 @@
       }
     },
     "crystal palace": {
+      "clubId": "crystal-palace",
       "canonicalName": "Crystal Palace",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -14526,7 +16459,29 @@
       }
     },
     "curzon ashton": {
+      "clubId": "curzon-ashton",
       "canonicalName": "Curzon Ashton",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -14585,7 +16540,32 @@
       }
     },
     "dagenham and redbridge": {
+      "clubId": "dagenham-and-redbridge",
       "canonicalName": "Dagenham & Redbridge",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2007,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2007,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4",
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -14707,7 +16687,29 @@
       }
     },
     "darlington": {
+      "clubId": "darlington",
       "canonicalName": "Darlington",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -14779,7 +16781,38 @@
       }
     },
     "darlington 1883": {
+      "clubId": "darlington-1883",
       "canonicalName": "Darlington (1883)",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": 2009,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": 2009,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -15122,7 +17155,30 @@
       }
     },
     "dartford": {
+      "clubId": "dartford",
       "canonicalName": "Dartford",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": 2023,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": 2023,
+            "tiers": [
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -15203,7 +17259,30 @@
       }
     },
     "darwen": {
+      "clubId": "darwen",
       "canonicalName": "Darwen",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1890,
+        "trackedToSeason": 1898,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1890,
+            "toSeason": 1898,
+            "tiers": [
+              "tier1",
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -15281,7 +17360,44 @@
       }
     },
     "derby county": {
+      "clubId": "derby-county",
       "canonicalName": "Derby County",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1888,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1888,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -15742,7 +17858,38 @@
       }
     },
     "doncaster rovers": {
+      "clubId": "doncaster-rovers",
       "canonicalName": "Doncaster Rovers",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1901,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1901,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -16124,7 +18271,30 @@
       }
     },
     "dorking wanderers": {
+      "clubId": "dorking-wanderers",
       "canonicalName": "Dorking Wanderers",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -16190,7 +18360,30 @@
       }
     },
     "dover athletic": {
+      "clubId": "dover-athletic",
       "canonicalName": "Dover Athletic",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2014,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2014,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -16286,7 +18479,29 @@
       }
     },
     "dulwich hamlet": {
+      "clubId": "dulwich-hamlet",
       "canonicalName": "Dulwich Hamlet",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": 2022,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": 2022,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -16336,7 +18551,29 @@
       }
     },
     "durham city": {
+      "clubId": "durham-city",
       "canonicalName": "Durham City",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": 1927,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": 1927,
+            "tiers": [
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -16401,7 +18638,29 @@
       }
     },
     "eastbourne borough": {
+      "clubId": "eastbourne-borough",
       "canonicalName": "Eastbourne Borough",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -16460,7 +18719,29 @@
       }
     },
     "eastleigh": {
+      "clubId": "eastleigh",
       "canonicalName": "Eastleigh",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2014,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2014,
+            "toSeason": null,
+            "tiers": [
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -16540,7 +18821,30 @@
       }
     },
     "ebbsfleet united": {
+      "clubId": "ebbsfleet-united",
       "canonicalName": "Ebbsfleet United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -16640,7 +18944,29 @@
       }
     },
     "enfield town": {
+      "clubId": "enfield-town",
       "canonicalName": "Enfield Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2024,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2024,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -16690,7 +19016,43 @@
       }
     },
     "everton": {
+      "clubId": "everton",
       "canonicalName": "Everton",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1888,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1888,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -17144,7 +19506,37 @@
       }
     },
     "exeter city": {
+      "clubId": "exeter-city",
       "canonicalName": "Exeter City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -17499,7 +19891,29 @@
       }
     },
     "farnborough": {
+      "clubId": "farnborough",
       "canonicalName": "Farnborough",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2022,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2022,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -17555,7 +19969,29 @@
       }
     },
     "farsley celtic": {
+      "clubId": "farsley-celtic",
       "canonicalName": "Farsley Celtic",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": 2024,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": 2024,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -17611,7 +20047,29 @@
       }
     },
     "fc halifax town": {
+      "clubId": "fc-halifax-town",
       "canonicalName": "FC Halifax Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2013,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2013,
+            "toSeason": null,
+            "tiers": [
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -17716,7 +20174,30 @@
       }
     },
     "fleetwood town": {
+      "clubId": "fleetwood-town",
       "canonicalName": "Fleetwood Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -17809,7 +20290,31 @@
       }
     },
     "forest green rovers": {
+      "clubId": "forest-green-rovers",
       "canonicalName": "Forest Green Rovers",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -17909,7 +20414,45 @@
       }
     },
     "fulham": {
+      "clubId": "fulham",
       "canonicalName": "Fulham",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1907,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1907,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -18320,7 +20863,29 @@
       }
     },
     "gainsborough trinity": {
+      "clubId": "gainsborough-trinity",
       "canonicalName": "Gainsborough Trinity",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1896,
+        "trackedToSeason": 1911,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1896,
+            "toSeason": 1911,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -18412,7 +20977,30 @@
       }
     },
     "gateshead": {
+      "clubId": "gateshead",
       "canonicalName": "Gateshead",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -18524,7 +21112,38 @@
       }
     },
     "gateshead 1899": {
+      "clubId": "gateshead-1899",
       "canonicalName": "Gateshead (1899)",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1919,
+        "trackedToSeason": 1959,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1919,
+            "toSeason": 1959,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -18738,7 +21357,31 @@
       }
     },
     "gillingham": {
+      "clubId": "gillingham",
       "canonicalName": "Gillingham",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -19090,7 +21733,30 @@
       }
     },
     "glossop": {
+      "clubId": "glossop",
       "canonicalName": "Glossop",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1898,
+        "trackedToSeason": 1914,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1898,
+            "toSeason": 1914,
+            "tiers": [
+              "tier1",
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -19215,7 +21881,29 @@
       }
     },
     "gloucester city": {
+      "clubId": "gloucester-city",
       "canonicalName": "Gloucester City",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": 2023,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": 2023,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -19268,7 +21956,46 @@
       }
     },
     "grimsby town": {
+      "clubId": "grimsby-town",
       "canonicalName": "Grimsby Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1890,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1890,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -19748,7 +22475,30 @@
       }
     },
     "guiseley": {
+      "clubId": "guiseley",
       "canonicalName": "Guiseley",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2015,
+        "trackedToSeason": 2021,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2015,
+            "toSeason": 2021,
+            "tiers": [
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -19823,7 +22573,37 @@
       }
     },
     "halifax town": {
+      "clubId": "halifax-town",
       "canonicalName": "Halifax Town",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": 2001,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": 2001,
+            "tiers": [
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -20116,7 +22896,29 @@
       }
     },
     "hampton and richmond borough": {
+      "clubId": "hampton-and-richmond-borough",
       "canonicalName": "Hampton & Richmond Borough",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -20175,7 +22977,30 @@
       }
     },
     "harrogate town": {
+      "clubId": "harrogate-town",
       "canonicalName": "Harrogate Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2018,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2018,
+            "toSeason": null,
+            "tiers": [
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -20250,7 +23075,38 @@
       }
     },
     "hartlepool united": {
+      "clubId": "hartlepool-united",
       "canonicalName": "Hartlepool United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -20666,7 +23522,30 @@
       }
     },
     "havant and waterlooville": {
+      "clubId": "havant-and-waterlooville",
       "canonicalName": "Havant & Waterlooville",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2018,
+        "trackedToSeason": 2023,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2018,
+            "toSeason": 2023,
+            "tiers": [
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -20741,7 +23620,29 @@
       }
     },
     "hemel hempstead town": {
+      "clubId": "hemel-hempstead-town",
       "canonicalName": "Hemel Hempstead Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -20800,7 +23701,29 @@
       }
     },
     "hereford": {
+      "clubId": "hereford",
       "canonicalName": "Hereford",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -20872,7 +23795,32 @@
       }
     },
     "hereford united": {
+      "clubId": "hereford-united",
       "canonicalName": "Hereford United",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1972,
+        "trackedToSeason": 2013,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1972,
+            "toSeason": 2013,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -21061,7 +24009,29 @@
       }
     },
     "hornchurch": {
+      "clubId": "hornchurch",
       "canonicalName": "Hornchurch",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2024,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2024,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -21111,7 +24081,29 @@
       }
     },
     "horsham": {
+      "clubId": "horsham",
       "canonicalName": "Horsham",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2025,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2025,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -21158,7 +24150,45 @@
       }
     },
     "huddersfield town": {
+      "clubId": "huddersfield-town",
       "canonicalName": "Huddersfield Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1910,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1910,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -21560,7 +24590,45 @@
       }
     },
     "hull city": {
+      "clubId": "hull-city",
       "canonicalName": "Hull City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1905,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1905,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -21977,7 +25045,29 @@
       }
     },
     "hungerford town": {
+      "clubId": "hungerford-town",
       "canonicalName": "Hungerford Town",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": 2022,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": 2022,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -22027,7 +25117,29 @@
       }
     },
     "hyde": {
+      "clubId": "hyde",
       "canonicalName": "Hyde",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": 2013,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": 2013,
+            "tiers": [
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -22077,7 +25189,39 @@
       }
     },
     "ipswich town": {
+      "clubId": "ipswich-town",
       "canonicalName": "Ipswich Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1938,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1938,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -22397,7 +25541,29 @@
       }
     },
     "kettering town": {
+      "clubId": "kettering-town",
       "canonicalName": "Kettering Town",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": 2022,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": 2022,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -22447,7 +25613,31 @@
       }
     },
     "kidderminster harriers": {
+      "clubId": "kidderminster-harriers",
       "canonicalName": "Kidderminster Harriers",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2000,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2000,
+            "toSeason": null,
+            "tiers": [
+              "tier4",
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -22569,7 +25759,30 @@
       }
     },
     "kings lynn town": {
+      "clubId": "kings-lynn-town",
       "canonicalName": "King's Lynn Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2020,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2020,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -22638,7 +25851,29 @@
       }
     },
     "leamington": {
+      "clubId": "leamington",
       "canonicalName": "Leamington",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -22706,7 +25941,29 @@
       }
     },
     "leeds city": {
+      "clubId": "leeds-city",
       "canonicalName": "Leeds City",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1905,
+        "trackedToSeason": 1914,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1905,
+            "toSeason": 1914,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -22793,7 +26050,38 @@
       }
     },
     "leeds united": {
+      "clubId": "leeds-united",
       "canonicalName": "Leeds United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -23173,7 +26461,44 @@
       }
     },
     "leicester city": {
+      "clubId": "leicester-city",
       "canonicalName": "Leicester City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1894,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1894,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -23635,7 +26960,46 @@
       }
     },
     "leyton orient": {
+      "clubId": "leyton-orient",
       "canonicalName": "Leyton Orient",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1905,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1905,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -24102,7 +27466,45 @@
       }
     },
     "lincoln city": {
+      "clubId": "lincoln-city",
       "canonicalName": "Lincoln City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1891,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1891,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -24596,7 +27998,43 @@
       }
     },
     "liverpool": {
+      "clubId": "liverpool",
       "canonicalName": "Liverpool",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1893,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1893,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -25035,7 +28473,29 @@
       }
     },
     "loughborough": {
+      "clubId": "loughborough",
       "canonicalName": "Loughborough",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1895,
+        "trackedToSeason": 1899,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1895,
+            "toSeason": 1899,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -25094,7 +28554,40 @@
       }
     },
     "luton town": {
+      "clubId": "luton-town",
       "canonicalName": "Luton Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1897,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1897,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -25495,7 +28988,29 @@
       }
     },
     "macclesfield": {
+      "clubId": "macclesfield",
       "canonicalName": "Macclesfield",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2025,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2025,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -25542,7 +29057,31 @@
       }
     },
     "macclesfield town": {
+      "clubId": "macclesfield-town",
       "canonicalName": "Macclesfield Town",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1997,
+        "trackedToSeason": 2020,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1997,
+            "toSeason": 2020,
+            "tiers": [
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -25672,7 +29211,30 @@
       }
     },
     "maidenhead united": {
+      "clubId": "maidenhead-united",
       "canonicalName": "Maidenhead United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2017,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2017,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -25750,7 +29312,30 @@
       }
     },
     "maidstone united": {
+      "clubId": "maidstone-united",
       "canonicalName": "Maidstone United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2016,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2016,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -25850,7 +29435,29 @@
       }
     },
     "maidstone united 1897": {
+      "clubId": "maidstone-united-1897",
       "canonicalName": "Maidstone United (1897)",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1989,
+        "trackedToSeason": 1992,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1989,
+            "toSeason": 1992,
+            "tiers": [
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -25926,7 +29533,44 @@
       }
     },
     "manchester city": {
+      "clubId": "manchester-city",
       "canonicalName": "Manchester City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1891,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1891,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -26401,7 +30045,43 @@
       }
     },
     "manchester united": {
+      "clubId": "manchester-united",
       "canonicalName": "Manchester United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1890,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1890,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -26874,7 +30554,39 @@
       }
     },
     "mansfield town": {
+      "clubId": "mansfield-town",
       "canonicalName": "Mansfield Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1931,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1931,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -27213,7 +30925,29 @@
       }
     },
     "marine": {
+      "clubId": "marine",
       "canonicalName": "Marine",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2024,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2024,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -27263,7 +30997,31 @@
       }
     },
     "merthyr town": {
+      "clubId": "merthyr-town",
       "canonicalName": "Merthyr Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -27366,7 +31124,44 @@
       }
     },
     "middlesbrough": {
+      "clubId": "middlesbrough",
       "canonicalName": "Middlesbrough",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1899,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1899,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -27794,7 +31589,29 @@
       }
     },
     "middlesbrough ironopolis": {
+      "clubId": "middlesbrough-ironopolis",
       "canonicalName": "Middlesbrough Ironopolis",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1893,
+        "trackedToSeason": 1893,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1893,
+            "toSeason": 1893,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -27841,7 +31658,39 @@
       }
     },
     "millwall": {
+      "clubId": "millwall",
       "canonicalName": "Millwall",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -28215,7 +32064,31 @@
       }
     },
     "milton keynes dons": {
+      "clubId": "milton-keynes-dons",
       "canonicalName": "Milton Keynes Dons",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2004,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2004,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -28352,7 +32225,31 @@
       }
     },
     "morecambe": {
+      "clubId": "morecambe",
       "canonicalName": "Morecambe",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2007,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2007,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -28467,7 +32364,29 @@
       }
     },
     "needham market": {
+      "clubId": "needham-market",
       "canonicalName": "Needham Market",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2024,
+        "trackedToSeason": 2024,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2024,
+            "toSeason": 2024,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -28514,7 +32433,30 @@
       }
     },
     "nelson": {
+      "clubId": "nelson",
       "canonicalName": "Nelson",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": 1930,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": 1930,
+            "tiers": [
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -28595,7 +32537,36 @@
       }
     },
     "new brighton": {
+      "clubId": "new-brighton",
       "canonicalName": "New Brighton",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1923,
+        "trackedToSeason": 1950,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1923,
+            "toSeason": 1950,
+            "tiers": [
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -28714,7 +32685,29 @@
       }
     },
     "new brighton tower": {
+      "clubId": "new-brighton-tower",
       "canonicalName": "New Brighton Tower",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1898,
+        "trackedToSeason": 1900,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1898,
+            "toSeason": 1900,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -28767,7 +32760,43 @@
       }
     },
     "newcastle united": {
+      "clubId": "newcastle-united",
       "canonicalName": "Newcastle United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1893,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1893,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -29206,7 +33235,30 @@
       }
     },
     "newport county": {
+      "clubId": "newport-county",
       "canonicalName": "Newport County",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": null,
+            "tiers": [
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -29312,7 +33364,38 @@
       }
     },
     "newport county 1912": {
+      "clubId": "newport-county-1912",
       "canonicalName": "Newport County (1912)",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": 1987,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": 1987,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -29592,7 +33675,29 @@
       }
     },
     "north ferriby united": {
+      "clubId": "north-ferriby-united",
       "canonicalName": "North Ferriby United",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2016,
+        "trackedToSeason": 2016,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2016,
+            "toSeason": 2016,
+            "tiers": [
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -29639,7 +33744,39 @@
       }
     },
     "northampton town": {
+      "clubId": "northampton-town",
       "canonicalName": "Northampton Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -30013,7 +34150,29 @@
       }
     },
     "northwich victoria": {
+      "clubId": "northwich-victoria",
       "canonicalName": "Northwich Victoria",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1892,
+        "trackedToSeason": 1893,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1892,
+            "toSeason": 1893,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -30063,7 +34222,39 @@
       }
     },
     "norwich city": {
+      "clubId": "norwich-city",
       "canonicalName": "Norwich City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -30437,7 +34628,45 @@
       }
     },
     "nottingham forest": {
+      "clubId": "nottingham-forest",
       "canonicalName": "Nottingham Forest",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1890,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1890,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -30899,7 +35128,46 @@
       }
     },
     "notts county": {
+      "clubId": "notts-county",
       "canonicalName": "Notts County",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1888,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1888,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -31374,7 +35642,29 @@
       }
     },
     "nuneaton town": {
+      "clubId": "nuneaton-town",
       "canonicalName": "Nuneaton Town",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": 2014,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": 2014,
+            "tiers": [
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -31427,7 +35717,46 @@
       }
     },
     "oldham athletic": {
+      "clubId": "oldham-athletic",
       "canonicalName": "Oldham Athletic",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1907,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1907,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -31845,7 +36174,31 @@
       }
     },
     "oxford city": {
+      "clubId": "oxford-city",
       "canonicalName": "Oxford City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier6",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -31918,7 +36271,32 @@
       }
     },
     "oxford united": {
+      "clubId": "oxford-united",
       "canonicalName": "Oxford United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1962,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1962,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -32175,7 +36553,29 @@
       }
     },
     "peterborough sports": {
+      "clubId": "peterborough-sports",
       "canonicalName": "Peterborough Sports",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2022,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2022,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -32231,7 +36631,31 @@
       }
     },
     "peterborough united": {
+      "clubId": "peterborough-united",
       "canonicalName": "Peterborough United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1960,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1960,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -32487,7 +36911,38 @@
       }
     },
     "plymouth argyle": {
+      "clubId": "plymouth-argyle",
       "canonicalName": "Plymouth Argyle",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -32854,7 +37309,38 @@
       }
     },
     "port vale": {
+      "clubId": "port-vale",
       "canonicalName": "Port Vale",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1892,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1892,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -33301,7 +37787,39 @@
       }
     },
     "portsmouth": {
+      "clubId": "portsmouth",
       "canonicalName": "Portsmouth",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -33675,7 +38193,45 @@
       }
     },
     "preston north end": {
+      "clubId": "preston-north-end",
       "canonicalName": "Preston North End",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1888,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1888,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -34143,7 +38699,39 @@
       }
     },
     "queens park rangers": {
+      "clubId": "queens-park-rangers",
       "canonicalName": "Queens Park Rangers",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -34517,7 +39105,29 @@
       }
     },
     "radcliffe": {
+      "clubId": "radcliffe",
       "canonicalName": "Radcliffe",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2024,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2024,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -34567,7 +39177,39 @@
       }
     },
     "reading": {
+      "clubId": "reading",
       "canonicalName": "Reading",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -34941,7 +39583,38 @@
       }
     },
     "rochdale": {
+      "clubId": "rochdale",
       "canonicalName": "Rochdale",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -35305,7 +39978,30 @@
       }
     },
     "rotherham county": {
+      "clubId": "rotherham-county",
       "canonicalName": "Rotherham County",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1919,
+        "trackedToSeason": 1924,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1919,
+            "toSeason": 1924,
+            "tiers": [
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -35387,7 +40083,29 @@
       }
     },
     "rotherham town": {
+      "clubId": "rotherham-town",
       "canonicalName": "Rotherham Town",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1893,
+        "trackedToSeason": 1895,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1893,
+            "toSeason": 1895,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -35453,7 +40171,38 @@
       }
     },
     "rotherham united": {
+      "clubId": "rotherham-united",
       "canonicalName": "Rotherham United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1925,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1925,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -35829,7 +40578,29 @@
       }
     },
     "rushall olympic": {
+      "clubId": "rushall-olympic",
       "canonicalName": "Rushall Olympic",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2023,
+        "trackedToSeason": 2024,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2023,
+            "toSeason": 2024,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -35879,7 +40650,30 @@
       }
     },
     "rushden and diamonds": {
+      "clubId": "rushden-and-diamonds",
       "canonicalName": "Rushden & Diamonds",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2001,
+        "trackedToSeason": 2005,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2001,
+            "toSeason": 2005,
+            "tiers": [
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -35945,7 +40739,30 @@
       }
     },
     "salford city": {
+      "clubId": "salford-city",
       "canonicalName": "Salford City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2018,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2018,
+            "toSeason": null,
+            "tiers": [
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -36020,7 +40837,29 @@
       }
     },
     "salisbury": {
+      "clubId": "salisbury",
       "canonicalName": "Salisbury",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2024,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2024,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -36070,7 +40909,29 @@
       }
     },
     "salisbury city": {
+      "clubId": "salisbury-city",
       "canonicalName": "Salisbury City",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2013,
+        "trackedToSeason": 2013,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2013,
+            "toSeason": 2013,
+            "tiers": [
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -36117,7 +40978,29 @@
       }
     },
     "scarborough": {
+      "clubId": "scarborough",
       "canonicalName": "Scarborough",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1987,
+        "trackedToSeason": 1998,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1987,
+            "toSeason": 1998,
+            "tiers": [
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -36210,7 +41093,29 @@
       }
     },
     "scarborough athletic": {
+      "clubId": "scarborough-athletic",
       "canonicalName": "Scarborough Athletic",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2022,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2022,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -36279,7 +41184,33 @@
       }
     },
     "scunthorpe united": {
+      "clubId": "scunthorpe-united",
       "canonicalName": "Scunthorpe United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1950,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1950,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -36602,7 +41533,45 @@
       }
     },
     "sheffield united": {
+      "clubId": "sheffield-united",
       "canonicalName": "Sheffield United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1892,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1892,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -37058,7 +42027,44 @@
       }
     },
     "sheffield wednesday": {
+      "clubId": "sheffield-wednesday",
       "canonicalName": "Sheffield Wednesday",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1890,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1890,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -37537,7 +42543,31 @@
       }
     },
     "shrewsbury town": {
+      "clubId": "shrewsbury-town",
       "canonicalName": "Shrewsbury Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1950,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1950,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -37832,7 +42862,29 @@
       }
     },
     "slough town": {
+      "clubId": "slough-town",
       "canonicalName": "Slough Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -37891,7 +42943,29 @@
       }
     },
     "solihull moors": {
+      "clubId": "solihull-moors",
       "canonicalName": "Solihull Moors",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2016,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2016,
+            "toSeason": null,
+            "tiers": [
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -37965,7 +43039,29 @@
       }
     },
     "south shields": {
+      "clubId": "south-shields",
       "canonicalName": "South Shields",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2023,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2023,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -38018,7 +43114,39 @@
       }
     },
     "southampton": {
+      "clubId": "southampton",
       "canonicalName": "Southampton",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -38392,7 +43520,39 @@
       }
     },
     "southend united": {
+      "clubId": "southend-united",
       "canonicalName": "Southend United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -38766,7 +43926,39 @@
       }
     },
     "southport": {
+      "clubId": "southport",
       "canonicalName": "Southport",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4",
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -39043,7 +44235,29 @@
       }
     },
     "spennymoor town": {
+      "clubId": "spennymoor-town",
       "canonicalName": "Spennymoor Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -39102,7 +44316,29 @@
       }
     },
     "st albans city": {
+      "clubId": "st-albans-city",
       "canonicalName": "St Albans City",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": 2024,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": 2024,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -39158,7 +44394,29 @@
       }
     },
     "stalybridge celtic": {
+      "clubId": "stalybridge-celtic",
       "canonicalName": "Stalybridge Celtic",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": 1922,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": 1922,
+            "tiers": [
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -39208,7 +44466,30 @@
       }
     },
     "stevenage": {
+      "clubId": "stevenage",
       "canonicalName": "Stevenage",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2010,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2010,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -39307,7 +44588,45 @@
       }
     },
     "stockport county": {
+      "clubId": "stockport-county",
       "canonicalName": "Stockport County",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1900,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1900,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -39745,7 +45064,38 @@
       }
     },
     "stoke city": {
+      "clubId": "stoke-city",
       "canonicalName": "Stoke City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1888,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1888,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -40209,7 +45559,44 @@
       }
     },
     "sunderland": {
+      "clubId": "sunderland",
       "canonicalName": "Sunderland",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1890,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1890,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -40664,7 +46051,29 @@
       }
     },
     "sunderland albion": {
+      "clubId": "sunderland-albion",
       "canonicalName": "Sunderland Albion",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1890,
+        "trackedToSeason": 1890,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1890,
+            "toSeason": 1890,
+            "tiers": [
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -40711,7 +46120,30 @@
       }
     },
     "sutton united": {
+      "clubId": "sutton-united",
       "canonicalName": "Sutton United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2016,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2016,
+            "toSeason": null,
+            "tiers": [
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -40792,7 +46224,39 @@
       }
     },
     "swansea city": {
+      "clubId": "swansea-city",
       "canonicalName": "Swansea City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -41191,7 +46655,39 @@
       }
     },
     "swindon town": {
+      "clubId": "swindon-town",
       "canonicalName": "Swindon Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -41565,7 +47061,30 @@
       }
     },
     "tamworth": {
+      "clubId": "tamworth",
       "canonicalName": "Tamworth",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -41643,7 +47162,29 @@
       }
     },
     "taunton town": {
+      "clubId": "taunton-town",
       "canonicalName": "Taunton Town",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2022,
+        "trackedToSeason": 2023,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2022,
+            "toSeason": 2023,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -41693,7 +47234,29 @@
       }
     },
     "thames": {
+      "clubId": "thames",
       "canonicalName": "Thames",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1930,
+        "trackedToSeason": 1931,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1930,
+            "toSeason": 1931,
+            "tiers": [
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -41743,7 +47306,29 @@
       }
     },
     "tonbridge angels": {
+      "clubId": "tonbridge-angels",
       "canonicalName": "Tonbridge Angels",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2021,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2021,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -41802,7 +47387,39 @@
       }
     },
     "torquay united": {
+      "clubId": "torquay-united",
       "canonicalName": "Torquay United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1927,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1927,
+            "toSeason": null,
+            "tiers": [
+              "tier3",
+              "tier4",
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -42166,7 +47783,43 @@
       }
     },
     "tottenham hotspur": {
+      "clubId": "tottenham-hotspur",
       "canonicalName": "Tottenham Hotspur",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1908,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1908,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -42560,7 +48213,39 @@
       }
     },
     "tranmere rovers": {
+      "clubId": "tranmere-rovers",
       "canonicalName": "Tranmere Rovers",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -42931,7 +48616,30 @@
       }
     },
     "truro city": {
+      "clubId": "truro-city",
       "canonicalName": "Truro City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2023,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2023,
+            "toSeason": null,
+            "tiers": [
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -42991,7 +48699,38 @@
       }
     },
     "walsall": {
+      "clubId": "walsall",
       "canonicalName": "Walsall",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1890,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1890,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -43424,7 +49163,29 @@
       }
     },
     "warrington town": {
+      "clubId": "warrington-town",
       "canonicalName": "Warrington Town",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2023,
+        "trackedToSeason": 2024,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2023,
+            "toSeason": 2024,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -43474,7 +49235,39 @@
       }
     },
     "watford": {
+      "clubId": "watford",
       "canonicalName": "Watford",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1920,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1920,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -43848,7 +49641,29 @@
       }
     },
     "wealdstone": {
+      "clubId": "wealdstone",
       "canonicalName": "Wealdstone",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2020,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2020,
+            "toSeason": null,
+            "tiers": [
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -43910,7 +49725,30 @@
       }
     },
     "welling united": {
+      "clubId": "welling-united",
       "canonicalName": "Welling United",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2013,
+        "trackedToSeason": 2024,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2013,
+            "toSeason": 2024,
+            "tiers": [
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -43994,7 +49832,44 @@
       }
     },
     "west bromwich albion": {
+      "clubId": "west-bromwich-albion",
       "canonicalName": "West Bromwich Albion",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1888,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1888,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -44455,7 +50330,37 @@
       }
     },
     "west ham united": {
+      "clubId": "west-ham-united",
       "canonicalName": "West Ham United",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1919,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1919,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -44818,7 +50723,29 @@
       }
     },
     "weston-super-mare": {
+      "clubId": "weston-super-mare",
       "canonicalName": "Weston-super-Mare",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2023,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2023,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -44871,7 +50798,30 @@
       }
     },
     "weymouth": {
+      "clubId": "weymouth",
       "canonicalName": "Weymouth",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 2020,
+        "trackedToSeason": 2024,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2020,
+            "toSeason": 2024,
+            "tiers": [
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -44937,7 +50887,32 @@
       }
     },
     "wigan athletic": {
+      "clubId": "wigan-athletic",
       "canonicalName": "Wigan Athletic",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1978,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1978,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -45159,7 +51134,29 @@
       }
     },
     "wigan borough": {
+      "clubId": "wigan-borough",
       "canonicalName": "Wigan Borough",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": 1931,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": 1931,
+            "tiers": [
+              "tier3"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -45249,7 +51246,32 @@
       }
     },
     "wimbledon": {
+      "clubId": "wimbledon",
       "canonicalName": "Wimbledon",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1977,
+        "trackedToSeason": 2003,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1977,
+            "toSeason": 2003,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -45420,7 +51442,29 @@
       }
     },
     "woking": {
+      "clubId": "woking",
       "canonicalName": "Woking",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2012,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2012,
+            "toSeason": null,
+            "tiers": [
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -45515,7 +51559,45 @@
       }
     },
     "wolverhampton wanderers": {
+      "clubId": "wolverhampton-wanderers",
       "canonicalName": "Wolverhampton Wanderers",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1888,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1888,
+            "toSeason": null,
+            "tiers": [
+              "tier1",
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1915,
+            "toSeason": 1918,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -45983,7 +52065,30 @@
       }
     },
     "workington": {
+      "clubId": "workington",
       "canonicalName": "Workington",
+      "status": {
+        "current": "unknown",
+        "trackedFromSeason": 1951,
+        "trackedToSeason": 1976,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1951,
+            "toSeason": 1976,
+            "tiers": [
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -46112,7 +52217,29 @@
       }
     },
     "worksop town": {
+      "clubId": "worksop-town",
       "canonicalName": "Worksop Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2025,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2025,
+            "toSeason": null,
+            "tiers": [
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -46159,7 +52286,29 @@
       }
     },
     "worthing": {
+      "clubId": "worthing",
       "canonicalName": "Worthing",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2022,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2022,
+            "toSeason": null,
+            "tiers": [
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -46215,7 +52364,39 @@
       }
     },
     "wrexham": {
+      "clubId": "wrexham",
       "canonicalName": "Wrexham",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1921,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1921,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -46584,7 +52765,31 @@
       }
     },
     "wycombe wanderers": {
+      "clubId": "wycombe-wanderers",
       "canonicalName": "Wycombe Wanderers",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1993,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1993,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -46741,7 +52946,33 @@
       }
     },
     "yeovil town": {
+      "clubId": "yeovil-town",
       "canonicalName": "Yeovil Town",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 2003,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": false
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 2003,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5",
+              "tier7"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": []
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [
@@ -46882,7 +53113,40 @@
       }
     },
     "york city": {
+      "clubId": "york-city",
       "canonicalName": "York City",
+      "status": {
+        "current": "active",
+        "trackedFromSeason": 1929,
+        "trackedToSeason": null,
+        "hasUnexplainedGaps": true
+      },
+      "history": {
+        "nameHistory": [],
+        "lifecycleEvents": [],
+        "trackedMembership": [
+          {
+            "fromSeason": 1929,
+            "toSeason": null,
+            "tiers": [
+              "tier2",
+              "tier3",
+              "tier4",
+              "tier5",
+              "tier6"
+            ],
+            "basis": "observed"
+          }
+        ],
+        "absenceExplanations": [
+          {
+            "fromSeason": 1939,
+            "toSeason": 1945,
+            "reason": "official-competition-paused",
+            "basis": "season-metadata"
+          }
+        ]
+      },
       "derived": {
         "source": "football-data-output",
         "aliases": [

--- a/data/club-metadata.json
+++ b/data/club-metadata.json
@@ -2,8 +2,8 @@
   "metadata": {
     "schemaVersion": 1,
     "generator": "club-metadata-seed",
-    "generatedAt": "2026-06-13T01:55:02.779Z",
-    "gitSha": "b76157a",
+    "generatedAt": "2026-06-13T02:09:56.781Z",
+    "gitSha": "eb41a68",
     "sourceFiles": [
       "/Users/dsteele/repos/footy-data-kit/data-output/all-seasons.json"
     ],
@@ -1000,11 +1000,24 @@
         "current": "active",
         "trackedFromSeason": 2017,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2019,
+            "description": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2019–20_in_English_football",
+                "notes": "National League Top Division table in 2019–20_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2017,
@@ -1016,7 +1029,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2020,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2019–20_in_English_football",
+                "notes": "National League Top Division table in 2019–20_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -1110,11 +1139,48 @@
         "current": "active",
         "trackedFromSeason": 2012,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2012,
+            "description": "Relegation to Conference North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2012–13_in_English_football",
+                "notes": "League tables table in 2012–13_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2014,
+            "description": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2014–15_in_English_football",
+                "notes": "Conference Premier table in 2014–15_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2022,
+            "description": "Relegation to the Southern League Premier Division Central",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2022–23_in_English_football",
+                "notes": "North table in 2022–23_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2012,
@@ -1126,7 +1192,53 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2013,
+            "toSeason": 2013,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Conference North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2012–13_in_English_football",
+                "notes": "League tables table in 2012–13_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 2015,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2014–15_in_English_football",
+                "notes": "Conference Premier table in 2014–15_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 2023,
+            "toSeason": 2024,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to the Southern League Premier Division Central",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2022–23_in_English_football",
+                "notes": "North table in 2022–23_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -1839,11 +1951,24 @@
         "current": "active",
         "trackedFromSeason": 2012,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2014,
+            "description": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2014–15_in_English_football",
+                "notes": "Conference Premier table in 2014–15_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2012,
@@ -1855,7 +1980,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2015,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2014–15_in_English_football",
+                "notes": "Conference Premier table in 2014–15_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -1949,11 +2090,24 @@
         "current": "active",
         "trackedFromSeason": 2014,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2015,
+            "description": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2015–16_in_English_football",
+                "notes": "National League Top Division table in 2015–16_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2014,
@@ -1964,7 +2118,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2016,
+            "toSeason": 2019,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2015–16_in_English_football",
+                "notes": "National League Top Division table in 2015–16_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -3282,11 +3452,24 @@
         "current": "active",
         "trackedFromSeason": 1991,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2000,
+            "description": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2000–01_in_English_football",
+                "notes": "Football League Third Division table in 2000–01_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1991,
@@ -3299,7 +3482,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2001,
+            "toSeason": 2004,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2000–01_in_English_football",
+                "notes": "Football League Third Division table in 2000–01_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -3945,11 +4144,36 @@
         "current": "active",
         "trackedFromSeason": 1921,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "not-re-elected",
+            "season": 1971,
+            "description": "Failed re-election and demoted to the Northern Premier League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1971–72_in_English_football",
+                "notes": "Fourth Division table in 1971–72_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2012,
+            "description": "Relegation to Conference North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2012–13_in_English_football",
+                "notes": "League tables table in 2012–13_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1921,
@@ -3968,6 +4192,36 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1972,
+            "toSeason": 2011,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted to the Northern Premier League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1971–72_in_English_football",
+                "notes": "Fourth Division table in 1971–72_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 2013,
+            "toSeason": 2014,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Conference North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2012–13_in_English_football",
+                "notes": "League tables table in 2012–13_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -5621,11 +5875,24 @@
         "current": "active",
         "trackedFromSeason": 1896,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "not-re-elected",
+            "season": 1898,
+            "description": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1898–99_in_English_football",
+                "notes": "Second Division table in 1898–99_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1896,
@@ -5640,6 +5907,21 @@
           }
         ],
         "absenceExplanations": [
+          {
+            "fromSeason": 1899,
+            "toSeason": 1899,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1898–99_in_English_football",
+                "notes": "Second Division table in 1898–99_in_English_football"
+              }
+            ]
+          },
           {
             "fromSeason": 1915,
             "toSeason": 1918,
@@ -6873,11 +7155,24 @@
         "current": "active",
         "trackedFromSeason": 2002,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2006,
+            "description": "Relegation to Conference North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2006–07_in_English_football",
+                "notes": "Football League Two table in 2006–07_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2002,
@@ -6890,7 +7185,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2007,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Conference North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2006–07_in_English_football",
+                "notes": "Football League Two table in 2006–07_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -7547,11 +7858,24 @@
         "current": "unknown",
         "trackedFromSeason": 1908,
         "trackedToSeason": 2022,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "not-re-elected",
+            "season": 1969,
+            "description": "Failed re-election and demoted to the Northern Premier League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1969–70_in_English_football",
+                "notes": "Fourth Division table in 1969–70_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1908,
@@ -7578,6 +7902,21 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1970,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted to the Northern Premier League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1969–70_in_English_football",
+                "notes": "Fourth Division table in 1969–70_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -7849,11 +8188,36 @@
         "current": "active",
         "trackedFromSeason": 2012,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2016,
+            "description": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2016–17_in_English_football",
+                "notes": "National League Top Division table in 2016–17_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2018,
+            "description": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2018–19_in_English_football",
+                "notes": "National League Top Division table in 2018–19_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2012,
@@ -7865,7 +8229,38 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2017,
+            "toSeason": 2017,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2016–17_in_English_football",
+                "notes": "National League Top Division table in 2016–17_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 2019,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2018–19_in_English_football",
+                "notes": "National League Top Division table in 2018–19_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -11286,11 +11681,24 @@
         "current": "active",
         "trackedFromSeason": 1970,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2004,
+            "description": "Relegation to Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2004–05_in_English_football",
+                "notes": "Football League Two table in 2004–05_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1970,
@@ -11304,7 +11712,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2005,
+            "toSeason": 2011,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2004–05_in_English_football",
+                "notes": "Football League Two table in 2004–05_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -11941,11 +12365,24 @@
         "current": "active",
         "trackedFromSeason": 1928,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2003,
+            "description": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2003–04_in_English_football",
+                "notes": "Football League Third Division table in 2003–04_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1928,
@@ -11966,6 +12403,21 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 2004,
+            "toSeason": 2004,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2003–04_in_English_football",
+                "notes": "Football League Third Division table in 2003–04_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -13565,11 +14017,24 @@
         "current": "active",
         "trackedFromSeason": 2013,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2017,
+            "description": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2017–18_in_English_football",
+                "notes": "National League Top Division table in 2017–18_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2013,
@@ -13581,7 +14046,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2018,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2017–18_in_English_football",
+                "notes": "National League Top Division table in 2017–18_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -13694,11 +14175,24 @@
         "current": "unknown",
         "trackedFromSeason": 1931,
         "trackedToSeason": 2008,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 1999,
+            "description": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1999–2000_in_English_football",
+                "notes": "Football League Division Three table in 1999–2000_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1931,
@@ -13716,6 +14210,21 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 2000,
+            "toSeason": 2003,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1999–2000_in_English_football",
+                "notes": "Football League Division Three table in 1999–2000_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -14616,11 +15125,24 @@
         "current": "active",
         "trackedFromSeason": 2019,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2019,
+            "description": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2019–20_in_English_football",
+                "notes": "National League Top Division table in 2019–20_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2019,
@@ -14632,7 +15154,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2020,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2019–20_in_English_football",
+                "notes": "National League Top Division table in 2019–20_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -14720,11 +15258,24 @@
         "current": "active",
         "trackedFromSeason": 1950,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 1989,
+            "description": "Relegation to the Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1989–90_in_English_football",
+                "notes": "Fourth Division table in 1989–90_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1950,
@@ -14737,7 +15288,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 1990,
+            "toSeason": 1991,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to the Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1989–90_in_English_football",
+                "notes": "Fourth Division table in 1989–90_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -15636,11 +16203,24 @@
         "current": "active",
         "trackedFromSeason": 1890,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "resigned-from-league",
+            "season": 1895,
+            "description": "Resigned from league",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1895–96_in_English_football",
+                "notes": "Second Division table in 1895–96_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1890,
@@ -15654,6 +16234,21 @@
           }
         ],
         "absenceExplanations": [
+          {
+            "fromSeason": 1896,
+            "toSeason": 1920,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "resigned-from-league",
+            "basis": "table-note",
+            "notes": "Resigned from league",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1895–96_in_English_football",
+                "notes": "Second Division table in 1895–96_in_English_football"
+              }
+            ]
+          },
           {
             "fromSeason": 1939,
             "toSeason": 1945,
@@ -16787,11 +17382,24 @@
         "current": "unknown",
         "trackedFromSeason": 1921,
         "trackedToSeason": 2009,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 1988,
+            "description": "Relegation to the Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1988–89_in_English_football",
+                "notes": "Fourth Division table in 1988–89_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1921,
@@ -16810,6 +17418,21 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1989,
+            "toSeason": 1989,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to the Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1988–89_in_English_football",
+                "notes": "Fourth Division table in 1988–89_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -17161,11 +17784,24 @@
         "current": "unknown",
         "trackedFromSeason": 2012,
         "trackedToSeason": 2023,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2014,
+            "description": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2014–15_in_English_football",
+                "notes": "Conference Premier table in 2014–15_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2012,
@@ -17177,7 +17813,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2015,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2014–15_in_English_football",
+                "notes": "Conference Premier table in 2014–15_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -17864,11 +18516,48 @@
         "current": "active",
         "trackedFromSeason": 1901,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "not-re-elected",
+            "season": 1902,
+            "description": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1902–03_in_English_football",
+                "notes": "Second Division table in 1902–03_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "not-re-elected",
+            "season": 1904,
+            "description": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1904–05_in_English_football",
+                "notes": "Second Division table in 1904–05_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 1997,
+            "description": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1997–98_in_English_football",
+                "notes": "Third Division table in 1997–98_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1901,
@@ -17883,10 +18572,55 @@
         ],
         "absenceExplanations": [
           {
+            "fromSeason": 1903,
+            "toSeason": 1903,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1902–03_in_English_football",
+                "notes": "Second Division table in 1902–03_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 1905,
+            "toSeason": 1922,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1904–05_in_English_football",
+                "notes": "Second Division table in 1904–05_in_English_football"
+              }
+            ]
+          },
+          {
             "fromSeason": 1939,
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1998,
+            "toSeason": 2002,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1997–98_in_English_football",
+                "notes": "Third Division table in 1997–98_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -18366,11 +19100,24 @@
         "current": "active",
         "trackedFromSeason": 2014,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2023,
+            "description": "Relegation to the Isthmian League Premier Division",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2023–24_in_English_football",
+                "notes": "South table in 2023–24_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2014,
@@ -18382,7 +19129,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2024,
+            "toSeason": 2024,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to the Isthmian League Premier Division",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2023–24_in_English_football",
+                "notes": "South table in 2023–24_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -18827,11 +19590,36 @@
         "current": "active",
         "trackedFromSeason": 2012,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2012,
+            "description": "Relegation to Conference South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2012–13_in_English_football",
+                "notes": "League tables table in 2012–13_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2019,
+            "description": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2019–20_in_English_football",
+                "notes": "National League Top Division table in 2019–20_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2012,
@@ -18843,7 +19631,38 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2013,
+            "toSeason": 2016,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Conference South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2012–13_in_English_football",
+                "notes": "League tables table in 2012–13_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 2020,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2019–20_in_English_football",
+                "notes": "National League Top Division table in 2019–20_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -19512,11 +20331,24 @@
         "current": "active",
         "trackedFromSeason": 1920,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2002,
+            "description": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2002–03_in_English_football",
+                "notes": "Football League Third Division table in 2002–03_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1920,
@@ -19534,6 +20366,21 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 2003,
+            "toSeason": 2007,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2002–03_in_English_football",
+                "notes": "Football League Third Division table in 2002–03_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -20053,11 +20900,24 @@
         "current": "active",
         "trackedFromSeason": 2013,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2015,
+            "description": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2015–16_in_English_football",
+                "notes": "National League Top Division table in 2015–16_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2013,
@@ -20068,7 +20928,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2016,
+            "toSeason": 2016,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2015–16_in_English_football",
+                "notes": "National League Top Division table in 2015–16_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -20983,11 +21859,24 @@
         "current": "active",
         "trackedFromSeason": 2012,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2018,
+            "description": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2018–19_in_English_football",
+                "notes": "National League Top Division table in 2018–19_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2012,
@@ -20999,7 +21888,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2019,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2018–19_in_English_football",
+                "notes": "National League Top Division table in 2018–19_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -21363,11 +22268,24 @@
         "current": "active",
         "trackedFromSeason": 1920,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "not-re-elected",
+            "season": 1937,
+            "description": "Failed re-election and demoted to the Southern League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1937–38_in_English_football",
+                "notes": "Third Division South table in 1937–38_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1920,
@@ -21380,7 +22298,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 1938,
+            "toSeason": 1949,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted to the Southern League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1937–38_in_English_football",
+                "notes": "Third Division South table in 1937–38_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -21962,11 +22896,36 @@
         "current": "active",
         "trackedFromSeason": 1890,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "not-re-elected",
+            "season": 1909,
+            "description": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1909–10_in_English_football",
+                "notes": "Second Division table in 1909–10_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2009,
+            "description": "Relegation to Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2009–10_in_English_football",
+                "notes": "Football League Two table in 2009–10_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1890,
@@ -21983,6 +22942,21 @@
         ],
         "absenceExplanations": [
           {
+            "fromSeason": 1910,
+            "toSeason": 1910,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1909–10_in_English_football",
+                "notes": "Second Division table in 1909–10_in_English_football"
+              }
+            ]
+          },
+          {
             "fromSeason": 1915,
             "toSeason": 1918,
             "reason": "official-competition-paused",
@@ -21993,6 +22967,21 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 2010,
+            "toSeason": 2011,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2009–10_in_English_football",
+                "notes": "Football League Two table in 2009–10_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -22481,11 +23470,24 @@
         "current": "unknown",
         "trackedFromSeason": 2015,
         "trackedToSeason": 2021,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2017,
+            "description": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2017–18_in_English_football",
+                "notes": "National League Top Division table in 2017–18_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2015,
@@ -22497,7 +23499,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2018,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2017–18_in_English_football",
+                "notes": "National League Top Division table in 2017–18_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -22579,11 +23597,24 @@
         "current": "unknown",
         "trackedFromSeason": 1921,
         "trackedToSeason": 2001,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 1992,
+            "description": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1992–93_in_English_football",
+                "notes": "League Division Three table in 1992–93_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1921,
@@ -22601,6 +23632,21 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1993,
+            "toSeason": 1997,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1992–93_in_English_football",
+                "notes": "League Division Three table in 1992–93_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -23528,11 +24574,24 @@
         "current": "unknown",
         "trackedFromSeason": 2018,
         "trackedToSeason": 2023,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2018,
+            "description": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2018–19_in_English_football",
+                "notes": "National League Top Division table in 2018–19_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2018,
@@ -23544,7 +24603,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2019,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2018–19_in_English_football",
+                "notes": "National League Top Division table in 2018–19_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -23801,11 +24876,24 @@
         "current": "unknown",
         "trackedFromSeason": 1972,
         "trackedToSeason": 2013,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 1996,
+            "description": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1996–97_in_English_football",
+                "notes": "Third Division table in 1996–97_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1972,
@@ -23819,7 +24907,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 1997,
+            "toSeason": 2005,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1996–97_in_English_football",
+                "notes": "Third Division table in 1996–97_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -25619,11 +26723,36 @@
         "current": "active",
         "trackedFromSeason": 2000,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2004,
+            "description": "Relegation to Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2004–05_in_English_football",
+                "notes": "Football League Two table in 2004–05_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2015,
+            "description": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2015–16_in_English_football",
+                "notes": "National League Top Division table in 2015–16_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2000,
@@ -25636,7 +26765,38 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2005,
+            "toSeason": 2011,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2004–05_in_English_football",
+                "notes": "Football League Two table in 2004–05_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 2016,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2015–16_in_English_football",
+                "notes": "National League Top Division table in 2015–16_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -25857,11 +27017,24 @@
         "current": "active",
         "trackedFromSeason": 2021,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2022,
+            "description": "Relegation to the Southern League Premier Division Central",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2022–23_in_English_football",
+                "notes": "North table in 2022–23_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2021,
@@ -25872,7 +27045,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2023,
+            "toSeason": 2023,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to the Southern League Premier Division Central",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2022–23_in_English_football",
+                "notes": "North table in 2022–23_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -27472,11 +28661,72 @@
         "current": "active",
         "trackedFromSeason": 1891,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "not-re-elected",
+            "season": 1907,
+            "description": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1907–08_in_English_football",
+                "notes": "Second Division table in 1907–08_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "not-re-elected",
+            "season": 1910,
+            "description": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1910–11_in_English_football",
+                "notes": "Second Division table in 1910–11_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "not-re-elected",
+            "season": 1919,
+            "description": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1919–20_in_English_football",
+                "notes": "Second Division table in 1919–20_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 1986,
+            "description": "Relegation to the Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1986–87_in_English_football",
+                "notes": "Fourth Division table in 1986–87_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2010,
+            "description": "Relegation to Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2010–11_in_English_football",
+                "notes": "Football League Two table in 2010–11_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1891,
@@ -27492,16 +28742,91 @@
         ],
         "absenceExplanations": [
           {
+            "fromSeason": 1908,
+            "toSeason": 1908,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1907–08_in_English_football",
+                "notes": "Second Division table in 1907–08_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 1911,
+            "toSeason": 1911,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1910–11_in_English_football",
+                "notes": "Second Division table in 1910–11_in_English_football"
+              }
+            ]
+          },
+          {
             "fromSeason": 1915,
             "toSeason": 1918,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
           },
           {
+            "fromSeason": 1920,
+            "toSeason": 1920,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1919–20_in_English_football",
+                "notes": "Second Division table in 1919–20_in_English_football"
+              }
+            ]
+          },
+          {
             "fromSeason": 1939,
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1987,
+            "toSeason": 1987,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to the Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1986–87_in_English_football",
+                "notes": "Fourth Division table in 1986–87_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 2011,
+            "toSeason": 2011,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2010–11_in_English_football",
+                "notes": "Football League Two table in 2010–11_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -28560,11 +29885,36 @@
         "current": "active",
         "trackedFromSeason": 1897,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "not-re-elected",
+            "season": 1899,
+            "description": "Failed re-election and demoted to the Southern League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1899–1900_in_English_football",
+                "notes": "Second Division table in 1899–1900_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2008,
+            "description": "Relegated to Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2008–09_in_English_football",
+                "notes": "Football League Two table in 2008–09_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1897,
@@ -28581,10 +29931,40 @@
         ],
         "absenceExplanations": [
           {
+            "fromSeason": 1900,
+            "toSeason": 1919,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted to the Southern League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1899–1900_in_English_football",
+                "notes": "Second Division table in 1899–1900_in_English_football"
+              }
+            ]
+          },
+          {
             "fromSeason": 1939,
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 2009,
+            "toSeason": 2011,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegated to Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2008–09_in_English_football",
+                "notes": "Football League Two table in 2008–09_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -29318,11 +30698,24 @@
         "current": "active",
         "trackedFromSeason": 2016,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2018,
+            "description": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2018–19_in_English_football",
+                "notes": "National League Top Division table in 2018–19_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2016,
@@ -29334,7 +30727,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2019,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2018–19_in_English_football",
+                "notes": "National League Top Division table in 2018–19_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -30560,11 +31969,24 @@
         "current": "active",
         "trackedFromSeason": 1931,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2007,
+            "description": "Relegation to 2008–09 Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2007–08_in_English_football",
+                "notes": "Football League Two table in 2007–08_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1931,
@@ -30584,6 +32006,21 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 2008,
+            "toSeason": 2011,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to 2008–09 Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2007–08_in_English_football",
+                "notes": "Football League Two table in 2007–08_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -31003,11 +32440,24 @@
         "current": "active",
         "trackedFromSeason": 1920,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "not-re-elected",
+            "season": 1929,
+            "description": "Failed re-election and demoted to the Southern League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1929–30_in_English_football",
+                "notes": "Third Division South table in 1929–30_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1920,
@@ -31020,7 +32470,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 1930,
+            "toSeason": 2024,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted to the Southern League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1929–30_in_English_football",
+                "notes": "Third Division South table in 1929–30_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -33370,11 +34836,24 @@
         "current": "unknown",
         "trackedFromSeason": 1920,
         "trackedToSeason": 1987,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "not-re-elected",
+            "season": 1930,
+            "description": "Failed re-election and demoted to the Southern League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1930–31_in_English_football",
+                "notes": "Third Division South table in 1930–31_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1920,
@@ -33388,6 +34867,21 @@
           }
         ],
         "absenceExplanations": [
+          {
+            "fromSeason": 1931,
+            "toSeason": 1931,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted to the Southern League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1930–31_in_English_football",
+                "notes": "Third Division South table in 1930–31_in_English_football"
+              }
+            ]
+          },
           {
             "fromSeason": 1939,
             "toSeason": 1945,
@@ -36277,11 +37771,24 @@
         "current": "active",
         "trackedFromSeason": 1962,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2005,
+            "description": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2005–06_in_English_football",
+                "notes": "Football League Two table in 2005–06_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1962,
@@ -36295,7 +37802,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2006,
+            "toSeason": 2009,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2005–06_in_English_football",
+                "notes": "Football League Two table in 2005–06_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -37315,11 +38838,36 @@
         "current": "active",
         "trackedFromSeason": 1892,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "resigned-from-league",
+            "season": 1895,
+            "description": "Resigned from league",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1895–96_in_English_football",
+                "notes": "Second Division table in 1895–96_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "resigned-from-league",
+            "season": 1906,
+            "description": "Resigned from the league",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1906–07_in_English_football",
+                "notes": "Second Division table in 1906–07_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1892,
@@ -37333,6 +38881,36 @@
           }
         ],
         "absenceExplanations": [
+          {
+            "fromSeason": 1896,
+            "toSeason": 1897,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "resigned-from-league",
+            "basis": "table-note",
+            "notes": "Resigned from league",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1895–96_in_English_football",
+                "notes": "Second Division table in 1895–96_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 1907,
+            "toSeason": 1918,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "resigned-from-league",
+            "basis": "table-note",
+            "notes": "Resigned from the league",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1906–07_in_English_football",
+                "notes": "Second Division table in 1906–07_in_English_football"
+              }
+            ]
+          },
           {
             "fromSeason": 1939,
             "toSeason": 1945,
@@ -42549,11 +44127,24 @@
         "current": "active",
         "trackedFromSeason": 1950,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2002,
+            "description": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2002–03_in_English_football",
+                "notes": "Football League Third Division table in 2002–03_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1950,
@@ -42566,7 +44157,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2003,
+            "toSeason": 2003,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2002–03_in_English_football",
+                "notes": "Football League Third Division table in 2002–03_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -43932,11 +45539,36 @@
         "current": "active",
         "trackedFromSeason": 1921,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "not-re-elected",
+            "season": 1977,
+            "description": "Failed re-election and demoted to the Northern Premier League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1977–78_in_English_football",
+                "notes": "Fourth Division table in 1977–78_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2016,
+            "description": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2016–17_in_English_football",
+                "notes": "National League Top Division table in 2016–17_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1921,
@@ -43956,6 +45588,36 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 1978,
+            "toSeason": 2011,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted to the Northern Premier League",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1977–78_in_English_football",
+                "notes": "Fourth Division table in 1977–78_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 2017,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2016–17_in_English_football",
+                "notes": "National League Top Division table in 2016–17_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -44594,11 +46256,48 @@
         "current": "active",
         "trackedFromSeason": 1900,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "not-re-elected",
+            "season": 1903,
+            "description": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1903–04_in_English_football",
+                "notes": "Second Division table in 1903–04_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2010,
+            "description": "Relegation to Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2010–11_in_English_football",
+                "notes": "Football League Two table in 2010–11_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2012,
+            "description": "Relegation to Conference North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2012–13_in_English_football",
+                "notes": "League tables table in 2012–13_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1900,
@@ -44614,6 +46313,21 @@
         ],
         "absenceExplanations": [
           {
+            "fromSeason": 1904,
+            "toSeason": 1904,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1903–04_in_English_football",
+                "notes": "Second Division table in 1903–04_in_English_football"
+              }
+            ]
+          },
+          {
             "fromSeason": 1915,
             "toSeason": 1918,
             "reason": "official-competition-paused",
@@ -44624,6 +46338,36 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 2011,
+            "toSeason": 2011,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2010–11_in_English_football",
+                "notes": "Football League Two table in 2010–11_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 2013,
+            "toSeason": 2018,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Conference North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2012–13_in_English_football",
+                "notes": "League tables table in 2012–13_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -45070,11 +46814,24 @@
         "current": "active",
         "trackedFromSeason": 1888,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "resigned-from-league",
+            "season": 1907,
+            "description": "Resigned from the league",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1907–08_in_English_football",
+                "notes": "Second Division table in 1907–08_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1888,
@@ -45088,6 +46845,21 @@
           }
         ],
         "absenceExplanations": [
+          {
+            "fromSeason": 1908,
+            "toSeason": 1918,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "resigned-from-league",
+            "basis": "table-note",
+            "notes": "Resigned from the league",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1907–08_in_English_football",
+                "notes": "Second Division table in 1907–08_in_English_football"
+              }
+            ]
+          },
           {
             "fromSeason": 1939,
             "toSeason": 1945,
@@ -47067,11 +48839,24 @@
         "current": "active",
         "trackedFromSeason": 2012,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2013,
+            "description": "Relegation to Conference North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2013–14_in_English_football",
+                "notes": "League tables table in 2013–14_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2012,
@@ -47083,7 +48868,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2014,
+            "toSeason": 2022,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Conference North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2013–14_in_English_football",
+                "notes": "League tables table in 2013–14_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -47393,11 +49194,36 @@
         "current": "active",
         "trackedFromSeason": 1927,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2006,
+            "description": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2006–07_in_English_football",
+                "notes": "Football League Two table in 2006–07_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2017,
+            "description": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2017–18_in_English_football",
+                "notes": "National League Top Division table in 2017–18_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1927,
@@ -47417,6 +49243,36 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 2007,
+            "toSeason": 2008,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2006–07_in_English_football",
+                "notes": "Football League Two table in 2006–07_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 2018,
+            "toSeason": 2018,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2017–18_in_English_football",
+                "notes": "National League Top Division table in 2017–18_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -48705,11 +50561,36 @@
         "current": "active",
         "trackedFromSeason": 1890,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "resigned-from-league",
+            "season": 1894,
+            "description": "Resigned from league",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1894–95_in_English_football",
+                "notes": "Second Division table in 1894–95_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "not-re-elected",
+            "season": 1900,
+            "description": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1900–01_in_English_football",
+                "notes": "Second Division table in 1900–01_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1890,
@@ -48723,6 +50604,36 @@
           }
         ],
         "absenceExplanations": [
+          {
+            "fromSeason": 1895,
+            "toSeason": 1895,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "resigned-from-league",
+            "basis": "table-note",
+            "notes": "Resigned from league",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1894–95_in_English_football",
+                "notes": "Second Division table in 1894–95_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 1901,
+            "toSeason": 1920,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "not-re-elected",
+            "basis": "table-note",
+            "notes": "Failed re-election and demoted",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/1900–01_in_English_football",
+                "notes": "Second Division table in 1900–01_in_English_football"
+              }
+            ]
+          },
           {
             "fromSeason": 1939,
             "toSeason": 1945,
@@ -49731,11 +51642,24 @@
         "current": "unknown",
         "trackedFromSeason": 2013,
         "trackedToSeason": 2024,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2015,
+            "description": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2015–16_in_English_football",
+                "notes": "National League Top Division table in 2015–16_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2013,
@@ -49747,7 +51671,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2016,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2015–16_in_English_football",
+                "notes": "National League Top Division table in 2015–16_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -51448,11 +53388,24 @@
         "current": "active",
         "trackedFromSeason": 2012,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2017,
+            "description": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2017–18_in_English_football",
+                "notes": "National League Top Division table in 2017–18_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 2012,
@@ -51463,7 +53416,23 @@
             "basis": "observed"
           }
         ],
-        "absenceExplanations": []
+        "absenceExplanations": [
+          {
+            "fromSeason": 2018,
+            "toSeason": 2018,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League South",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2017–18_in_English_football",
+                "notes": "National League Top Division table in 2017–18_in_English_football"
+              }
+            ]
+          }
+        ]
       },
       "derived": {
         "source": "football-data-output",
@@ -52370,11 +54339,24 @@
         "current": "active",
         "trackedFromSeason": 1921,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2007,
+            "description": "Relegation to 2008–09 Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2007–08_in_English_football",
+                "notes": "Football League Two table in 2007–08_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1921,
@@ -52394,6 +54376,21 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 2008,
+            "toSeason": 2011,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to 2008–09 Conference National",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2007–08_in_English_football",
+                "notes": "Football League Two table in 2007–08_in_English_football"
+              }
+            ]
           }
         ]
       },
@@ -53119,11 +55116,36 @@
         "current": "active",
         "trackedFromSeason": 1929,
         "trackedToSeason": null,
-        "hasUnexplainedGaps": true
+        "hasUnexplainedGaps": false
       },
       "history": {
         "nameHistory": [],
-        "lifecycleEvents": [],
+        "lifecycleEvents": [
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2003,
+            "description": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2003–04_in_English_football",
+                "notes": "Football League Third Division table in 2003–04_in_English_football"
+              }
+            ]
+          },
+          {
+            "type": "relegated-outside-tracked-coverage",
+            "season": 2016,
+            "description": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2016–17_in_English_football",
+                "notes": "National League Top Division table in 2016–17_in_English_football"
+              }
+            ]
+          }
+        ],
         "trackedMembership": [
           {
             "fromSeason": 1929,
@@ -53144,6 +55166,36 @@
             "toSeason": 1945,
             "reason": "official-competition-paused",
             "basis": "season-metadata"
+          },
+          {
+            "fromSeason": 2004,
+            "toSeason": 2011,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to Football Conference",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2003–04_in_English_football",
+                "notes": "Football League Third Division table in 2003–04_in_English_football"
+              }
+            ]
+          },
+          {
+            "fromSeason": 2017,
+            "toSeason": 2020,
+            "reason": "outside-tracked-coverage",
+            "linkedEventType": "relegated-outside-tracked-coverage",
+            "basis": "table-note",
+            "notes": "Relegation to National League North",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-season-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/2016–17_in_English_football",
+                "notes": "National League Top Division table in 2016–17_in_English_football"
+              }
+            ]
           }
         ]
       },

--- a/docs/club-metadata-layer-2.md
+++ b/docs/club-metadata-layer-2.md
@@ -1,0 +1,357 @@
+# Club Metadata Layer 2 Plan
+
+Layer 1 now derives club continuity metadata from the scraped season table data. It explains observed coverage gaps using table-row notes such as `Failed re-election`, `Resigned from league`, and `Relegation to Conference North`.
+
+Layer 2 should add source-backed club history facts that are not safely derivable from season table rows alone.
+
+## Current Layer 1 Boundary
+
+Layer 1 is intentionally conservative:
+
+- It is generated from `data-output/all-seasons.json`.
+- It only uses facts already present in scraped table rows and season metadata.
+- It emits `history.lifecycleEvents[]` and `history.absenceExplanations[]`.
+- Table-note explanations use `basis: "table-note"`.
+- Official competition pauses use `basis: "season-metadata"`.
+- It explains why a club left our tracked table coverage, not every event that happened during a long absence.
+
+This should stay reproducible. Do not hand-edit `data/club-metadata.json` to add researched facts.
+
+## Layer 2 Goal
+
+Layer 2 should enrich club metadata with researched, source-backed events such as:
+
+- `club-dissolved`
+- `club-reformed`
+- `club-inactive`
+- `liquidation`
+- `administration`
+- `phoenix`
+- `identity-continuity-note`
+- name changes with date ranges when they are not already covered by observed table names
+
+These facts should help consumers understand long gaps and historical identity changes without overloading the season table data.
+
+## Proposed Data Model
+
+Keep layer 2 facts separate from generated observations until they are merged by the generator.
+
+Recommended source file:
+
+```text
+data/club-history-overrides.json
+```
+
+Possible shape:
+
+```json
+{
+  "metadata": {
+    "schemaVersion": 1,
+    "description": "Source-backed club history enrichments merged into generated club metadata."
+  },
+  "clubs": {
+    "merthyr-town": {
+      "history": {
+        "lifecycleEvents": [
+          {
+            "type": "club-dissolved",
+            "season": 1934,
+            "description": "Original Merthyr Town ceased to play after four seasons back in the Southern League.",
+            "basis": "researched-source",
+            "sourceRefs": [
+              {
+                "type": "wikipedia-club-page",
+                "sourceUrl": "https://en.wikipedia.org/wiki/Merthyr_Town_F.C."
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+Open schema questions to settle during implementation:
+
+- Whether `basis` should be added to `ClubLifecycleEvent` as a first-class typed field.
+- Whether financial events should be event `type` values under `lifecycleEvents`, or a separate `history.financialEvents[]` list.
+- Whether identity notes should live under `history.lifecycleEvents[]` or `derived.relationships[]` when they connect predecessor/successor clubs.
+
+Recommendation:
+
+- Add `basis?: string` to `ClubLifecycleEvent`.
+- Keep financial events under `history.lifecycleEvents[]` for now with event types like `liquidation` and `administration`.
+- Keep relationships in `derived.relationships[]` only when there are two distinct tracked club identities to connect.
+
+## Merge Strategy
+
+Layer 2 should be merged during `wiki:club-seed`, not edited into generated JSON manually.
+
+Implementation steps:
+
+1. Add `data/club-history-overrides.json`.
+2. Add a loader/normalizer for the override file.
+3. Merge override `history.lifecycleEvents[]`, `history.nameHistory[]`, and possibly `history.absenceExplanations[]` into generated records.
+4. Preserve generated layer 1 events; do not replace them unless the override explicitly supersedes them.
+5. Deduplicate events by stable fields like `type`, `season`, `description`, and `sourceRefs`.
+6. Add tests for merge behavior and conflict handling.
+7. Regenerate `data/club-metadata.json`.
+
+The generator should fail loudly if an override references an unknown `clubId` or malformed source reference.
+
+## Verification Strategy
+
+The current continuity verifier only checks whether expected missing seasons are explained. Layer 2 should add source-quality checks:
+
+- Every researched event must have at least one `sourceRefs[]` entry.
+- Every researched event must have `basis: "researched-source"`.
+- Every override club key must resolve to a generated club identity.
+- Every source URL must be a non-empty HTTP(S) URL.
+- Event types should come from a small allowed list.
+
+Start these checks in report mode, then tighten to errors once the first batch is stable.
+
+## Initial Club Queue
+
+Prioritize long gaps where layer 1 is correct but incomplete:
+
+| Club                   | Layer 1 gap | Current layer 1 reason                                    | Layer 2 research need                                                                              |
+| ---------------------- | ----------- | --------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| Merthyr Town           | 1930-2024   | Failed re-election and demoted to Southern League         | Dissolved/ceased in 1934, Merthyr Tydfil period from 1945, liquidation/reformation in 2010         |
+| Bradford (Park Avenue) | 1970-2020   | Failed re-election and demoted to Northern Premier League | Disbanded/liquidated in 1974, reformed/phoenix identity in 1987                                    |
+| Barrow                 | 1972-2011   | Failed re-election and demoted to Northern Premier League | Mostly confirms layer 1; note return to EFL in 2020 and non-league period                          |
+| Southport              | 1978-2011   | Failed re-election and demoted to Northern Premier League | Mostly confirms layer 1; note long non-league period after losing Football League place            |
+| Crewe Alexandra        | 1896-1920   | Resigned from league                                      | Confirm non-league competitions before Third Division North entry                                  |
+| Luton Town             | 1900-1919   | Failed re-election and demoted to Southern League         | Financial instability caused exit; rejoined Football League in 1920-21                             |
+| Walsall                | 1901-1920   | Failed re-election and demoted                            | Confirm competitions/identity during non-league period                                             |
+| Doncaster Rovers       | 1905-1922   | Failed re-election and demoted                            | Lost re-election votes in 1903 and 1905; returned to Midland League and rejoined in 1923           |
+| Boston United          | 2007-2020   | Relegation to Conference North                            | Financial/admin nuance: relegated from League Two, later still in administration and demoted again |
+| Gillingham             | 1938-1949   | Failed re-election and demoted to Southern League         | Confirm Southern League period and Football League return                                          |
+| Port Vale              | 1907-1918   | Resigned from the league                                  | Financial collapse/insolvency, identity continuity through new Port Vale                           |
+| Stoke City             | 1908-1918   | Resigned from the league                                  | Financial problems/liquidation and league return after war                                         |
+
+## Spot-Check Research Notes
+
+These notes are for planning only. They should be re-verified when encoded as layer 2 metadata.
+
+### Merthyr Town
+
+Layer 1 says the club failed re-election and was demoted to the Southern League after the 1929-30 season.
+
+Research notes:
+
+- The club played in the Football League from 1920 to 1930.
+- It was voted out of the Football League in 1930.
+- It returned to the Southern League and ceased to play in 1934.
+- A Merthyr Tydfil club formed in 1945.
+- Merthyr Tydfil liquidated in 2010 and a new Merthyr Town was formed.
+
+Source:
+
+- https://en.wikipedia.org/wiki/Merthyr_Town_F.C.
+
+Likely layer 2 events:
+
+- `not-re-elected` already generated from layer 1.
+- `club-dissolved` or `club-inactive`, season 1934.
+- `club-reformed`, season 1945, likely linked to Merthyr Tydfil identity.
+- `liquidation`, season 2010.
+- `club-reformed`, season 2010.
+
+### Bradford (Park Avenue)
+
+Layer 1 says the club failed re-election and was demoted to the Northern Premier League after the 1969-70 season.
+
+Research notes:
+
+- The club failed in its Football League re-election bid in 1970.
+- It spent four seasons in the Northern Premier League before disbanding.
+- The modern club identity requires careful handling as a revived/reformed club.
+
+Source:
+
+- https://en.wikipedia.org/wiki/Bradford_%28Park_Avenue%29_A.F.C.
+
+Likely layer 2 events:
+
+- `not-re-elected` already generated from layer 1.
+- `club-dissolved` or `club-inactive`, season 1974.
+- `club-reformed` or `phoenix`, season 1987 if confirmed and modeled.
+
+### Barrow
+
+Layer 1 says the club failed re-election and was demoted to the Northern Premier League after the 1971-72 season.
+
+Research notes:
+
+- The generated reason is directionally correct.
+- The club returned to the EFL as National League champions in 2020.
+- Our layer 1 gap ends earlier than 2020 because lower-tier tracked coverage starts seeing Barrow again before the EFL return.
+
+Source:
+
+- https://en.wikipedia.org/wiki/Barrow_A.F.C.
+
+Likely layer 2 events:
+
+- No urgent new event needed beyond layer 1.
+- Optional: add researched note for EFL return in 2020 if we later track re-entry milestones.
+
+### Southport
+
+Layer 1 says the club failed re-election and was demoted to the Northern Premier League after the 1977-78 season.
+
+Research notes:
+
+- Southport was a Football League member from 1921 to 1978.
+- It failed to gain re-election in 1978.
+- It then played in the Northern Premier League and Football Conference structure.
+
+Source:
+
+- https://en.wikipedia.org/wiki/Southport_F.C.
+
+Likely layer 2 events:
+
+- No urgent new event needed beyond layer 1.
+- Optional: add researched note for post-Football League competitions.
+
+### Crewe Alexandra
+
+Layer 1 says the club resigned from the league after the 1895-96 season.
+
+Research notes:
+
+- The table note explains the gap.
+- Further research should confirm the club's non-league competitions between the 1896 exit and 1921 Football League return.
+- Known likely path includes Combination, Lancashire League, Birmingham & District League, and Central League, but encode only after source verification.
+
+Source:
+
+- https://en.wikipedia.org/wiki/Crewe_Alexandra_F.C.
+
+Likely layer 2 events:
+
+- `resigned-from-league` already generated from layer 1.
+- Optional: researched `joined-nonleague-competition` events are probably too granular for now.
+
+### Luton Town
+
+Layer 1 says the club failed re-election and was demoted to the Southern League after the 1899-1900 season.
+
+Research notes:
+
+- Luton joined the Football League in 1897.
+- It left again in 1900 because of financial instability.
+- It rejoined the Football League for the 1920-21 season.
+
+Source:
+
+- https://en.wikipedia.org/wiki/History_of_Luton_Town_F.C._%281885%E2%80%931970%29
+
+Likely layer 2 events:
+
+- Layer 1 event should maybe stay as `not-re-elected` if driven by the table note.
+- Add researched `financial-issue` or `left-football-league` event for 1900 if we introduce that type.
+
+### Boston United
+
+Layer 1 says the club was relegated to Conference North after the 2006-07 season.
+
+Research notes:
+
+- Boston was relegated from League Two in May 2007.
+- The club was still in administration in May 2008 and was relegated again to the Northern Premier League Premier Division.
+- This is a good candidate for financial/admin metadata.
+
+Source:
+
+- https://en.wikipedia.org/wiki/Boston_United_F.C.
+
+Likely layer 2 events:
+
+- `relegated-outside-tracked-coverage` already generated from layer 1.
+- `administration`, around 2007-2008.
+- Optional `demoted` event for the 2008 administrative/financial drop.
+
+### Port Vale
+
+Layer 1 says Burslem Port Vale resigned from the league after the 1906-07 season.
+
+Research notes:
+
+- Financial turmoil intensified with debts and falling support.
+- The chairman declared the club insolvent on 14 June 1907.
+- Vale resigned from the Football League.
+- There is identity-continuity nuance around the Port Vale name after the old Burslem Port Vale era ended.
+
+Source:
+
+- https://en.wikipedia.org/wiki/1906%E2%80%9307_Burslem_Port_Vale_F.C._season
+
+Likely layer 2 events:
+
+- `resigned-from-league` already generated from layer 1.
+- `liquidation` or `club-inactive`, season 1907.
+- `identity-continuity-note` for continuation under Port Vale.
+
+### Stoke City
+
+Layer 1 says Stoke resigned from the league after the 1907-08 season.
+
+Research notes:
+
+- Stoke had financial problems around 1900.
+- In 1908, Stoke went into liquidation and resigned from the League.
+- The club later continued and returned after the war-era gap.
+
+Source:
+
+- https://en.wikipedia.org/wiki/History_of_Stoke_City_F.C.
+
+Likely layer 2 events:
+
+- `resigned-from-league` already generated from layer 1.
+- `liquidation`, season 1908.
+- Optional `club-reformed` or `identity-continuity-note` depending on how the source describes the new company.
+
+### Doncaster Rovers
+
+Layer 1 says the club failed re-election and was demoted after the 1904-05 season.
+
+Research notes:
+
+- Doncaster entered the Football League in 1901.
+- It lost re-election votes in 1903 and 1905.
+- It returned to the Midland League.
+- It was admitted to the Football League for a third time in 1923.
+
+Source:
+
+- https://en.wikipedia.org/wiki/Doncaster_Rovers_F.C.
+
+Likely layer 2 events:
+
+- `not-re-elected` already generated from layer 1.
+- Optional researched `returned-to-football-league`, season 1923, if we decide to track re-entry events.
+
+## Implementation Notes
+
+Keep event types small at first. A reasonable initial enum:
+
+- `not-re-elected`
+- `resigned-from-league`
+- `relegated-outside-tracked-coverage`
+- `club-inactive`
+- `club-dissolved`
+- `club-reformed`
+- `liquidation`
+- `administration`
+- `phoenix`
+- `identity-continuity-note`
+
+Do not add all event types to generated layer 1. Layer 1 should stay limited to table-note-derived continuity signals.
+
+Layer 2 should be implemented as a curated enrichment pass with explicit source references and tests.

--- a/docs/index.html
+++ b/docs/index.html
@@ -67,18 +67,29 @@
 
         <div class="release-pin">
           <span class="release-label">latest</span>
-          <strong>v0.8.0</strong>
+          <strong>v0.8.1</strong>
           <span>1888-2025. 138 seasons. 232 club metadata records.</span>
           <span class="release-actions">
             <a href="https://github.com/dills122/footy-data-kit/releases/latest">notes</a>
             <a
-              href="https://github.com/dills122/footy-data-kit/releases/latest/download/footy-data-kit-v0.8.0-data.zip"
+              href="https://github.com/dills122/footy-data-kit/releases/latest/download/footy-data-kit-v0.8.1-data.zip"
               >data zip</a
             >
           </span>
         </div>
 
         <div class="release-rows" aria-label="historic releases">
+          <div class="release-row">
+            <span>v0.8.0</span>
+            <span>previous data release</span>
+            <span class="release-actions">
+              <a href="https://github.com/dills122/footy-data-kit/releases/tag/v0.8.0">notes</a>
+              <a
+                href="https://github.com/dills122/footy-data-kit/releases/download/v0.8.0/footy-data-kit-v0.8.0-data.zip"
+                >data zip</a
+              >
+            </span>
+          </div>
           <div class="release-row">
             <span>v0.7.0</span>
             <span>previous data release</span>
@@ -186,7 +197,7 @@
           </li>
           <li>
             <code>club-metadata.json</code>
-            <span>Club identity sidecar metadata. 926K.</span>
+            <span>Club identity sidecar metadata. 1.1M.</span>
             <a
               href="https://github.com/dills122/footy-data-kit/releases/latest/download/club-metadata.json"
               >json</a

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -15,6 +15,7 @@ Temporary working note for the next phase after the clean dataset release.
    - Expand canonical club-name handling beyond the current minimal alias set.
    - Cover historical rename and spelling variants that affect continuity checks and dataset diffs.
    - Add tests around canonicalisation so future cleanup work is less manual.
+   - Use [club-metadata-layer-2.md](/Users/dsteele/repos/footy-data-kit/docs/club-metadata-layer-2.md) as the plan for source-backed club history enrichments beyond generated table-note metadata.
 
 3. Regression fixture growth
 

--- a/docs/site-data.json
+++ b/docs/site-data.json
@@ -26,12 +26,18 @@
     }
   ],
   "latestRelease": {
-    "tag": "v0.8.0",
+    "tag": "v0.8.1",
     "summary": "1888-2025. 138 seasons. 232 club metadata records.",
     "notesUrl": "https://github.com/dills122/footy-data-kit/releases/latest",
-    "zipUrl": "https://github.com/dills122/footy-data-kit/releases/latest/download/footy-data-kit-v0.8.0-data.zip"
+    "zipUrl": "https://github.com/dills122/footy-data-kit/releases/latest/download/footy-data-kit-v0.8.1-data.zip"
   },
   "historicReleases": [
+    {
+      "tag": "v0.8.0",
+      "summary": "previous data release",
+      "notesUrl": "https://github.com/dills122/footy-data-kit/releases/tag/v0.8.0",
+      "zipUrl": "https://github.com/dills122/footy-data-kit/releases/download/v0.8.0/footy-data-kit-v0.8.0-data.zip"
+    },
     {
       "tag": "v0.7.0",
       "summary": "previous data release",
@@ -121,7 +127,7 @@
     {
       "file": "club-metadata.json",
       "description": "Club identity sidecar metadata.",
-      "size": "926K",
+      "size": "1.1M",
       "links": [
         {
           "label": "json",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "wiki:build:overview": "node wikipedia/cli/index.js overview --start 1888 --end 2025 --output ./data-output --force-update --include-war-placeholders",
     "wiki:build:combined": "node wikipedia/data/combine-output-files.js --output ./data-output/all-seasons.json ./data-output/wiki_overview_tables_by_season.json",
     "wiki:club-seed": "node wikipedia/data/generate-club-metadata-seed.js ./data-output/all-seasons.json --output ./data/club-metadata.json",
+    "wiki:club-verify": "node wikipedia/data/verify-club-continuity.js",
     "wiki:verify": "node wikipedia/data/verify-football-data.js --fail-on-issues ./data-output",
     "wiki:minify:promotion": "node scripts/minify-json.js ./data-output/wiki_promotion_relegations_by_season.json",
     "wiki:minify:overview": "node scripts/minify-json.js ./data-output/wiki_overview_tables_by_season.json",

--- a/readme.md
+++ b/readme.md
@@ -173,8 +173,17 @@ node rsssf/cli.js scrape --from-file ./rsssf-cache/1960-61.html --from-file ./rs
   - `gitSha`
   - `sourceFiles`
   - `buildOptions`
-- Every FootballData export may also include an optional top-level `clubs` map keyed by canonical club key. Layer-1 metadata is generated from the existing season tables and stored under `derived`:
+- Every FootballData export may also include an optional top-level `clubs` map keyed by canonical club key. Club records are split into consumer-facing identity/status fields, source-backed `history`, and generated `derived` observations:
+  - `clubId` – URL-safe unique slug for the club identity, such as `manchester-united`
   - `canonicalName`
+  - `status.current` – small status label such as `active` or `unknown`
+  - `status.trackedFromSeason`
+  - `status.trackedToSeason`
+  - `status.hasUnexplainedGaps`
+  - `history.nameHistory[]` for source-backed name periods
+  - `history.lifecycleEvents[]` for events such as `renamed`, `merged`, `dissolved`, `not-re-elected`, or `phoenix`
+  - `history.trackedMembership[]` for the season span where the club is expected in the tracked dataset
+  - `history.absenceExplanations[]` for expected absences using broad reason codes such as `official-competition-paused`, `outside-tracked-tiers`, `club-ceased`, `club-identity-changed`, `data-gap`, or `unknown`
   - `derived.aliases`
   - `derived.identitySources[]` with source URLs for curated identity/rename decisions
   - `derived.relationships[]` for sourced non-alias links such as phoenix clubs, mergers, relocations, and supporter-founded clubs
@@ -187,7 +196,8 @@ node rsssf/cli.js scrape --from-file ./rsssf-cache/1960-61.html --from-file ./rs
   - `derived.tierSeasons`
   - `derived.coverageGaps`
 - `derived.coverageGaps` means gaps in this dataset's observed league-table coverage, not confirmed inactivity or a financial interruption.
-- Future layer-2 enrichment can add sourced facts such as `founded`, `dissolved`, `nameHistory`, `financialEvents`, `notes`, and `sourceUrl`.
+- `history` is reserved for source-backed facts and explanations. Generated observations should stay under `derived`.
+- `clubId` is additive; season table rows still expose the scraped/canonical `team` text and do not yet embed `clubId`.
 - Each season contains a `seasonInfo` summary object plus one or more `tierN` objects.
 - `seasonInfo` is not a league table. It is a season-level summary that currently stores:
   - `season`
@@ -223,6 +233,9 @@ node wikipedia/data/combine-output-files.js --output ./data-output/all-seasons.j
 
 # Run the data lint pass on every JSON file under ./data-output
 node wikipedia/data/verify-football-data.js --fail-on-issues ./data-output
+
+# Report club continuity gaps from the club metadata sidecar
+node wikipedia/data/verify-club-continuity.js
 
 # Compare a previous release file against a freshly generated one
 node wikipedia/data/compare-football-data.js ./releases/all-seasons-prev.json ./data-output/all-seasons.json

--- a/readme.md
+++ b/readme.md
@@ -183,7 +183,7 @@ node rsssf/cli.js scrape --from-file ./rsssf-cache/1960-61.html --from-file ./rs
   - `history.nameHistory[]` for source-backed name periods
   - `history.lifecycleEvents[]` for events such as `renamed`, `merged`, `dissolved`, `not-re-elected`, or `phoenix`
   - `history.trackedMembership[]` for the season span where the club is expected in the tracked dataset
-  - `history.absenceExplanations[]` for expected absences using broad reason codes such as `official-competition-paused`, `outside-tracked-tiers`, `club-ceased`, `club-identity-changed`, `data-gap`, or `unknown`
+  - `history.absenceExplanations[]` for expected absences using broad reason codes such as `official-competition-paused`, `outside-tracked-coverage`, `club-inactive`, `club-dissolved`, `club-reformed`, or `unknown`
   - `derived.aliases`
   - `derived.identitySources[]` with source URLs for curated identity/rename decisions
   - `derived.relationships[]` for sourced non-alias links such as phoenix clubs, mergers, relocations, and supporter-founded clubs

--- a/wikipedia/__tests__/generate-club-metadata-seed.test.js
+++ b/wikipedia/__tests__/generate-club-metadata-seed.test.js
@@ -366,6 +366,73 @@ describe('buildClubMetadataSeed', () => {
     ]);
     expect(seed['accrington stanley 1891'].status.hasUnexplainedGaps).toBe(false);
   });
+
+  test('derives gap explanations from table notes when clubs leave tracked coverage', () => {
+    const dataset = {
+      seasons: {
+        2007: {
+          tier4: {
+            metadata: {
+              sourceUrl: 'https://example.test/2007-08',
+              seasonSlug: '2007-08-example-season',
+              title: 'League Two',
+            },
+            table: [
+              {
+                team: 'Example Town',
+                notes: 'Relegation to 2008–09 Conference National',
+              },
+            ],
+          },
+        },
+        2008: { tier4: { table: [] } },
+        2009: { tier4: { table: [] } },
+        2010: { tier4: { table: [] } },
+        2011: { tier4: { table: [] } },
+        2012: {
+          tier5: {
+            table: [{ team: 'Example Town' }],
+          },
+        },
+      },
+    };
+
+    const seed = buildClubMetadataSeed(dataset);
+
+    expect(seed['example town'].history.lifecycleEvents).toEqual([
+      {
+        type: 'relegated-outside-tracked-coverage',
+        season: 2007,
+        description: 'Relegation to 2008–09 Conference National',
+        sourceRefs: [
+          {
+            type: 'wikipedia-season-page',
+            sourceUrl: 'https://example.test/2007-08',
+            notes: 'League Two table in 2007-08-example-season',
+          },
+        ],
+      },
+    ]);
+    expect(seed['example town'].history.absenceExplanations).toEqual([
+      {
+        fromSeason: 2008,
+        toSeason: 2011,
+        reason: 'outside-tracked-coverage',
+        linkedEventType: 'relegated-outside-tracked-coverage',
+        basis: 'table-note',
+        notes: 'Relegation to 2008–09 Conference National',
+        sourceRefs: [
+          {
+            type: 'wikipedia-season-page',
+            sourceUrl: 'https://example.test/2007-08',
+            notes: 'League Two table in 2007-08-example-season',
+          },
+        ],
+      },
+    ]);
+    expect(seed['example town'].status.hasUnexplainedGaps).toBe(false);
+    expect(analyzeClubContinuity(dataset, { clubs: seed })).toEqual([]);
+  });
 });
 
 describe('analyzeClubContinuity', () => {

--- a/wikipedia/__tests__/generate-club-metadata-seed.test.js
+++ b/wikipedia/__tests__/generate-club-metadata-seed.test.js
@@ -5,6 +5,7 @@ import {
   buildClubMetadataSeed,
   writeClubMetadataSeedFile,
 } from '../data/generate-club-metadata-seed.js';
+import { analyzeClubContinuity } from '../data/verify-club-continuity.js';
 
 describe('buildClubMetadataSeed', () => {
   test('derives canonical club metadata from observed league table rows', () => {
@@ -39,8 +40,28 @@ describe('buildClubMetadataSeed', () => {
     });
 
     expect(Object.keys(seed)).toEqual(['arsenal', 'birmingham city']);
-    expect(seed.arsenal).toEqual({
+    expect(seed.arsenal).toMatchObject({
+      clubId: 'arsenal',
       canonicalName: 'Arsenal',
+      status: {
+        current: 'active',
+        trackedFromSeason: 1893,
+        trackedToSeason: null,
+        hasUnexplainedGaps: true,
+      },
+      history: {
+        nameHistory: [],
+        lifecycleEvents: [],
+        trackedMembership: [
+          {
+            fromSeason: 1893,
+            toSeason: null,
+            tiers: ['tier1', 'tier2'],
+            basis: 'observed',
+          },
+        ],
+        absenceExplanations: [],
+      },
       derived: {
         source: 'football-data-output',
         aliases: ['Arsenal', 'Woolwich Arsenal'],
@@ -84,7 +105,9 @@ describe('buildClubMetadataSeed', () => {
         coverageGaps: [{ startSeason: 1895, endSeason: 1913, length: 19 }],
       },
     });
+    expect(seed.arsenal.clubId).toBe('arsenal');
     expect(seed['birmingham city'].canonicalName).toBe('Birmingham City');
+    expect(seed['birmingham city'].clubId).toBe('birmingham-city');
     expect(seed['birmingham city'].derived.aliases).toEqual(['Birmingham', 'Small Heath']);
     expect(seed['birmingham city'].derived.coverageGaps).toEqual([
       { startSeason: 1894, endSeason: 1903, length: 10 },
@@ -226,8 +249,10 @@ describe('buildClubMetadataSeed', () => {
       'south shields',
     ]);
     expect(seed['accrington stanley 1891'].canonicalName).toBe('Accrington Stanley (1891)');
+    expect(seed['accrington stanley 1891'].clubId).toBe('accrington-stanley-1891');
     expect(seed['accrington stanley 1891'].derived.seasonsSeen).toEqual([1961]);
     expect(seed['accrington stanley'].canonicalName).toBe('Accrington Stanley');
+    expect(seed['accrington stanley'].clubId).toBe('accrington-stanley');
     expect(seed['accrington stanley'].derived.seasonsSeen).toEqual([2006]);
     expect(seed['accrington stanley 1891'].derived.relationships).toEqual([
       {
@@ -261,6 +286,187 @@ describe('buildClubMetadataSeed', () => {
     ]);
     expect(seed['south shields'].canonicalName).toBe('South Shields');
     expect(seed['south shields'].derived.seasonsSeen).toEqual([2024]);
+  });
+
+  test('adds official pause explanations for wartime observed coverage gaps', () => {
+    const seed = buildClubMetadataSeed({
+      seasons: {
+        1938: {
+          tier3: {
+            table: [{ team: 'Accrington Stanley' }],
+          },
+        },
+        1939: {
+          seasonInfo: {
+            season: 1939,
+            competitionStatus: 'abandoned-season',
+            officialLeagueTables: false,
+          },
+        },
+        1940: {
+          seasonInfo: {
+            season: 1940,
+            competitionStatus: 'wartime-special',
+            officialLeagueTables: false,
+          },
+        },
+        1941: {
+          seasonInfo: {
+            season: 1941,
+            competitionStatus: 'wartime-special',
+            officialLeagueTables: false,
+          },
+        },
+        1942: {
+          seasonInfo: {
+            season: 1942,
+            competitionStatus: 'wartime-special',
+            officialLeagueTables: false,
+          },
+        },
+        1943: {
+          seasonInfo: {
+            season: 1943,
+            competitionStatus: 'wartime-special',
+            officialLeagueTables: false,
+          },
+        },
+        1944: {
+          seasonInfo: {
+            season: 1944,
+            competitionStatus: 'wartime-special',
+            officialLeagueTables: false,
+          },
+        },
+        1945: {
+          seasonInfo: {
+            season: 1945,
+            competitionStatus: 'regional-bridge-season',
+            officialLeagueTables: false,
+          },
+        },
+        1946: {
+          tier3: {
+            table: [{ team: 'Accrington Stanley' }],
+          },
+        },
+      },
+    });
+
+    expect(seed['accrington stanley 1891'].derived.coverageGaps).toEqual([
+      { startSeason: 1939, endSeason: 1945, length: 7 },
+    ]);
+    expect(seed['accrington stanley 1891'].history.absenceExplanations).toEqual([
+      {
+        fromSeason: 1939,
+        toSeason: 1945,
+        reason: 'official-competition-paused',
+        basis: 'season-metadata',
+      },
+    ]);
+    expect(seed['accrington stanley 1891'].status.hasUnexplainedGaps).toBe(false);
+  });
+});
+
+describe('analyzeClubContinuity', () => {
+  test('reports missing expected seasons outside official pauses and explanations', () => {
+    const dataset = {
+      seasons: {
+        1950: { tier2: { table: [{ team: 'Example Town' }] } },
+        1951: { tier2: { table: [] } },
+        1952: { tier2: { table: [] } },
+        1953: { tier2: { table: [{ team: 'Example Town' }] } },
+      },
+    };
+    const clubMetadata = {
+      clubs: {
+        'example town': {
+          clubId: 'example-town',
+          canonicalName: 'Example Town',
+          derived: {
+            seasonsSeen: [1950, 1953],
+          },
+          history: {
+            trackedMembership: [
+              {
+                fromSeason: 1950,
+                toSeason: 1953,
+                tiers: ['tier2'],
+                basis: 'observed',
+              },
+            ],
+            absenceExplanations: [],
+          },
+        },
+      },
+    };
+
+    expect(analyzeClubContinuity(dataset, clubMetadata)).toEqual([
+      expect.objectContaining({
+        type: 'unexplained-club-gap',
+        clubId: 'example-town',
+        canonicalName: 'Example Town',
+        fromSeason: 1951,
+        toSeason: 1952,
+        missingSeasons: [1951, 1952],
+      }),
+    ]);
+  });
+
+  test('ignores official competition pauses and explicit absence explanations', () => {
+    const dataset = {
+      seasons: {
+        1938: { tier3: { table: [{ team: 'Example Town' }] } },
+        1939: {
+          seasonInfo: {
+            season: 1939,
+            competitionStatus: 'abandoned-season',
+            officialLeagueTables: false,
+          },
+        },
+        1940: {
+          seasonInfo: {
+            season: 1940,
+            competitionStatus: 'wartime-special',
+            officialLeagueTables: false,
+          },
+        },
+        1941: {
+          seasonInfo: {
+            season: 1941,
+            competitionStatus: 'wartime-special',
+            officialLeagueTables: false,
+          },
+        },
+        1942: {
+          tier3: { table: [{ team: 'Example Town' }] },
+        },
+      },
+    };
+    const clubMetadata = {
+      clubs: {
+        'example town': {
+          clubId: 'example-town',
+          canonicalName: 'Example Town',
+          derived: {
+            seasonsSeen: [1938, 1942],
+          },
+          history: {
+            trackedMembership: [
+              {
+                fromSeason: 1938,
+                toSeason: 1942,
+                tiers: ['tier3'],
+                basis: 'observed',
+              },
+            ],
+            absenceExplanations: [{ fromSeason: 1941, toSeason: 1941, reason: 'data-gap' }],
+          },
+        },
+      },
+    };
+
+    expect(analyzeClubContinuity(dataset, clubMetadata)).toEqual([]);
   });
 });
 

--- a/wikipedia/data/generate-club-metadata-seed.js
+++ b/wikipedia/data/generate-club-metadata-seed.js
@@ -19,6 +19,7 @@ import { getTierKeys, getTierTable, sortSeasonKeys } from './season-rules.js';
 const DEFAULT_INPUT_FILE = './data-output/all-seasons.json';
 const DEFAULT_OUTPUT_FILE = './data/club-metadata.json';
 const DERIVED_SOURCE_ID = 'football-data-output';
+const OFFICIAL_COMPETITION_PAUSED_REASON = 'official-competition-paused';
 
 function parseSeasonKey(value) {
   const parsed = Number.parseInt(String(value), 10);
@@ -40,6 +41,16 @@ function sortedNumbers(values) {
 
 function sortedStrings(values) {
   return [...values].sort((a, b) => a.localeCompare(b));
+}
+
+function slugifyClubId(value) {
+  return String(value || '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
 }
 
 function incrementMapValue(map, key) {
@@ -185,6 +196,58 @@ function buildCoverageGaps(seasonsSeen) {
   return gaps;
 }
 
+function isFullSeasonRangeCovered(startSeason, endSeason, seasonSet) {
+  for (let season = startSeason; season <= endSeason; season += 1) {
+    if (!seasonSet.has(season)) return false;
+  }
+  return true;
+}
+
+function buildAutoAbsenceExplanations(coverageGaps, officialPausedSeasons) {
+  return coverageGaps
+    .filter((gap) =>
+      isFullSeasonRangeCovered(gap.startSeason, gap.endSeason, officialPausedSeasons)
+    )
+    .map((gap) => ({
+      fromSeason: gap.startSeason,
+      toSeason: gap.endSeason,
+      reason: OFFICIAL_COMPETITION_PAUSED_REASON,
+      basis: 'season-metadata',
+    }));
+}
+
+function buildTrackedMembership(seasonsSeen, tiersSeen, latestSeason) {
+  if (!seasonsSeen.length) return [];
+  const firstSeenSeason = seasonsSeen[0];
+  const lastSeenSeason = seasonsSeen[seasonsSeen.length - 1];
+  return [
+    {
+      fromSeason: firstSeenSeason,
+      toSeason: lastSeenSeason === latestSeason ? null : lastSeenSeason,
+      tiers: sortTierKeys(tiersSeen),
+      basis: 'observed',
+    },
+  ];
+}
+
+function buildClubStatus(seasonsSeen, coverageGaps, absenceExplanations, latestSeason) {
+  const firstSeenSeason = seasonsSeen[0] ?? null;
+  const lastSeenSeason = seasonsSeen[seasonsSeen.length - 1] ?? null;
+  const explainedGapKeys = new Set(
+    absenceExplanations.map((entry) => `${entry.fromSeason}:${entry.toSeason}`)
+  );
+  const hasUnexplainedGaps = coverageGaps.some(
+    (gap) => !explainedGapKeys.has(`${gap.startSeason}:${gap.endSeason}`)
+  );
+
+  return {
+    current: lastSeenSeason === latestSeason ? 'active' : 'unknown',
+    trackedFromSeason: firstSeenSeason,
+    trackedToSeason: lastSeenSeason === latestSeason ? null : lastSeenSeason,
+    hasUnexplainedGaps,
+  };
+}
+
 function buildObservedNames(aliasSeasons, aliasTiers) {
   return [...aliasSeasons.entries()]
     .map(([rawName, seasons]) => {
@@ -225,11 +288,26 @@ function buildRelationships(relationships) {
   });
 }
 
-function buildClubMetadataRecord(accumulator) {
+function buildClubMetadataRecord(accumulator, { latestSeason, officialPausedSeasons } = {}) {
   const seasonsSeen = sortedNumbers(accumulator.seasonsSeen);
+  const tiersSeen = sortTierKeys(accumulator.tiersSeen);
+  const coverageGaps = buildCoverageGaps(accumulator.seasonsSeen);
+  const absenceExplanations = buildAutoAbsenceExplanations(
+    coverageGaps,
+    officialPausedSeasons || new Set()
+  );
+  const trackedMembership = buildTrackedMembership(seasonsSeen, tiersSeen, latestSeason);
 
   return {
+    clubId: slugifyClubId(accumulator.clubKey),
     canonicalName: accumulator.canonicalName,
+    status: buildClubStatus(seasonsSeen, coverageGaps, absenceExplanations, latestSeason),
+    history: {
+      nameHistory: [],
+      lifecycleEvents: [],
+      trackedMembership,
+      absenceExplanations,
+    },
     derived: {
       source: DERIVED_SOURCE_ID,
       aliases: sortedStrings(accumulator.aliasCounts.keys()),
@@ -241,11 +319,24 @@ function buildClubMetadataRecord(accumulator) {
       lastSeenSeason: seasonsSeen[seasonsSeen.length - 1] ?? null,
       seasonsSeen,
       totalSeasonsSeen: seasonsSeen.length,
-      tiersSeen: sortTierKeys(accumulator.tiersSeen),
+      tiersSeen,
       tierSeasons: buildTierSeasons(accumulator.tierSeasons),
-      coverageGaps: buildCoverageGaps(accumulator.seasonsSeen),
+      coverageGaps,
     },
   };
+}
+
+function isOfficialCompetitionPausedSeason(seasonRecord) {
+  const seasonInfo = seasonRecord?.seasonInfo || {};
+  return (
+    seasonInfo.officialLeagueTables === false ||
+    seasonInfo.officialCompetitionsSuspended === true ||
+    seasonInfo.officialCompetitionsAbandoned === true ||
+    seasonInfo.regionalBridgeSeason === true ||
+    ['wartime-special', 'abandoned-season', 'regional-bridge-season'].includes(
+      String(seasonInfo.competitionStatus || '')
+    )
+  );
 }
 
 /**
@@ -255,12 +346,18 @@ function buildClubMetadataRecord(accumulator) {
 export function buildClubMetadataSeed(dataset) {
   const clubs = new Map();
   const seasonKeys = sortSeasonKeys(Object.keys(dataset?.seasons || {}));
+  const seasonNumbers = seasonKeys.map(parseSeasonKey).filter(Number.isInteger);
+  const latestSeason = seasonNumbers[seasonNumbers.length - 1] ?? null;
+  const officialPausedSeasons = new Set();
 
   for (const seasonKey of seasonKeys) {
     const seasonNumber = parseSeasonKey(seasonKey);
     if (seasonNumber == null) continue;
 
     const seasonRecord = dataset.seasons[seasonKey];
+    if (isOfficialCompetitionPausedSeason(seasonRecord)) {
+      officialPausedSeasons.add(seasonNumber);
+    }
     for (const tierKey of getTierKeys(seasonRecord)) {
       for (const row of getTierTable(seasonRecord[tierKey])) {
         if (!row || typeof row !== 'object' || typeof row.team !== 'string') continue;
@@ -286,7 +383,10 @@ export function buildClubMetadataSeed(dataset) {
   applyClubRelationshipRules(clubs);
 
   const entries = [...clubs.entries()]
-    .map(([clubKey, accumulator]) => [clubKey, buildClubMetadataRecord(accumulator)])
+    .map(([clubKey, accumulator]) => [
+      clubKey,
+      buildClubMetadataRecord(accumulator, { latestSeason, officialPausedSeasons }),
+    ])
     .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey));
 
   return normaliseClubsMap(Object.fromEntries(entries)) || {};

--- a/wikipedia/data/generate-club-metadata-seed.js
+++ b/wikipedia/data/generate-club-metadata-seed.js
@@ -20,6 +20,9 @@ const DEFAULT_INPUT_FILE = './data-output/all-seasons.json';
 const DEFAULT_OUTPUT_FILE = './data/club-metadata.json';
 const DERIVED_SOURCE_ID = 'football-data-output';
 const OFFICIAL_COMPETITION_PAUSED_REASON = 'official-competition-paused';
+const OUTSIDE_TRACKED_COVERAGE_REASON = 'outside-tracked-coverage';
+const SEASON_METADATA_BASIS = 'season-metadata';
+const TABLE_NOTE_BASIS = 'table-note';
 
 function parseSeasonKey(value) {
   const parsed = Number.parseInt(String(value), 10);
@@ -67,6 +70,7 @@ function createAccumulator(clubKey, teamName) {
     aliasTiers: new Map(),
     identitySources: new Map(),
     relationships: new Map(),
+    rowObservations: [],
     seasonsSeen: new Set(),
     tiersSeen: new Set(),
     tierSeasons: new Map(),
@@ -123,6 +127,42 @@ function addTierSeason(accumulator, tierKey, seasonNumber) {
     accumulator.tierSeasons.set(tierKey, new Set());
   }
   accumulator.tierSeasons.get(tierKey).add(seasonNumber);
+}
+
+function normalizeNoteText(value) {
+  if (value == null) return '';
+  if (Array.isArray(value)) {
+    return value
+      .map((entry) => normalizeNoteText(entry))
+      .filter(Boolean)
+      .join('; ');
+  }
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+
+function buildTierSourceRefs(tierValue, tierKey, seasonNumber) {
+  const metadata = tierValue && typeof tierValue === 'object' ? tierValue.metadata || {} : {};
+  if (!metadata.sourceUrl) return [];
+
+  const title = metadata.title || tierKey;
+  const seasonLabel = metadata.seasonSlug || seasonNumber;
+  return [
+    {
+      type: 'wikipedia-season-page',
+      sourceUrl: metadata.sourceUrl,
+      notes: `${title} table in ${seasonLabel}`,
+    },
+  ];
+}
+
+function addRowObservation(accumulator, { seasonNumber, tierKey, teamName, row, tierValue }) {
+  accumulator.rowObservations.push({
+    seasonNumber,
+    tierKey,
+    teamName,
+    notes: normalizeNoteText(row.notes),
+    sourceRefs: buildTierSourceRefs(tierValue, tierKey, seasonNumber),
+  });
 }
 
 function maybeUpdateCanonicalName(accumulator, teamName, seasonNumber) {
@@ -196,6 +236,44 @@ function buildCoverageGaps(seasonsSeen) {
   return gaps;
 }
 
+export function classifyClubTableNoteForContinuity(note) {
+  const noteText = normalizeNoteText(note);
+  if (!noteText) return null;
+
+  const outsideTrackedSignal = {
+    absenceReason: OUTSIDE_TRACKED_COVERAGE_REASON,
+    basis: TABLE_NOTE_BASIS,
+    description: noteText,
+  };
+
+  if (/failed re-?election/i.test(noteText)) {
+    return {
+      ...outsideTrackedSignal,
+      eventType: 'not-re-elected',
+    };
+  }
+
+  if (/resigned from (?:the )?league/i.test(noteText)) {
+    return {
+      ...outsideTrackedSignal,
+      eventType: 'resigned-from-league',
+    };
+  }
+
+  const outsideTrackedLeaguePattern =
+    /(?:relegat(?:ion|ed) to|demoted to)\s+(?:\d{4}[–-]\d{2}\s+)?(?:the\s+)?(?:football conference|conference national|national league(?: north| south)?|conference north|conference south|southern league|northern premier league|isthmian league)/i;
+  if (outsideTrackedLeaguePattern.test(noteText)) {
+    return {
+      ...outsideTrackedSignal,
+      eventType: /demoted to/i.test(noteText)
+        ? 'demoted-outside-tracked-coverage'
+        : 'relegated-outside-tracked-coverage',
+    };
+  }
+
+  return null;
+}
+
 function isFullSeasonRangeCovered(startSeason, endSeason, seasonSet) {
   for (let season = startSeason; season <= endSeason; season += 1) {
     if (!seasonSet.has(season)) return false;
@@ -203,17 +281,66 @@ function isFullSeasonRangeCovered(startSeason, endSeason, seasonSet) {
   return true;
 }
 
-function buildAutoAbsenceExplanations(coverageGaps, officialPausedSeasons) {
-  return coverageGaps
-    .filter((gap) =>
-      isFullSeasonRangeCovered(gap.startSeason, gap.endSeason, officialPausedSeasons)
-    )
-    .map((gap) => ({
-      fromSeason: gap.startSeason,
-      toSeason: gap.endSeason,
-      reason: OFFICIAL_COMPETITION_PAUSED_REASON,
-      basis: 'season-metadata',
-    }));
+function findPreviousObservation(rowObservations, gap) {
+  return [...rowObservations]
+    .sort((a, b) => b.seasonNumber - a.seasonNumber)
+    .find((row) => row.seasonNumber < gap.startSeason);
+}
+
+function buildTableNoteLifecycleEvents(coverageGaps, rowObservations) {
+  const events = [];
+  const seen = new Set();
+
+  for (const gap of coverageGaps) {
+    const previousObservation = findPreviousObservation(rowObservations, gap);
+    const signal = classifyClubTableNoteForContinuity(previousObservation?.notes);
+    if (!previousObservation || !signal) continue;
+
+    const event = {
+      type: signal.eventType,
+      season: previousObservation.seasonNumber,
+      description: signal.description,
+      sourceRefs: previousObservation.sourceRefs,
+    };
+    const dedupeKey = JSON.stringify(event);
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    events.push(event);
+  }
+
+  return events.sort((a, b) => {
+    if (a.season !== b.season) return a.season - b.season;
+    return a.type.localeCompare(b.type);
+  });
+}
+
+function buildAutoAbsenceExplanations(coverageGaps, officialPausedSeasons, rowObservations) {
+  return coverageGaps.map((gap) => {
+    if (isFullSeasonRangeCovered(gap.startSeason, gap.endSeason, officialPausedSeasons)) {
+      return {
+        fromSeason: gap.startSeason,
+        toSeason: gap.endSeason,
+        reason: OFFICIAL_COMPETITION_PAUSED_REASON,
+        basis: SEASON_METADATA_BASIS,
+      };
+    }
+
+    const previousObservation = findPreviousObservation(rowObservations, gap);
+    const signal = classifyClubTableNoteForContinuity(previousObservation?.notes);
+    if (previousObservation && signal) {
+      return {
+        fromSeason: gap.startSeason,
+        toSeason: gap.endSeason,
+        reason: signal.absenceReason,
+        linkedEventType: signal.eventType,
+        basis: signal.basis,
+        notes: signal.description,
+        sourceRefs: previousObservation.sourceRefs,
+      };
+    }
+
+    return null;
+  }).filter(Boolean);
 }
 
 function buildTrackedMembership(seasonsSeen, tiersSeen, latestSeason) {
@@ -294,8 +421,10 @@ function buildClubMetadataRecord(accumulator, { latestSeason, officialPausedSeas
   const coverageGaps = buildCoverageGaps(accumulator.seasonsSeen);
   const absenceExplanations = buildAutoAbsenceExplanations(
     coverageGaps,
-    officialPausedSeasons || new Set()
+    officialPausedSeasons || new Set(),
+    accumulator.rowObservations
   );
+  const lifecycleEvents = buildTableNoteLifecycleEvents(coverageGaps, accumulator.rowObservations);
   const trackedMembership = buildTrackedMembership(seasonsSeen, tiersSeen, latestSeason);
 
   return {
@@ -304,7 +433,7 @@ function buildClubMetadataRecord(accumulator, { latestSeason, officialPausedSeas
     status: buildClubStatus(seasonsSeen, coverageGaps, absenceExplanations, latestSeason),
     history: {
       nameHistory: [],
-      lifecycleEvents: [],
+      lifecycleEvents,
       trackedMembership,
       absenceExplanations,
     },
@@ -375,6 +504,7 @@ export function buildClubMetadataSeed(dataset) {
         addAliasSeason(accumulator, teamName, seasonNumber);
         addAliasTier(accumulator, teamName, tierKey);
         addTierSeason(accumulator, tierKey, seasonNumber);
+        addRowObservation(accumulator, { seasonNumber, tierKey, teamName, row, tierValue: seasonRecord[tierKey] });
         maybeUpdateCanonicalName(accumulator, teamName, seasonNumber);
       }
     }

--- a/wikipedia/data/generate-output-files.js
+++ b/wikipedia/data/generate-output-files.js
@@ -207,6 +207,167 @@ function normaliseClubFinancialEvents(value) {
 /**
  * @param {unknown} value
  */
+function normaliseClubLifecycleEvents(value) {
+  if (!Array.isArray(value)) return [];
+  const events = [];
+  const seen = new Set();
+
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+    const type = toStringValue(item.type);
+    if (!type) continue;
+
+    const normalizedItem = {
+      type,
+      season: toSeasonNumberOrNull(item.season),
+      fromSeason: toSeasonNumberOrNull(item.fromSeason),
+      toSeason: toSeasonNumberOrNull(item.toSeason),
+      fromName: toStringValue(item.fromName),
+      toName: toStringValue(item.toName),
+      description: toStringValue(item.description),
+      sourceRefs: normaliseIdentitySources(item.sourceRefs),
+    };
+    const dedupeKey = JSON.stringify(normalizedItem);
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    events.push(
+      Object.fromEntries(
+        Object.entries(normalizedItem).filter(([, entry]) => {
+          if (entry == null) return false;
+          if (Array.isArray(entry)) return entry.length > 0;
+          return true;
+        })
+      )
+    );
+  }
+
+  return events.sort((a, b) => {
+    const leftSeason = a.season ?? a.fromSeason ?? 0;
+    const rightSeason = b.season ?? b.fromSeason ?? 0;
+    if (leftSeason !== rightSeason) return leftSeason - rightSeason;
+    return a.type.localeCompare(b.type);
+  });
+}
+
+/**
+ * @param {unknown} value
+ */
+function normaliseClubTrackedMembership(value) {
+  if (!Array.isArray(value)) return [];
+  const memberships = [];
+  const seen = new Set();
+
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+    const fromSeason = toSeasonNumberOrNull(item.fromSeason);
+    if (fromSeason == null) continue;
+
+    const normalizedItem = {
+      fromSeason,
+      toSeason: toSeasonNumberOrNull(item.toSeason),
+      tiers: normalizeStringArray(item.tiers).sort(),
+      basis: toStringValue(item.basis),
+      notes: toStringValue(item.notes),
+      sourceRefs: normaliseIdentitySources(item.sourceRefs),
+    };
+    const dedupeKey = JSON.stringify(normalizedItem);
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    memberships.push(
+      Object.fromEntries(
+        Object.entries(normalizedItem).filter(([key, entry]) => {
+          if (key === 'toSeason') return true;
+          if (entry == null) return false;
+          if (Array.isArray(entry)) return entry.length > 0;
+          return true;
+        })
+      )
+    );
+  }
+
+  return memberships.sort((a, b) => a.fromSeason - b.fromSeason);
+}
+
+/**
+ * @param {unknown} value
+ */
+function normaliseClubAbsenceExplanations(value) {
+  if (!Array.isArray(value)) return [];
+  const explanations = [];
+  const seen = new Set();
+
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+    const fromSeason = toSeasonNumberOrNull(item.fromSeason);
+    const reason = toStringValue(item.reason);
+    if (fromSeason == null || !reason) continue;
+
+    const normalizedItem = {
+      fromSeason,
+      toSeason: toSeasonNumberOrNull(item.toSeason),
+      reason,
+      linkedEventType: toStringValue(item.linkedEventType),
+      basis: toStringValue(item.basis),
+      notes: toStringValue(item.notes),
+      sourceRefs: normaliseIdentitySources(item.sourceRefs),
+    };
+    const dedupeKey = JSON.stringify(normalizedItem);
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    explanations.push(
+      Object.fromEntries(
+        Object.entries(normalizedItem).filter(([, entry]) => {
+          if (entry == null) return false;
+          if (Array.isArray(entry)) return entry.length > 0;
+          return true;
+        })
+      )
+    );
+  }
+
+  return explanations.sort((a, b) => a.fromSeason - b.fromSeason);
+}
+
+/**
+ * @param {unknown} value
+ */
+function normaliseClubHistory(value) {
+  const source = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+  return {
+    nameHistory: normaliseClubNameHistory(source.nameHistory),
+    lifecycleEvents: normaliseClubLifecycleEvents(source.lifecycleEvents),
+    trackedMembership: normaliseClubTrackedMembership(source.trackedMembership),
+    absenceExplanations: normaliseClubAbsenceExplanations(source.absenceExplanations),
+  };
+}
+
+/**
+ * @param {unknown} value
+ */
+function normaliseClubStatus(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const current = toStringValue(value.current);
+  const status = {
+    current,
+    trackedFromSeason: toSeasonNumberOrNull(value.trackedFromSeason),
+    trackedToSeason: toSeasonNumberOrNull(value.trackedToSeason),
+    hasUnexplainedGaps:
+      typeof value.hasUnexplainedGaps === 'boolean' ? value.hasUnexplainedGaps : null,
+  };
+
+  const cleaned = Object.fromEntries(
+    Object.entries(status).filter(([key, entry]) => key === 'trackedToSeason' || entry != null)
+  );
+
+  return Object.keys(cleaned).length ? cleaned : undefined;
+}
+
+/**
+ * @param {unknown} value
+ */
 function normaliseObservedNamePeriods(value) {
   if (!Array.isArray(value)) return [];
   const periods = [];
@@ -412,8 +573,27 @@ function normaliseClubRecord(value, fallbackKey) {
   const canonicalName = toStringValue(value.canonicalName) || toStringValue(fallbackKey);
   if (!canonicalName) return null;
 
+  const hasHistoryInput =
+    (value.history && typeof value.history === 'object' && !Array.isArray(value.history)) ||
+    value.lifecycleEvents ||
+    value.trackedMembership ||
+    value.absenceExplanations;
+  const history = hasHistoryInput
+    ? normaliseClubHistory({
+        ...(value.history && typeof value.history === 'object' && !Array.isArray(value.history)
+          ? value.history
+          : {}),
+        lifecycleEvents: value.history?.lifecycleEvents || value.lifecycleEvents,
+        trackedMembership: value.history?.trackedMembership || value.trackedMembership,
+        absenceExplanations: value.history?.absenceExplanations || value.absenceExplanations,
+      })
+    : undefined;
+
   const normalized = {
+    clubId: toStringValue(value.clubId),
     canonicalName,
+    status: normaliseClubStatus(value.status),
+    history,
     derived: normaliseClubDerivedMetadata(value.derived),
     founded: toStringValue(value.founded),
     dissolved: toStringValue(value.dissolved),

--- a/wikipedia/data/verify-club-continuity.js
+++ b/wikipedia/data/verify-club-continuity.js
@@ -1,0 +1,253 @@
+#!/usr/bin/env node
+// @ts-check
+
+import { Command } from 'commander';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { loadFootballData } from './generate-output-files.js';
+import { isHistoricalPlaceholderSeason, parseSeasonNumber, sortSeasonKeys } from './season-rules.js';
+
+const DEFAULT_DATASET_FILE = './data-output/all-seasons.json';
+const DEFAULT_CLUB_METADATA_FILE = './data/club-metadata.json';
+
+function loadJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function getSeasonNumbers(dataset) {
+  return sortSeasonKeys(Object.keys(dataset?.seasons || {}))
+    .map(parseSeasonNumber)
+    .filter(Number.isInteger);
+}
+
+function getOfficialPausedSeasons(dataset) {
+  const pausedSeasons = new Set();
+  for (const [seasonKey, seasonRecord] of Object.entries(dataset?.seasons || {})) {
+    const seasonNumber = parseSeasonNumber(seasonKey);
+    if (seasonNumber == null) continue;
+    const seasonInfo = seasonRecord?.seasonInfo || {};
+    if (
+      isHistoricalPlaceholderSeason(seasonRecord, seasonKey) ||
+      seasonInfo.officialLeagueTables === false ||
+      seasonInfo.officialCompetitionsSuspended === true ||
+      seasonInfo.officialCompetitionsAbandoned === true ||
+      seasonInfo.regionalBridgeSeason === true
+    ) {
+      pausedSeasons.add(seasonNumber);
+    }
+  }
+  return pausedSeasons;
+}
+
+function seasonIsCoveredByAbsenceExplanation(season, explanations = []) {
+  return explanations.some((entry) => {
+    if (!entry || typeof entry !== 'object') return false;
+    const fromSeason = parseSeasonNumber(entry.fromSeason);
+    const toSeason = entry.toSeason == null ? fromSeason : parseSeasonNumber(entry.toSeason);
+    if (fromSeason == null || toSeason == null) return false;
+    return season >= fromSeason && season <= toSeason;
+  });
+}
+
+function groupConsecutiveSeasons(seasons) {
+  const sortedSeasons = [...seasons].sort((a, b) => a - b);
+  const groups = [];
+  let startSeason = null;
+  let previousSeason = null;
+
+  for (const season of sortedSeasons) {
+    if (startSeason == null) {
+      startSeason = season;
+      previousSeason = season;
+      continue;
+    }
+
+    if (season === previousSeason + 1) {
+      previousSeason = season;
+      continue;
+    }
+
+    groups.push({ startSeason, endSeason: previousSeason });
+    startSeason = season;
+    previousSeason = season;
+  }
+
+  if (startSeason != null && previousSeason != null) {
+    groups.push({ startSeason, endSeason: previousSeason });
+  }
+
+  return groups;
+}
+
+function getMembershipEndSeason(membership, latestSeason) {
+  const explicitEndSeason = parseSeasonNumber(membership?.toSeason);
+  if (explicitEndSeason != null) return explicitEndSeason;
+  return latestSeason;
+}
+
+function createGapIssue({ clubKey, club, membership, missingSeasons }) {
+  return {
+    type: 'unexplained-club-gap',
+    clubKey,
+    clubId: club.clubId || null,
+    canonicalName: club.canonicalName,
+    fromSeason: missingSeasons[0],
+    toSeason: missingSeasons[missingSeasons.length - 1],
+    missingSeasons,
+    trackedFromSeason: membership.fromSeason,
+    trackedToSeason: membership.toSeason ?? null,
+    suggestedReason: 'unknown',
+    message: `${club.canonicalName} is expected in tracked membership but is missing ${missingSeasons.length} season(s)`,
+  };
+}
+
+function analyzeClubContinuityForRecord({
+  clubKey,
+  club,
+  availableSeasons,
+  latestSeason,
+  officialPausedSeasons,
+}) {
+  const observedSeasons = new Set(club?.derived?.seasonsSeen || []);
+  const memberships = Array.isArray(club?.history?.trackedMembership)
+    ? club.history.trackedMembership
+    : [];
+  const absenceExplanations = Array.isArray(club?.history?.absenceExplanations)
+    ? club.history.absenceExplanations
+    : [];
+  const issues = [];
+
+  for (const membership of memberships) {
+    const fromSeason = parseSeasonNumber(membership?.fromSeason);
+    const toSeason = getMembershipEndSeason(membership, latestSeason);
+    if (fromSeason == null || toSeason == null || toSeason < fromSeason) continue;
+
+    const missingSeasons = [];
+    for (const season of availableSeasons) {
+      if (season < fromSeason || season > toSeason) continue;
+      if (observedSeasons.has(season)) continue;
+      if (officialPausedSeasons.has(season)) continue;
+      if (seasonIsCoveredByAbsenceExplanation(season, absenceExplanations)) continue;
+      missingSeasons.push(season);
+    }
+
+    for (const group of groupConsecutiveSeasons(missingSeasons)) {
+      const groupedSeasons = [];
+      for (let season = group.startSeason; season <= group.endSeason; season += 1) {
+        groupedSeasons.push(season);
+      }
+      issues.push(createGapIssue({ clubKey, club, membership, missingSeasons: groupedSeasons }));
+    }
+  }
+
+  return issues;
+}
+
+export function analyzeClubContinuity(dataset, clubMetadata) {
+  const clubs = clubMetadata?.clubs || {};
+  const availableSeasons = getSeasonNumbers(dataset);
+  const latestSeason = availableSeasons[availableSeasons.length - 1] ?? null;
+  const officialPausedSeasons = getOfficialPausedSeasons(dataset);
+  const issues = [];
+
+  for (const [clubKey, club] of Object.entries(clubs)) {
+    if (!club || typeof club !== 'object') continue;
+    issues.push(
+      ...analyzeClubContinuityForRecord({
+        clubKey,
+        club,
+        availableSeasons,
+        latestSeason,
+        officialPausedSeasons,
+      })
+    );
+  }
+
+  return issues.sort((a, b) => {
+    if (a.fromSeason !== b.fromSeason) return a.fromSeason - b.fromSeason;
+    return a.clubKey.localeCompare(b.clubKey);
+  });
+}
+
+export function analyzeClubContinuityFiles({
+  datasetPath = DEFAULT_DATASET_FILE,
+  clubMetadataPath = DEFAULT_CLUB_METADATA_FILE,
+  cwd = process.cwd(),
+} = {}) {
+  const resolvedDatasetPath = path.resolve(cwd, datasetPath);
+  const resolvedClubMetadataPath = path.resolve(cwd, clubMetadataPath);
+  const dataset = loadFootballData(resolvedDatasetPath);
+  const clubMetadata = loadJson(resolvedClubMetadataPath);
+  const issues = analyzeClubContinuity(dataset, clubMetadata);
+
+  return {
+    datasetPath: resolvedDatasetPath,
+    clubMetadataPath: resolvedClubMetadataPath,
+    clubCount: Object.keys(clubMetadata?.clubs || {}).length,
+    issueCount: issues.length,
+    issues,
+  };
+}
+
+export function runCli(argv = process.argv) {
+  const program = new Command();
+
+  program
+    .name('verify-club-continuity')
+    .description('Report club metadata continuity gaps against a FootballData season export.')
+    .option('-d, --dataset <file>', 'FootballData JSON dataset file', DEFAULT_DATASET_FILE)
+    .option(
+      '-c, --club-metadata <file>',
+      'Club metadata sidecar JSON file',
+      DEFAULT_CLUB_METADATA_FILE
+    )
+    .option('--json', 'Print machine-readable JSON output', false)
+    .option('--fail-on-issues', 'Exit non-zero when continuity issues are found', false);
+
+  program.parse(argv);
+  const options = program.opts();
+  const report = analyzeClubContinuityFiles({
+    datasetPath: options.dataset,
+    clubMetadataPath: options.clubMetadata,
+    cwd: process.cwd(),
+  });
+
+  if (options.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    console.log(`Club metadata records scanned: ${report.clubCount}`);
+    if (!report.issues.length) {
+      console.log('No club continuity issues detected ✅');
+    } else {
+      console.log(`Club continuity issues detected: ${report.issues.length}`);
+      for (const issue of report.issues) {
+        const seasonLabel =
+          issue.fromSeason === issue.toSeason
+            ? String(issue.fromSeason)
+            : `${issue.fromSeason}-${issue.toSeason}`;
+        console.log(`- ${issue.canonicalName} (${issue.clubId || issue.clubKey}): ${seasonLabel}`);
+      }
+    }
+  }
+
+  if (options.failOnIssues && report.issues.length) {
+    process.exitCode = 1;
+  }
+
+  return report;
+}
+
+const isDirectExecution = process.argv[1]
+  ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  : false;
+
+if (isDirectExecution) {
+  runCli(process.argv);
+}
+
+export default {
+  analyzeClubContinuity,
+  analyzeClubContinuityFiles,
+  runCli,
+};

--- a/wikipedia/models/output-file.ts
+++ b/wikipedia/models/output-file.ts
@@ -137,6 +137,56 @@ export interface ClubCoverageGap {
   length: number;
 }
 
+export interface ClubSourceRef {
+  type: string;
+  sourceUrl: string;
+  notes?: string | null;
+}
+
+export interface ClubLifecycleEvent {
+  type: string;
+  season?: number | null;
+  fromSeason?: number | null;
+  toSeason?: number | null;
+  fromName?: string | null;
+  toName?: string | null;
+  description?: string | null;
+  sourceRefs?: ClubSourceRef[];
+}
+
+export interface ClubTrackedMembership {
+  fromSeason: number;
+  toSeason?: number | null;
+  tiers?: string[];
+  basis?: string | null;
+  notes?: string | null;
+  sourceRefs?: ClubSourceRef[];
+}
+
+export interface ClubAbsenceExplanation {
+  fromSeason: number;
+  toSeason?: number | null;
+  reason: string;
+  linkedEventType?: string | null;
+  basis?: string | null;
+  notes?: string | null;
+  sourceRefs?: ClubSourceRef[];
+}
+
+export interface ClubHistory {
+  nameHistory?: ClubNamePeriod[];
+  lifecycleEvents?: ClubLifecycleEvent[];
+  trackedMembership?: ClubTrackedMembership[];
+  absenceExplanations?: ClubAbsenceExplanation[];
+}
+
+export interface ClubStatus {
+  current?: 'active' | 'defunct' | 'renamed' | 'merged' | 'phoenix' | 'unknown' | string;
+  trackedFromSeason?: number | null;
+  trackedToSeason?: number | null;
+  hasUnexplainedGaps?: boolean;
+}
+
 export interface ClubDerivedMetadata {
   source?: string | null;
   aliases?: string[];
@@ -154,7 +204,10 @@ export interface ClubDerivedMetadata {
 }
 
 export interface ClubMetadata {
+  clubId?: string;
   canonicalName: string;
+  status?: ClubStatus;
+  history?: ClubHistory;
   derived?: ClubDerivedMetadata;
   founded?: string | null;
   dissolved?: string | null;


### PR DESCRIPTION
## Summary
- Adds generated club continuity explanations from scraped league table notes.
- Reduces club continuity verifier gaps to zero.
- Documents the planned layer 2 researched metadata enrichment path.

## What Changed
- Classifies row notes like `Failed re-election`, `Resigned from league`, and `Relegation to Conference National`.
- Emits `history.lifecycleEvents[]` and `history.absenceExplanations[]` with `basis: "table-note"`.
- Regenerates `data/club-metadata.json`.
- Adds focused Jest coverage for table-note-derived gap explanations.
- Adds `docs/club-metadata-layer-2.md` with researched long-gap notes and future implementation plan.
- Updates README reason-code docs.

## Validation
- `pnpm -s test:jest`
- `pnpm wiki:verify`
- `pnpm wiki:club-verify --json`
- `pnpm docs:check`
- `pnpm lint`
- `pnpm format:check`

## Scope Notes
- Layer 1 remains fully generated from scraped season/table data.
- Layer 2 researched facts are documented but not implemented in this slice.
- `pnpm lint` passes with the existing warning in `wikipedia/builders/parse-ext-season-overview-pages.js`.