### PR TITLE
Add themed schema docs viewer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -57,6 +57,7 @@
         <nav class="link-grid" aria-label="project links">
           <a href="https://github.com/dills122/footy-data-kit">GitHub repo</a>
           <a href="https://github.com/dills122/footy-data-kit/releases">Releases</a>
+          <a href="./schema/">Schema docs</a>
           <a href="https://github.com/dills122/footy-data-kit/blob/main/readme.md">README</a>
           <a href="https://github.com/dills122/footy-data-kit/tree/main/wikipedia">Pipeline code</a>
         </nav>
@@ -215,6 +216,41 @@
             >
             <a
               href="https://raw.githubusercontent.com/dills122/footy-data-kit/main/data/club-metadata.json"
+              >raw</a
+            >
+          </li>
+        </ul>
+      </section>
+
+      <section class="panel">
+        <div class="section-heading">
+          <h2>Schema</h2>
+          <a class="release-link" href="./schema/">schema index</a>
+        </div>
+
+        <p>Human-readable JSON Schema references for the published data files.</p>
+        <ul class="download-list schema-list">
+          <li>
+            <code>club-metadata.schema.json</code>
+            <span
+              >Sidecar club identity metadata keyed by clubId. Records combine source-backed history
+              with generated observations from the season tables.</span
+            >
+            <a href="./schema/club-metadata.html">view</a>
+            <a
+              href="https://raw.githubusercontent.com/dills122/footy-data-kit/main/schemas/club-metadata.schema.json"
+              >raw</a
+            >
+          </li>
+          <li>
+            <code>football-data.schema.json</code>
+            <span
+              >Merged English football season dataset. Season records contain a seasonInfo summary
+              and zero or more tierN league-table records.</span
+            >
+            <a href="./schema/football-data.html">view</a>
+            <a
+              href="https://raw.githubusercontent.com/dills122/footy-data-kit/main/schemas/football-data.schema.json"
               >raw</a
             >
           </li>

--- a/docs/index.template.html
+++ b/docs/index.template.html
@@ -94,6 +94,25 @@
       </section>
 
       <section class="panel">
+        <div class="section-heading">
+          <h2>Schema</h2>
+          <a class="release-link" href="./schema/">schema index</a>
+        </div>
+
+        <p>Human-readable JSON Schema references for the published data files.</p>
+        <ul class="download-list schema-list">
+          {{#schemaDocs}}
+          <li>
+            <code>{{fileName}}</code>
+            <span>{{description}}</span>
+            <a href="{{{docUrl}}}">view</a>
+            <a href="{{{rawUrl}}}">raw</a>
+          </li>
+          {{/schemaDocs}}
+        </ul>
+      </section>
+
+      <section class="panel">
         <h2>Use it</h2>
         <pre><code>curl -L {{{curlUrl}}} \
   -o all-seasons.min.json</code></pre>

--- a/docs/schema/club-metadata.html
+++ b/docs/schema/club-metadata.html
@@ -1,0 +1,933 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>ClubMetadataExport schema | footy-data-kit</title>
+    <meta
+      name="description"
+      content="Sidecar club identity metadata keyed by clubId. Records combine source-backed history with generated observations from the season tables."
+    />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <header class="site-header">
+        <p class="eyebrow">schema reference</p>
+        <h1>ClubMetadataExport</h1>
+        <p class="lede">
+          Sidecar club identity metadata keyed by clubId. Records combine source-backed history with
+          generated observations from the season tables.
+        </p>
+      </header>
+
+      <section class="panel">
+        <h2>Schema Links</h2>
+        <nav class="link-grid" aria-label="schema links">
+          <a href="../index.html">docs home</a>
+          <a href="./index.html">schema index</a>
+          <a
+            href="https://raw.githubusercontent.com/dills122/footy-data-kit/main/schemas/club-metadata.schema.json"
+            >raw schema</a
+          >
+          <a href="./football-data.html">FootballData</a>
+        </nav>
+      </section>
+
+      <section class="panel">
+        <h2>Contents</h2>
+        <nav class="schema-toc" aria-label="schema contents">
+          <a href="#root">Root</a><a href="#club-absence-explanation">ClubAbsenceExplanation</a
+          ><a href="#club-coverage-gap">ClubCoverageGap</a
+          ><a href="#club-derived-metadata">ClubDerivedMetadata</a
+          ><a href="#club-financial-event">ClubFinancialEvent</a
+          ><a href="#club-history">ClubHistory</a
+          ><a href="#club-identity-source">ClubIdentitySource</a
+          ><a href="#club-lifecycle-event">ClubLifecycleEvent</a
+          ><a href="#club-metadata">ClubMetadata</a><a href="#club-name-period">ClubNamePeriod</a
+          ><a href="#club-observed-name">ClubObservedName</a
+          ><a href="#club-observed-name-period">ClubObservedNamePeriod</a
+          ><a href="#club-relationship">ClubRelationship</a><a href="#clubs-map">ClubsMap</a
+          ><a href="#club-source-ref">ClubSourceRef</a><a href="#club-status">ClubStatus</a
+          ><a href="#club-tier-seasons">ClubTierSeasons</a
+          ><a href="#club-tracked-membership">ClubTrackedMembership</a
+          ><a href="#integer-list">IntegerList</a><a href="#source-refs">SourceRefs</a
+          ><a href="#string-list">StringList</a>
+        </nav>
+      </section>
+
+      <section class="panel schema-definition" id="root">
+        <div class="section-heading">
+          <h2>Root</h2>
+          <a href="#root">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>1 required</span><span>closed object</span>
+        </div>
+        <p>
+          Sidecar club identity metadata keyed by clubId. Records combine source-backed history with
+          generated observations from the season tables.
+        </p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>clubs</code>
+            <span><a href="#clubs-map">ClubsMap</a></span>
+            <span>required</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-absence-explanation">
+        <div class="section-heading">
+          <h2>ClubAbsenceExplanation</h2>
+          <a href="#club-absence-explanation">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>2 required</span><span>closed object</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>fromSeason</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>toSeason</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>reason</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span
+              >Broad reason code such as official-competition-paused, outside-tracked-coverage,
+              club-inactive, club-dissolved, club-reformed, or unknown.</span
+            >
+          </div>
+          <div class="schema-row">
+            <code>linkedEventType</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>basis</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>notes</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>sourceRefs</code>
+            <span><a href="#source-refs">SourceRefs</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-coverage-gap">
+        <div class="section-heading">
+          <h2>ClubCoverageGap</h2>
+          <a href="#club-coverage-gap">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>3 required</span><span>closed object</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>startSeason</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>endSeason</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>length</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-derived-metadata">
+        <div class="section-heading">
+          <h2>ClubDerivedMetadata</h2>
+          <a href="#club-derived-metadata">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>closed object</span>
+        </div>
+        <p>
+          Generated observations from the season table data. These fields describe dataset coverage,
+          not necessarily real-world club activity.
+        </p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>source</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>aliases</code>
+            <span><a href="#string-list">StringList</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>identitySources</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>relationships</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>observedNames</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>observedNamePeriods</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>firstSeenSeason</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>lastSeenSeason</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>seasonsSeen</code>
+            <span><a href="#integer-list">IntegerList</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>totalSeasonsSeen</code>
+            <span><code>integer</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>tiersSeen</code>
+            <span><a href="#string-list">StringList</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>tierSeasons</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>coverageGaps</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-financial-event">
+        <div class="section-heading">
+          <h2>ClubFinancialEvent</h2>
+          <a href="#club-financial-event">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>1 required</span><span>closed object</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>type</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>startSeason</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>endSeason</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>seasonsMissed</code>
+            <span><a href="#integer-list">IntegerList</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>notes</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-history">
+        <div class="section-heading">
+          <h2>ClubHistory</h2>
+          <a href="#club-history">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>closed object</span>
+        </div>
+        <p>Source-backed club history and expected membership context.</p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>nameHistory</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>lifecycleEvents</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>trackedMembership</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>absenceExplanations</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-identity-source">
+        <div class="section-heading">
+          <h2>ClubIdentitySource</h2>
+          <a href="#club-identity-source">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>2 required</span><span>closed object</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>type</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>sourceUrl</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>notes</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-lifecycle-event">
+        <div class="section-heading">
+          <h2>ClubLifecycleEvent</h2>
+          <a href="#club-lifecycle-event">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>1 required</span><span>closed object</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>type</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span
+              >Event label such as renamed, merged, dissolved, not-re-elected, relocated, or
+              phoenix.</span
+            >
+          </div>
+          <div class="schema-row">
+            <code>season</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>date</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>fromSeason</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>toSeason</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>fromName</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>toName</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>label</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>description</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>notes</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>sourceRefs</code>
+            <span><a href="#source-refs">SourceRefs</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-metadata">
+        <div class="section-heading">
+          <h2>ClubMetadata</h2>
+          <a href="#club-metadata">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>1 required</span><span>closed object</span>
+        </div>
+        <p>Metadata for a single club identity.</p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>clubId</code>
+            <span><code>string</code></span>
+            <span>optional</span>
+            <span>URL-safe stable club identity slug.</span>
+          </div>
+          <div class="schema-row">
+            <code>canonicalName</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span>Preferred display name for this club identity.</span>
+          </div>
+          <div class="schema-row">
+            <code>status</code>
+            <span><a href="#club-status">ClubStatus</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>history</code>
+            <span><a href="#club-history">ClubHistory</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>derived</code>
+            <span><a href="#club-derived-metadata">ClubDerivedMetadata</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>founded</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>dissolved</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>nameHistory</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span>Legacy name-history field. Prefer history.nameHistory for new consumers.</span>
+          </div>
+          <div class="schema-row">
+            <code>financialEvents</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span
+              >Legacy financial-event field. Prefer source-backed lifecycle events for new
+              consumers.</span
+            >
+          </div>
+          <div class="schema-row">
+            <code>notes</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>sourceUrl</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-name-period">
+        <div class="section-heading">
+          <h2>ClubNamePeriod</h2>
+          <a href="#club-name-period">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>1 required</span><span>closed object</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>name</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>startSeason</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>endSeason</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>notes</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-observed-name">
+        <div class="section-heading">
+          <h2>ClubObservedName</h2>
+          <a href="#club-observed-name">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>4 required</span><span>closed object</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>rawName</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>normalizedName</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>firstSeenSeason</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>lastSeenSeason</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>seasonsSeen</code>
+            <span><a href="#integer-list">IntegerList</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>tiersSeen</code>
+            <span><a href="#string-list">StringList</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-observed-name-period">
+        <div class="section-heading">
+          <h2>ClubObservedNamePeriod</h2>
+          <a href="#club-observed-name-period">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>3 required</span><span>closed object</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>name</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>startSeason</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>endSeason</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-relationship">
+        <div class="section-heading">
+          <h2>ClubRelationship</h2>
+          <a href="#club-relationship">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>3 required</span><span>closed object</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>clubKey</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>relationship</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>direction</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>season</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>label</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>sourceRefs</code>
+            <span><a href="#source-refs">SourceRefs</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>notes</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="clubs-map">
+        <div class="section-heading">
+          <h2>ClubsMap</h2>
+          <a href="#clubs-map">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>closed object</span><span>pattern keys</span>
+        </div>
+        <p>Map of club key to club metadata record.</p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>^[a-z0-9][a-z0-9-]*$</code>
+            <span><a href="#club-metadata">ClubMetadata</a></span>
+            <span>optional</span>
+            <span>Pattern property</span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-source-ref">
+        <div class="section-heading">
+          <h2>ClubSourceRef</h2>
+          <a href="#club-source-ref">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>2 required</span><span>closed object</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>type</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>sourceUrl</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>notes</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-status">
+        <div class="section-heading">
+          <h2>ClubStatus</h2>
+          <a href="#club-status">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>closed object</span>
+        </div>
+        <p>Consumer-facing status summary for the club identity.</p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>current</code>
+            <span><code>string</code></span>
+            <span>optional</span>
+            <span
+              >Small status label such as active, historical, defunct, merged, relocated, renamed,
+              phoenix, or unknown.</span
+            >
+          </div>
+          <div class="schema-row">
+            <code>trackedFromSeason</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>trackedToSeason</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>hasUnexplainedGaps</code>
+            <span><code>boolean</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>reason</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>reasonLabel</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>sourceRefs</code>
+            <span><a href="#source-refs">SourceRefs</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-tier-seasons">
+        <div class="section-heading">
+          <h2>ClubTierSeasons</h2>
+          <a href="#club-tier-seasons">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>2 required</span><span>closed object</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>tierKey</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>seasons</code>
+            <span><a href="#integer-list">IntegerList</a></span>
+            <span>required</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="club-tracked-membership">
+        <div class="section-heading">
+          <h2>ClubTrackedMembership</h2>
+          <a href="#club-tracked-membership">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>1 required</span><span>closed object</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>fromSeason</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>toSeason</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>tiers</code>
+            <span><a href="#string-list">StringList</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>basis</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>notes</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>sourceRefs</code>
+            <span><a href="#source-refs">SourceRefs</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="integer-list">
+        <div class="section-heading">
+          <h2>IntegerList</h2>
+          <a href="#integer-list">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>array</code></span>
+        </div>
+
+        <p class="schema-muted">No named properties.</p>
+      </section>
+      <section class="panel schema-definition" id="source-refs">
+        <div class="section-heading">
+          <h2>SourceRefs</h2>
+          <a href="#source-refs">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>array</code></span>
+        </div>
+
+        <p class="schema-muted">No named properties.</p>
+      </section>
+      <section class="panel schema-definition" id="string-list">
+        <div class="section-heading">
+          <h2>StringList</h2>
+          <a href="#string-list">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>array</code></span>
+        </div>
+
+        <p class="schema-muted">No named properties.</p>
+      </section>
+
+      <footer>
+        <span>generated from schemas/club-metadata.schema.json</span>
+        <a href="../index.html">footy-data-kit</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/docs/schema/club-metadata.html
+++ b/docs/schema/club-metadata.html
@@ -51,8 +51,8 @@
           ><a href="#club-source-ref">ClubSourceRef</a><a href="#club-status">ClubStatus</a
           ><a href="#club-tier-seasons">ClubTierSeasons</a
           ><a href="#club-tracked-membership">ClubTrackedMembership</a
-          ><a href="#integer-list">IntegerList</a><a href="#source-refs">SourceRefs</a
-          ><a href="#string-list">StringList</a>
+          ><a href="#dataset-metadata">DatasetMetadata</a><a href="#integer-list">IntegerList</a
+          ><a href="#source-refs">SourceRefs</a><a href="#string-list">StringList</a>
         </nav>
       </section>
 
@@ -70,6 +70,12 @@
           generated observations from the season tables.
         </p>
         <div class="schema-table">
+          <div class="schema-row">
+            <code>metadata</code>
+            <span><a href="#dataset-metadata">DatasetMetadata</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
           <div class="schema-row">
             <code>clubs</code>
             <span><a href="#clubs-map">ClubsMap</a></span>
@@ -717,10 +723,10 @@
           <span>type <code>object</code></span>
           <span>closed object</span><span>pattern keys</span>
         </div>
-        <p>Map of club key to club metadata record.</p>
+        <p>Map of canonical club key to club metadata record.</p>
         <div class="schema-table">
           <div class="schema-row">
-            <code>^[a-z0-9][a-z0-9-]*$</code>
+            <code>^[a-z0-9][a-z0-9 -]*$</code>
             <span><a href="#club-metadata">ClubMetadata</a></span>
             <span>optional</span>
             <span>Pattern property</span>
@@ -885,6 +891,55 @@
           <div class="schema-row">
             <code>sourceRefs</code>
             <span><a href="#source-refs">SourceRefs</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="dataset-metadata">
+        <div class="section-heading">
+          <h2>DatasetMetadata</h2>
+          <a href="#dataset-metadata">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>closed object</span>
+        </div>
+        <p>Build provenance for the generated club metadata sidecar.</p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>schemaVersion</code>
+            <span><code>integer</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>generator</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>generatedAt</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>gitSha</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>sourceFiles</code>
+            <span><a href="#string-list">StringList</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>buildOptions</code>
+            <span><code>object</code></span>
             <span>optional</span>
             <span></span>
           </div>

--- a/docs/schema/football-data.html
+++ b/docs/schema/football-data.html
@@ -95,7 +95,7 @@
 
         <div class="schema-table">
           <div class="schema-row">
-            <code>^[a-z0-9][a-z0-9-]*$</code>
+            <code>^[a-z0-9][a-z0-9 -]*$</code>
             <span><a href="club-metadata.html#club-metadata">ClubMetadata</a></span>
             <span>optional</span>
             <span>Pattern property</span>

--- a/docs/schema/football-data.html
+++ b/docs/schema/football-data.html
@@ -1,0 +1,557 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>FootballData schema | footy-data-kit</title>
+    <meta
+      name="description"
+      content="Merged English football season dataset. Season records contain a seasonInfo summary and zero or more tierN league-table records."
+    />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <header class="site-header">
+        <p class="eyebrow">schema reference</p>
+        <h1>FootballData</h1>
+        <p class="lede">
+          Merged English football season dataset. Season records contain a seasonInfo summary and
+          zero or more tierN league-table records.
+        </p>
+      </header>
+
+      <section class="panel">
+        <h2>Schema Links</h2>
+        <nav class="link-grid" aria-label="schema links">
+          <a href="../index.html">docs home</a>
+          <a href="./index.html">schema index</a>
+          <a
+            href="https://raw.githubusercontent.com/dills122/footy-data-kit/main/schemas/football-data.schema.json"
+            >raw schema</a
+          >
+          <a href="./club-metadata.html">ClubMetadataExport</a>
+        </nav>
+      </section>
+
+      <section class="panel">
+        <h2>Contents</h2>
+        <nav class="schema-toc" aria-label="schema contents">
+          <a href="#root">Root</a><a href="#clubs-map">ClubsMap</a
+          ><a href="#dataset-metadata">DatasetMetadata</a
+          ><a href="#league-table-entry">LeagueTableEntry</a><a href="#season-data">SeasonData</a
+          ><a href="#season-info">SeasonInfo</a><a href="#seasons-map">SeasonsMap</a
+          ><a href="#string-list">StringList</a><a href="#tier-data">TierData</a
+          ><a href="#tier-metadata">TierMetadata</a>
+        </nav>
+      </section>
+
+      <section class="panel schema-definition" id="root">
+        <div class="section-heading">
+          <h2>Root</h2>
+          <a href="#root">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>1 required</span><span>closed object</span>
+        </div>
+        <p>
+          Merged English football season dataset. Season records contain a seasonInfo summary and
+          zero or more tierN league-table records.
+        </p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>metadata</code>
+            <span><a href="#dataset-metadata">DatasetMetadata</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>clubs</code>
+            <span><a href="#clubs-map">ClubsMap</a></span>
+            <span>optional</span>
+            <span
+              >Optional embedded club metadata. Release assets normally publish club metadata as a
+              sidecar file instead.</span
+            >
+          </div>
+          <div class="schema-row">
+            <code>seasons</code>
+            <span><a href="#seasons-map">SeasonsMap</a></span>
+            <span>required</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="clubs-map">
+        <div class="section-heading">
+          <h2>ClubsMap</h2>
+          <a href="#clubs-map">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>closed object</span><span>pattern keys</span>
+        </div>
+
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>^[a-z0-9][a-z0-9-]*$</code>
+            <span><a href="club-metadata.html#club-metadata">ClubMetadata</a></span>
+            <span>optional</span>
+            <span>Pattern property</span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="dataset-metadata">
+        <div class="section-heading">
+          <h2>DatasetMetadata</h2>
+          <a href="#dataset-metadata">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>closed object</span>
+        </div>
+        <p>Build provenance for a generated FootballData export.</p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>schemaVersion</code>
+            <span><code>integer</code></span>
+            <span>optional</span>
+            <span>Version of the generated dataset contract.</span>
+          </div>
+          <div class="schema-row">
+            <code>generator</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span>Generator or merge command that produced this export.</span>
+          </div>
+          <div class="schema-row">
+            <code>generatedAt</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span>ISO timestamp for the data generation run.</span>
+          </div>
+          <div class="schema-row">
+            <code>gitSha</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span>Git commit SHA used for the data generation run.</span>
+          </div>
+          <div class="schema-row">
+            <code>sourceFiles</code>
+            <span><code>array</code></span>
+            <span>optional</span>
+            <span>Input files used to build the export.</span>
+          </div>
+          <div class="schema-row">
+            <code>buildOptions</code>
+            <span><code>object</code></span>
+            <span>optional</span>
+            <span>Selected build options captured as primitive values.</span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="league-table-entry">
+        <div class="section-heading">
+          <h2>LeagueTableEntry</h2>
+          <a href="#league-table-entry">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>17 required</span><span>closed object</span>
+        </div>
+        <p>One final league-table row.</p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>pos</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>team</code>
+            <span><code>string</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>played</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>won</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>drawn</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>lost</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>goalsFor</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>goalsAgainst</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>goalDifference</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>goalAverage</code>
+            <span><code>number</code> | <code>null</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>points</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>notes</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>wasRelegated</code>
+            <span><code>boolean</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>wasPromoted</code>
+            <span><code>boolean</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>isExpansionTeam</code>
+            <span><code>boolean</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>wasReElected</code>
+            <span><code>boolean</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>wasReprieved</code>
+            <span><code>boolean</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="season-data">
+        <div class="section-heading">
+          <h2>SeasonData</h2>
+          <a href="#season-data">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>1 required</span><span>closed object</span><span>pattern keys</span>
+        </div>
+        <p>
+          A single season. Wartime or abandoned placeholder seasons may contain only seasonInfo.
+        </p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>seasonInfo</code>
+            <span><a href="#season-info">SeasonInfo</a></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>^tier\d+$</code>
+            <span><a href="#tier-data">TierData</a></span>
+            <span>optional</span>
+            <span>Pattern property</span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="season-info">
+        <div class="section-heading">
+          <h2>SeasonInfo</h2>
+          <a href="#season-info">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>4 required</span><span>closed object</span>
+        </div>
+        <p>
+          Season-level summary. promoted and relegated describe movement into and out of the next
+          season's top flight.
+        </p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>season</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span>Starting year for the season.</span>
+          </div>
+          <div class="schema-row">
+            <code>table</code>
+            <span><code>array</code></span>
+            <span>required</span>
+            <span>Always empty. seasonInfo is a summary object, not a league table.</span>
+          </div>
+          <div class="schema-row">
+            <code>relegated</code>
+            <span><a href="#string-list">StringList</a></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>promoted</code>
+            <span><a href="#string-list">StringList</a></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>seasonSlug</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>sourceUrl</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>tableCount</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>competitionStatus</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>warSuspensionLabel</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>officialLeagueTables</code>
+            <span><code>boolean</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>officialCompetitionsSuspended</code>
+            <span><code>boolean</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>officialCompetitionsAbandoned</code>
+            <span><code>boolean</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>regionalBridgeSeason</code>
+            <span><code>boolean</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>promotionRelegationApplies</code>
+            <span><code>boolean</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>specialCompetitions</code>
+            <span><a href="#string-list">StringList</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>notes</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="seasons-map">
+        <div class="section-heading">
+          <h2>SeasonsMap</h2>
+          <a href="#seasons-map">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>closed object</span><span>pattern keys</span>
+        </div>
+        <p>
+          Map of starting season year to season data. For example, 2025 means the 2025-26 season.
+        </p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>^\d{4}$</code>
+            <span><a href="#season-data">SeasonData</a></span>
+            <span>optional</span>
+            <span>Pattern property</span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="string-list">
+        <div class="section-heading">
+          <h2>StringList</h2>
+          <a href="#string-list">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>array</code></span>
+        </div>
+
+        <p class="schema-muted">No named properties.</p>
+      </section>
+      <section class="panel schema-definition" id="tier-data">
+        <div class="section-heading">
+          <h2>TierData</h2>
+          <a href="#tier-data">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>4 required</span><span>closed object</span>
+        </div>
+        <p>League-table data for one tier in a season.</p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>season</code>
+            <span><code>integer</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>table</code>
+            <span><code>array</code></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>relegated</code>
+            <span><a href="#string-list">StringList</a></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>promoted</code>
+            <span><a href="#string-list">StringList</a></span>
+            <span>required</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>metadata</code>
+            <span><a href="#tier-metadata">TierMetadata</a></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+      <section class="panel schema-definition" id="tier-metadata">
+        <div class="section-heading">
+          <h2>TierMetadata</h2>
+          <a href="#tier-metadata">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>closed object</span>
+        </div>
+        <p>Source and table-selection metadata for a tier record.</p>
+        <div class="schema-table">
+          <div class="schema-row">
+            <code>source</code>
+            <span><code>string</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>sourceUrl</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>seasonSlug</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>leagueId</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>title</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>leagueLevel</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>tableIndex</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>tableCount</code>
+            <span><code>integer</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+          <div class="schema-row">
+            <code>tierKey</code>
+            <span><code>string</code> | <code>null</code></span>
+            <span>optional</span>
+            <span></span>
+          </div>
+        </div>
+      </section>
+
+      <footer>
+        <span>generated from schemas/football-data.schema.json</span>
+        <a href="../index.html">footy-data-kit</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/docs/schema/index.html
+++ b/docs/schema/index.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Schema reference | footy-data-kit</title>
+    <meta name="description" content="Static schema reference for footy-data-kit JSON exports." />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <header class="site-header">
+        <p class="eyebrow">data contract</p>
+        <h1>schema reference</h1>
+        <p class="lede">Human-readable JSON Schema documentation for the published data files.</p>
+      </header>
+
+      <section class="panel">
+        <h2>Schema Files</h2>
+        <ul class="download-list schema-list">
+          <li>
+            <code>club-metadata.schema.json</code>
+            <span
+              >Sidecar club identity metadata keyed by clubId. Records combine source-backed history
+              with generated observations from the season tables.</span
+            >
+            <a href="./club-metadata.html">view</a>
+            <a
+              href="https://raw.githubusercontent.com/dills122/footy-data-kit/main/schemas/club-metadata.schema.json"
+              >raw</a
+            >
+          </li>
+          <li>
+            <code>football-data.schema.json</code>
+            <span
+              >Merged English football season dataset. Season records contain a seasonInfo summary
+              and zero or more tierN league-table records.</span
+            >
+            <a href="./football-data.html">view</a>
+            <a
+              href="https://raw.githubusercontent.com/dills122/footy-data-kit/main/schemas/football-data.schema.json"
+              >raw</a
+            >
+          </li>
+        </ul>
+      </section>
+
+      <section class="panel">
+        <h2>Use These Schemas</h2>
+        <p>
+          The schemas document the generated JSON contract and can be used by validators that
+          support JSON Schema Draft-07.
+        </p>
+        <pre><code>schemas/football-data.schema.json
+schemas/club-metadata.schema.json</code></pre>
+      </section>
+
+      <footer>
+        <span>static schema docs</span>
+        <a href="../index.html">docs home</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/docs/site-data.json
+++ b/docs/site-data.json
@@ -19,10 +19,27 @@
   "links": [
     { "label": "GitHub repo", "url": "https://github.com/dills122/footy-data-kit" },
     { "label": "Releases", "url": "https://github.com/dills122/footy-data-kit/releases" },
+    { "label": "Schema docs", "url": "./schema/" },
     { "label": "README", "url": "https://github.com/dills122/footy-data-kit/blob/main/readme.md" },
     {
       "label": "Pipeline code",
       "url": "https://github.com/dills122/footy-data-kit/tree/main/wikipedia"
+    }
+  ],
+  "schemaDocs": [
+    {
+      "title": "ClubMetadataExport",
+      "description": "Sidecar club identity metadata keyed by clubId. Records combine source-backed history with generated observations from the season tables.",
+      "fileName": "club-metadata.schema.json",
+      "docUrl": "./schema/club-metadata.html",
+      "rawUrl": "https://raw.githubusercontent.com/dills122/footy-data-kit/main/schemas/club-metadata.schema.json"
+    },
+    {
+      "title": "FootballData",
+      "description": "Merged English football season dataset. Season records contain a seasonInfo summary and zero or more tierN league-table records.",
+      "fileName": "football-data.schema.json",
+      "docUrl": "./schema/football-data.html",
+      "rawUrl": "https://raw.githubusercontent.com/dills122/footy-data-kit/main/schemas/football-data.schema.json"
     }
   ],
   "latestRelease": {

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -247,6 +247,53 @@ code {
   color: var(--muted);
 }
 
+.schema-list li {
+  grid-template-columns: minmax(18ch, 30ch) 1fr auto auto;
+}
+
+.schema-toc {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 9px 16px;
+}
+
+.schema-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 12px;
+  color: var(--muted);
+  font-size: 0.86rem;
+}
+
+.schema-summary span {
+  padding-right: 8px;
+  border-right: 1px solid var(--rule);
+}
+
+.schema-summary span:last-child {
+  border-right: 0;
+}
+
+.schema-table {
+  border-top: 1px solid var(--rule);
+}
+
+.schema-row {
+  display: grid;
+  grid-template-columns: minmax(15ch, 24ch) minmax(10ch, 18ch) 9ch 1fr;
+  gap: 8px 14px;
+  align-items: baseline;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--rule);
+}
+
+.schema-row > span:nth-child(3),
+.schema-row > span:nth-child(4),
+.schema-muted {
+  color: var(--muted);
+}
+
 pre {
   overflow-x: auto;
   margin: 0;
@@ -296,7 +343,8 @@ footer {
 @media (max-width: 560px) {
   .release-pin,
   .release-row,
-  .download-list li {
+  .download-list li,
+  .schema-row {
     grid-template-columns: 1fr;
     gap: 4px;
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "wiki:club-historical-audit:check": "node wikipedia/data/verify-club-continuity.js --check-historical-reasons --fail-on-issues",
     "wiki:club-verify": "node wikipedia/data/verify-club-continuity.js",
     "wiki:verify": "node wikipedia/data/verify-football-data.js --fail-on-issues ./data-output",
-    "verify:data": "pnpm -s wiki:verify && pnpm -s wiki:club-historical-audit:check",
+    "schema:verify": "node wikipedia/data/verify-json-schemas.js",
+    "verify:data": "pnpm -s wiki:verify && pnpm -s wiki:club-historical-audit:check && pnpm -s schema:verify",
     "wiki:minify:promotion": "node scripts/minify-json.js ./data-output/wiki_promotion_relegations_by_season.json",
     "wiki:minify:overview": "node scripts/minify-json.js ./data-output/wiki_overview_tables_by_season.json",
     "wiki:minify:combined": "node scripts/minify-json.js ./data-output/all-seasons.json",
@@ -64,6 +65,7 @@
     "wikipedia": "^2.4.2"
   },
   "devDependencies": {
+    "ajv": "8.17.1",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.1",
     "eslint-config-prettier": "^8.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
     devDependencies:
+      ajv:
+        specifier: 8.17.1
+        version: 8.17.1
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -418,6 +421,9 @@ packages:
 
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
+
+  ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
@@ -828,6 +834,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -1208,6 +1217,9 @@ packages:
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
@@ -1530,6 +1542,10 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   resolve-cwd@3.0.0:
@@ -2306,6 +2322,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.17.1:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -2758,6 +2781,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.2: {}
 
   fastq@1.19.1:
     dependencies:
@@ -3309,6 +3334,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
@@ -3592,6 +3619,8 @@ snapshots:
   react-is@18.3.1: {}
 
   require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
 
   resolve-cwd@3.0.0:
     dependencies:

--- a/readme.md
+++ b/readme.md
@@ -137,6 +137,7 @@ Each run saves season-by-season progress immediately, so reruns are fast. The `c
 - `wikipedia/data/compare-football-data.js` – compare two FootballData JSON files and report season, tier, table, outcome-list, and metadata changes between releases. Pass `--json` for machine-readable output.
   Pass `--markdown` for a release-note-friendly summary.
 - `wikipedia/data/build-release-notes.js` – combine a curated note from `docs/release-notes/vX.Y.Z.md` with generated dataset counts, club metadata counts, validation notes, and the release diff. The release workflow publishes this as `release-notes.md` and uses it as the GitHub release body.
+- `wikipedia/data/verify-json-schemas.js` – validate generated data files against the JSON Schema contracts in `schemas/`. Run with `pnpm -s schema:verify`; this is also included in `pnpm -s verify:data`.
 - `scripts/minify-json.js` – shrink JSON files in place or alongside (`foo.min.json`) so they are ready for publishing.
 - `wikipedia/data/verify-football-data.js` – lint FootballData exports for empty tiers, duplicate teams, stat mismatches, or promotion/relegation inconsistencies. Pass `--fail-on-issues` to exit non-zero when anomalies exist.
 
@@ -207,6 +208,9 @@ pnpm -s wiki:club-seed
 
 # Run the data lint pass and historical club-reason check
 pnpm -s verify:data
+
+# Run only the JSON Schema drift check
+pnpm -s schema:verify
 
 # Write the historical club-reason audit review artifact
 pnpm -s wiki:club-historical-audit

--- a/readme.md
+++ b/readme.md
@@ -96,6 +96,7 @@ pnpm test:integration:promotion
 
 - `data/` – generated sidecar club metadata, review artifacts, raw reference files, and one-off exports.
 - `data-output/` – canonical Wikipedia JSON outputs grouped by source.
+- `schemas/` – JSON Schema Draft-07 contracts for the published season dataset and club metadata sidecar.
 - `scripts/` – helper utilities such as `minify-json.js` plus older one-off generators.
 - `wikipedia/` – the main scraper, parsers, and FootballData models.
 - `rsssf/` – legacy RSSSF parsing experiments. See [RSSSF legacy tooling](docs/rsssf-legacy.md).
@@ -143,6 +144,7 @@ Each run saves season-by-season progress immediately, so reruns are fast. The `c
 
 - The main season contract is the merged file: `data-output/all-seasons.json`.
 - Club identity data is published separately as the sidecar file `data/club-metadata.json`.
+- JSON Schema contracts live in `schemas/` and are rendered into the docs site under `docs/schema/`.
 - Every FootballData export may include a top-level `metadata` object with release provenance:
   - `schemaVersion`
   - `generator`

--- a/schemas/club-metadata.schema.json
+++ b/schemas/club-metadata.schema.json
@@ -7,16 +7,48 @@
   "required": ["clubs"],
   "additionalProperties": false,
   "properties": {
+    "metadata": {
+      "$ref": "#/definitions/DatasetMetadata"
+    },
     "clubs": {
       "$ref": "#/definitions/ClubsMap"
     }
   },
   "definitions": {
+    "DatasetMetadata": {
+      "type": "object",
+      "description": "Build provenance for the generated club metadata sidecar.",
+      "additionalProperties": false,
+      "properties": {
+        "schemaVersion": {
+          "type": "integer"
+        },
+        "generator": {
+          "type": ["string", "null"]
+        },
+        "generatedAt": {
+          "type": ["string", "null"],
+          "format": "date-time"
+        },
+        "gitSha": {
+          "type": ["string", "null"]
+        },
+        "sourceFiles": {
+          "$ref": "#/definitions/StringList"
+        },
+        "buildOptions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "number", "boolean", "null"]
+          }
+        }
+      }
+    },
     "ClubsMap": {
       "type": "object",
-      "description": "Map of club key to club metadata record.",
+      "description": "Map of canonical club key to club metadata record.",
       "patternProperties": {
-        "^[a-z0-9][a-z0-9-]*$": {
+        "^[a-z0-9][a-z0-9 -]*$": {
           "$ref": "#/definitions/ClubMetadata"
         }
       },

--- a/schemas/club-metadata.schema.json
+++ b/schemas/club-metadata.schema.json
@@ -1,0 +1,489 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dills122.github.io/footy-data-kit/schemas/club-metadata.schema.json",
+  "title": "ClubMetadataExport",
+  "description": "Sidecar club identity metadata keyed by clubId. Records combine source-backed history with generated observations from the season tables.",
+  "type": "object",
+  "required": ["clubs"],
+  "additionalProperties": false,
+  "properties": {
+    "clubs": {
+      "$ref": "#/definitions/ClubsMap"
+    }
+  },
+  "definitions": {
+    "ClubsMap": {
+      "type": "object",
+      "description": "Map of club key to club metadata record.",
+      "patternProperties": {
+        "^[a-z0-9][a-z0-9-]*$": {
+          "$ref": "#/definitions/ClubMetadata"
+        }
+      },
+      "additionalProperties": false
+    },
+    "ClubMetadata": {
+      "type": "object",
+      "description": "Metadata for a single club identity.",
+      "required": ["canonicalName"],
+      "additionalProperties": false,
+      "properties": {
+        "clubId": {
+          "type": "string",
+          "description": "URL-safe stable club identity slug."
+        },
+        "canonicalName": {
+          "type": "string",
+          "description": "Preferred display name for this club identity."
+        },
+        "status": {
+          "$ref": "#/definitions/ClubStatus"
+        },
+        "history": {
+          "$ref": "#/definitions/ClubHistory"
+        },
+        "derived": {
+          "$ref": "#/definitions/ClubDerivedMetadata"
+        },
+        "founded": {
+          "type": ["string", "null"]
+        },
+        "dissolved": {
+          "type": ["string", "null"]
+        },
+        "nameHistory": {
+          "type": "array",
+          "description": "Legacy name-history field. Prefer history.nameHistory for new consumers.",
+          "items": {
+            "$ref": "#/definitions/ClubNamePeriod"
+          }
+        },
+        "financialEvents": {
+          "type": "array",
+          "description": "Legacy financial-event field. Prefer source-backed lifecycle events for new consumers.",
+          "items": {
+            "$ref": "#/definitions/ClubFinancialEvent"
+          }
+        },
+        "notes": {
+          "type": ["string", "null"]
+        },
+        "sourceUrl": {
+          "type": ["string", "null"],
+          "format": "uri"
+        }
+      }
+    },
+    "ClubStatus": {
+      "type": "object",
+      "description": "Consumer-facing status summary for the club identity.",
+      "additionalProperties": false,
+      "properties": {
+        "current": {
+          "type": "string",
+          "description": "Small status label such as active, historical, defunct, merged, relocated, renamed, phoenix, or unknown."
+        },
+        "trackedFromSeason": {
+          "type": ["integer", "null"]
+        },
+        "trackedToSeason": {
+          "type": ["integer", "null"]
+        },
+        "hasUnexplainedGaps": {
+          "type": "boolean"
+        },
+        "reason": {
+          "type": ["string", "null"]
+        },
+        "reasonLabel": {
+          "type": ["string", "null"]
+        },
+        "sourceRefs": {
+          "$ref": "#/definitions/SourceRefs"
+        }
+      }
+    },
+    "ClubHistory": {
+      "type": "object",
+      "description": "Source-backed club history and expected membership context.",
+      "additionalProperties": false,
+      "properties": {
+        "nameHistory": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClubNamePeriod"
+          }
+        },
+        "lifecycleEvents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClubLifecycleEvent"
+          }
+        },
+        "trackedMembership": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClubTrackedMembership"
+          }
+        },
+        "absenceExplanations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClubAbsenceExplanation"
+          }
+        }
+      }
+    },
+    "ClubDerivedMetadata": {
+      "type": "object",
+      "description": "Generated observations from the season table data. These fields describe dataset coverage, not necessarily real-world club activity.",
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": ["string", "null"]
+        },
+        "aliases": {
+          "$ref": "#/definitions/StringList"
+        },
+        "identitySources": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClubIdentitySource"
+          }
+        },
+        "relationships": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClubRelationship"
+          }
+        },
+        "observedNames": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClubObservedName"
+          }
+        },
+        "observedNamePeriods": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClubObservedNamePeriod"
+          }
+        },
+        "firstSeenSeason": {
+          "type": ["integer", "null"]
+        },
+        "lastSeenSeason": {
+          "type": ["integer", "null"]
+        },
+        "seasonsSeen": {
+          "$ref": "#/definitions/IntegerList"
+        },
+        "totalSeasonsSeen": {
+          "type": "integer"
+        },
+        "tiersSeen": {
+          "$ref": "#/definitions/StringList"
+        },
+        "tierSeasons": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClubTierSeasons"
+          }
+        },
+        "coverageGaps": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClubCoverageGap"
+          }
+        }
+      }
+    },
+    "ClubNamePeriod": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "startSeason": {
+          "type": ["integer", "null"]
+        },
+        "endSeason": {
+          "type": ["integer", "null"]
+        },
+        "notes": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "ClubFinancialEvent": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "startSeason": {
+          "type": ["integer", "null"]
+        },
+        "endSeason": {
+          "type": ["integer", "null"]
+        },
+        "seasonsMissed": {
+          "$ref": "#/definitions/IntegerList"
+        },
+        "notes": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "ClubLifecycleEvent": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Event label such as renamed, merged, dissolved, not-re-elected, relocated, or phoenix."
+        },
+        "season": {
+          "type": ["integer", "null"]
+        },
+        "date": {
+          "type": ["string", "null"]
+        },
+        "fromSeason": {
+          "type": ["integer", "null"]
+        },
+        "toSeason": {
+          "type": ["integer", "null"]
+        },
+        "fromName": {
+          "type": ["string", "null"]
+        },
+        "toName": {
+          "type": ["string", "null"]
+        },
+        "label": {
+          "type": ["string", "null"]
+        },
+        "description": {
+          "type": ["string", "null"]
+        },
+        "notes": {
+          "type": ["string", "null"]
+        },
+        "sourceRefs": {
+          "$ref": "#/definitions/SourceRefs"
+        }
+      }
+    },
+    "ClubTrackedMembership": {
+      "type": "object",
+      "required": ["fromSeason"],
+      "additionalProperties": false,
+      "properties": {
+        "fromSeason": {
+          "type": "integer"
+        },
+        "toSeason": {
+          "type": ["integer", "null"]
+        },
+        "tiers": {
+          "$ref": "#/definitions/StringList"
+        },
+        "basis": {
+          "type": ["string", "null"]
+        },
+        "notes": {
+          "type": ["string", "null"]
+        },
+        "sourceRefs": {
+          "$ref": "#/definitions/SourceRefs"
+        }
+      }
+    },
+    "ClubAbsenceExplanation": {
+      "type": "object",
+      "required": ["fromSeason", "reason"],
+      "additionalProperties": false,
+      "properties": {
+        "fromSeason": {
+          "type": "integer"
+        },
+        "toSeason": {
+          "type": ["integer", "null"]
+        },
+        "reason": {
+          "type": "string",
+          "description": "Broad reason code such as official-competition-paused, outside-tracked-coverage, club-inactive, club-dissolved, club-reformed, or unknown."
+        },
+        "linkedEventType": {
+          "type": ["string", "null"]
+        },
+        "basis": {
+          "type": ["string", "null"]
+        },
+        "notes": {
+          "type": ["string", "null"]
+        },
+        "sourceRefs": {
+          "$ref": "#/definitions/SourceRefs"
+        }
+      }
+    },
+    "ClubIdentitySource": {
+      "type": "object",
+      "required": ["type", "sourceUrl"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "sourceUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "notes": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "ClubSourceRef": {
+      "type": "object",
+      "required": ["type", "sourceUrl"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "sourceUrl": {
+          "type": "string",
+          "format": "uri"
+        },
+        "notes": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "ClubRelationship": {
+      "type": "object",
+      "required": ["clubKey", "relationship", "direction"],
+      "additionalProperties": false,
+      "properties": {
+        "clubKey": {
+          "type": "string"
+        },
+        "relationship": {
+          "type": "string"
+        },
+        "direction": {
+          "type": "string"
+        },
+        "season": {
+          "type": ["integer", "null"]
+        },
+        "label": {
+          "type": ["string", "null"]
+        },
+        "sourceRefs": {
+          "$ref": "#/definitions/SourceRefs"
+        },
+        "notes": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "ClubObservedName": {
+      "type": "object",
+      "required": ["rawName", "normalizedName", "firstSeenSeason", "lastSeenSeason"],
+      "additionalProperties": false,
+      "properties": {
+        "rawName": {
+          "type": "string"
+        },
+        "normalizedName": {
+          "type": "string"
+        },
+        "firstSeenSeason": {
+          "type": "integer"
+        },
+        "lastSeenSeason": {
+          "type": "integer"
+        },
+        "seasonsSeen": {
+          "$ref": "#/definitions/IntegerList"
+        },
+        "tiersSeen": {
+          "$ref": "#/definitions/StringList"
+        }
+      }
+    },
+    "ClubObservedNamePeriod": {
+      "type": "object",
+      "required": ["name", "startSeason", "endSeason"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "startSeason": {
+          "type": "integer"
+        },
+        "endSeason": {
+          "type": "integer"
+        }
+      }
+    },
+    "ClubTierSeasons": {
+      "type": "object",
+      "required": ["tierKey", "seasons"],
+      "additionalProperties": false,
+      "properties": {
+        "tierKey": {
+          "type": "string",
+          "pattern": "^tier\\d+$"
+        },
+        "seasons": {
+          "$ref": "#/definitions/IntegerList"
+        }
+      }
+    },
+    "ClubCoverageGap": {
+      "type": "object",
+      "required": ["startSeason", "endSeason", "length"],
+      "additionalProperties": false,
+      "properties": {
+        "startSeason": {
+          "type": "integer"
+        },
+        "endSeason": {
+          "type": "integer"
+        },
+        "length": {
+          "type": "integer"
+        }
+      }
+    },
+    "SourceRefs": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ClubSourceRef"
+      }
+    },
+    "StringList": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "IntegerList": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    }
+  }
+}

--- a/schemas/football-data.schema.json
+++ b/schemas/football-data.schema.json
@@ -290,7 +290,7 @@
     "ClubsMap": {
       "type": "object",
       "patternProperties": {
-        "^[a-z0-9][a-z0-9-]*$": {
+        "^[a-z0-9][a-z0-9 -]*$": {
           "$ref": "club-metadata.schema.json#/definitions/ClubMetadata"
         }
       },

--- a/schemas/football-data.schema.json
+++ b/schemas/football-data.schema.json
@@ -1,0 +1,306 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://dills122.github.io/footy-data-kit/schemas/football-data.schema.json",
+  "title": "FootballData",
+  "description": "Merged English football season dataset. Season records contain a seasonInfo summary and zero or more tierN league-table records.",
+  "type": "object",
+  "required": ["seasons"],
+  "additionalProperties": false,
+  "properties": {
+    "metadata": {
+      "$ref": "#/definitions/DatasetMetadata"
+    },
+    "clubs": {
+      "$ref": "#/definitions/ClubsMap",
+      "description": "Optional embedded club metadata. Release assets normally publish club metadata as a sidecar file instead."
+    },
+    "seasons": {
+      "$ref": "#/definitions/SeasonsMap"
+    }
+  },
+  "definitions": {
+    "DatasetMetadata": {
+      "type": "object",
+      "description": "Build provenance for a generated FootballData export.",
+      "additionalProperties": false,
+      "properties": {
+        "schemaVersion": {
+          "type": "integer",
+          "description": "Version of the generated dataset contract."
+        },
+        "generator": {
+          "type": ["string", "null"],
+          "description": "Generator or merge command that produced this export."
+        },
+        "generatedAt": {
+          "type": ["string", "null"],
+          "format": "date-time",
+          "description": "ISO timestamp for the data generation run."
+        },
+        "gitSha": {
+          "type": ["string", "null"],
+          "description": "Git commit SHA used for the data generation run."
+        },
+        "sourceFiles": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Input files used to build the export."
+        },
+        "buildOptions": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "number", "boolean", "null"]
+          },
+          "description": "Selected build options captured as primitive values."
+        }
+      }
+    },
+    "SeasonsMap": {
+      "type": "object",
+      "description": "Map of starting season year to season data. For example, 2025 means the 2025-26 season.",
+      "patternProperties": {
+        "^\\d{4}$": {
+          "$ref": "#/definitions/SeasonData"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SeasonData": {
+      "type": "object",
+      "description": "A single season. Wartime or abandoned placeholder seasons may contain only seasonInfo.",
+      "required": ["seasonInfo"],
+      "properties": {
+        "seasonInfo": {
+          "$ref": "#/definitions/SeasonInfo"
+        }
+      },
+      "patternProperties": {
+        "^tier\\d+$": {
+          "$ref": "#/definitions/TierData"
+        }
+      },
+      "additionalProperties": false
+    },
+    "SeasonInfo": {
+      "type": "object",
+      "description": "Season-level summary. promoted and relegated describe movement into and out of the next season's top flight.",
+      "required": ["season", "table", "relegated", "promoted"],
+      "additionalProperties": false,
+      "properties": {
+        "season": {
+          "type": "integer",
+          "description": "Starting year for the season."
+        },
+        "table": {
+          "type": "array",
+          "maxItems": 0,
+          "description": "Always empty. seasonInfo is a summary object, not a league table."
+        },
+        "relegated": {
+          "$ref": "#/definitions/StringList"
+        },
+        "promoted": {
+          "$ref": "#/definitions/StringList"
+        },
+        "seasonSlug": {
+          "type": ["string", "null"]
+        },
+        "sourceUrl": {
+          "type": ["string", "null"],
+          "format": "uri"
+        },
+        "tableCount": {
+          "type": ["integer", "null"]
+        },
+        "competitionStatus": {
+          "type": ["string", "null"]
+        },
+        "warSuspensionLabel": {
+          "type": ["string", "null"]
+        },
+        "officialLeagueTables": {
+          "type": ["boolean", "null"]
+        },
+        "officialCompetitionsSuspended": {
+          "type": ["boolean", "null"]
+        },
+        "officialCompetitionsAbandoned": {
+          "type": ["boolean", "null"]
+        },
+        "regionalBridgeSeason": {
+          "type": ["boolean", "null"]
+        },
+        "promotionRelegationApplies": {
+          "type": ["boolean", "null"]
+        },
+        "specialCompetitions": {
+          "$ref": "#/definitions/StringList"
+        },
+        "notes": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "TierData": {
+      "type": "object",
+      "description": "League-table data for one tier in a season.",
+      "required": ["season", "table", "relegated", "promoted"],
+      "additionalProperties": false,
+      "properties": {
+        "season": {
+          "type": "integer"
+        },
+        "table": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LeagueTableEntry"
+          }
+        },
+        "relegated": {
+          "$ref": "#/definitions/StringList"
+        },
+        "promoted": {
+          "$ref": "#/definitions/StringList"
+        },
+        "metadata": {
+          "$ref": "#/definitions/TierMetadata"
+        }
+      }
+    },
+    "LeagueTableEntry": {
+      "type": "object",
+      "description": "One final league-table row.",
+      "required": [
+        "pos",
+        "team",
+        "played",
+        "won",
+        "drawn",
+        "lost",
+        "goalsFor",
+        "goalsAgainst",
+        "goalDifference",
+        "goalAverage",
+        "points",
+        "notes",
+        "wasRelegated",
+        "wasPromoted",
+        "isExpansionTeam",
+        "wasReElected",
+        "wasReprieved"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "pos": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "team": {
+          "type": "string"
+        },
+        "played": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "won": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "drawn": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "lost": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "goalsFor": {
+          "type": "integer"
+        },
+        "goalsAgainst": {
+          "type": "integer"
+        },
+        "goalDifference": {
+          "type": ["integer", "null"]
+        },
+        "goalAverage": {
+          "type": ["number", "null"]
+        },
+        "points": {
+          "type": "integer"
+        },
+        "notes": {
+          "type": ["string", "null"]
+        },
+        "wasRelegated": {
+          "type": "boolean"
+        },
+        "wasPromoted": {
+          "type": "boolean"
+        },
+        "isExpansionTeam": {
+          "type": "boolean"
+        },
+        "wasReElected": {
+          "type": "boolean"
+        },
+        "wasReprieved": {
+          "type": "boolean"
+        }
+      }
+    },
+    "TierMetadata": {
+      "type": "object",
+      "description": "Source and table-selection metadata for a tier record.",
+      "additionalProperties": false,
+      "properties": {
+        "source": {
+          "type": "string"
+        },
+        "sourceUrl": {
+          "type": ["string", "null"],
+          "format": "uri"
+        },
+        "seasonSlug": {
+          "type": ["string", "null"]
+        },
+        "leagueId": {
+          "type": ["string", "null"]
+        },
+        "title": {
+          "type": ["string", "null"]
+        },
+        "leagueLevel": {
+          "type": ["integer", "null"]
+        },
+        "tableIndex": {
+          "type": ["integer", "null"]
+        },
+        "tableCount": {
+          "type": ["integer", "null"]
+        },
+        "tierKey": {
+          "type": ["string", "null"],
+          "pattern": "^tier\\d+$"
+        }
+      }
+    },
+    "ClubsMap": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z0-9][a-z0-9-]*$": {
+          "$ref": "club-metadata.schema.json#/definitions/ClubMetadata"
+        }
+      },
+      "additionalProperties": false
+    },
+    "StringList": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/scripts/build-docs-site.js
+++ b/scripts/build-docs-site.js
@@ -16,6 +16,8 @@ const ROOT_DIR = process.cwd();
 const TEMPLATE_PATH = path.join(ROOT_DIR, 'docs/index.template.html');
 const OUTPUT_PATH = path.join(ROOT_DIR, 'docs/index.html');
 const SITE_DATA_PATH = path.join(ROOT_DIR, 'docs/site-data.json');
+const SCHEMA_SOURCE_DIR = path.join(ROOT_DIR, 'schemas');
+const SCHEMA_OUTPUT_DIR = path.join(ROOT_DIR, 'docs/schema');
 const PRETTIER_OPTIONS = prettier.resolveConfig.sync(ROOT_DIR) || {};
 
 function formatGenerated(source, options) {
@@ -45,6 +47,22 @@ function formatBytes(bytes) {
 
   if (unitIndex === 0) return `${value}B`;
   return `${value >= 10 ? Math.round(value) : value.toFixed(1)}${units[unitIndex]}`;
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function slugify(value) {
+  return String(value)
+    .replaceAll(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-|-$/g, '');
 }
 
 function parseVersion(tag) {
@@ -85,6 +103,261 @@ function getTierCount(seasonRecord) {
   return Object.keys(seasonRecord || {}).filter((key) => /^tier\d+$/.test(key)).length;
 }
 
+function getSchemaFiles() {
+  if (!fs.existsSync(SCHEMA_SOURCE_DIR)) return [];
+  return fs
+    .readdirSync(SCHEMA_SOURCE_DIR)
+    .filter((fileName) => fileName.endsWith('.schema.json'))
+    .sort()
+    .map((fileName) => {
+      const schema = readJson(path.join('schemas', fileName));
+      const baseName = fileName.replace(/\.schema\.json$/, '');
+      return {
+        fileName,
+        baseName,
+        title: schema.title || baseName,
+        description: schema.description || 'JSON Schema reference.',
+        schema,
+        docFile: `${baseName}.html`,
+        docUrl: `./schema/${baseName}.html`,
+        rawUrl: `${RAW_MAIN_URL}/schemas/${fileName}`,
+      };
+    });
+}
+
+function getSchemaRefLabel(ref) {
+  const value = String(ref || '');
+  const match = value.match(/#\/definitions\/([^/]+)$/);
+  if (match) return match[1];
+  return value.split('/').pop() || value;
+}
+
+function getSchemaRefHref(ref, currentSchemaFile) {
+  const value = String(ref || '');
+  const fileMatch = value.match(/^([^#]+)#\/definitions\/([^/]+)$/);
+  if (fileMatch) {
+    const fileBase = fileMatch[1].replace(/\.schema\.json$/, '');
+    const prefix = fileMatch[1] === currentSchemaFile ? '' : `${fileBase}.html`;
+    return `${prefix}#${slugify(fileMatch[2])}`;
+  }
+
+  const definitionMatch = value.match(/#\/definitions\/([^/]+)$/);
+  if (definitionMatch) return `#${slugify(definitionMatch[1])}`;
+
+  return null;
+}
+
+function renderType(schema, currentSchemaFile) {
+  if (!schema || typeof schema !== 'object') return 'unknown';
+  if (schema.$ref) {
+    const href = getSchemaRefHref(schema.$ref, currentSchemaFile);
+    const label = escapeHtml(getSchemaRefLabel(schema.$ref));
+    return href ? `<a href="${escapeHtml(href)}">${label}</a>` : `<code>${label}</code>`;
+  }
+  if (schema.const !== undefined) return `<code>${escapeHtml(JSON.stringify(schema.const))}</code>`;
+  if (Array.isArray(schema.type)) {
+    return schema.type.map((entry) => `<code>${escapeHtml(entry)}</code>`).join(' | ');
+  }
+  if (schema.type) return `<code>${escapeHtml(schema.type)}</code>`;
+  if (schema.oneOf) return 'one of';
+  if (schema.anyOf) return 'any of';
+  if (schema.allOf) return 'all of';
+  return 'unspecified';
+}
+
+function renderSchemaDescription(schema) {
+  return schema?.description ? `<p>${escapeHtml(schema.description)}</p>` : '';
+}
+
+function renderSchemaBadges(schema) {
+  const badges = [];
+  if (schema?.required?.length) badges.push(`${schema.required.length} required`);
+  if (schema?.additionalProperties === false) badges.push('closed object');
+  if (schema?.patternProperties) badges.push('pattern keys');
+  if (schema?.format) badges.push(`format: ${schema.format}`);
+  if (schema?.pattern) badges.push(`pattern: ${schema.pattern}`);
+  if (schema?.maxItems === 0) badges.push('always empty');
+  return badges.map((badge) => `<span>${escapeHtml(badge)}</span>`).join('');
+}
+
+function renderPropertyRows(schema, currentSchemaFile) {
+  const rows = [];
+  const required = new Set(schema?.required || []);
+
+  for (const [name, propertySchema] of Object.entries(schema?.properties || {})) {
+    rows.push({
+      name,
+      required: required.has(name),
+      type: renderType(propertySchema, currentSchemaFile),
+      description: propertySchema?.description || '',
+    });
+  }
+
+  for (const [pattern, propertySchema] of Object.entries(schema?.patternProperties || {})) {
+    rows.push({
+      name: pattern,
+      required: false,
+      type: renderType(propertySchema, currentSchemaFile),
+      description: 'Pattern property',
+    });
+  }
+
+  if (!rows.length) return '<p class="schema-muted">No named properties.</p>';
+
+  return `<div class="schema-table">${rows
+    .map(
+      (row) => `<div class="schema-row">
+        <code>${escapeHtml(row.name)}</code>
+        <span>${row.type}</span>
+        <span>${row.required ? 'required' : 'optional'}</span>
+        <span>${escapeHtml(row.description)}</span>
+      </div>`
+    )
+    .join('')}</div>`;
+}
+
+function renderDefinitionSection(name, schema, currentSchemaFile) {
+  return `<section class="panel schema-definition" id="${escapeHtml(slugify(name))}">
+    <div class="section-heading">
+      <h2>${escapeHtml(name)}</h2>
+      <a href="#${escapeHtml(slugify(name))}">anchor</a>
+    </div>
+    <div class="schema-summary">
+      <span>type ${renderType(schema, currentSchemaFile)}</span>
+      ${renderSchemaBadges(schema)}
+    </div>
+    ${renderSchemaDescription(schema)}
+    ${renderPropertyRows(schema, currentSchemaFile)}
+  </section>`;
+}
+
+function renderSchemaPage(schemaDoc, schemaDocs) {
+  const definitions = Object.entries(schemaDoc.schema.definitions || {}).sort(([left], [right]) =>
+    left.localeCompare(right)
+  );
+  const allSections = [['Root', schemaDoc.schema], ...definitions];
+  const nav = allSections
+    .map(([name]) => `<a href="#${escapeHtml(slugify(name))}">${escapeHtml(name)}</a>`)
+    .join('');
+  const peerLinks = schemaDocs
+    .filter((entry) => entry.baseName !== schemaDoc.baseName)
+    .map((entry) => `<a href="./${escapeHtml(entry.docFile)}">${escapeHtml(entry.title)}</a>`)
+    .join('');
+
+  return formatGenerated(
+    `<!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>${escapeHtml(schemaDoc.title)} schema | footy-data-kit</title>
+        <meta name="description" content="${escapeHtml(schemaDoc.description)}" />
+        <link rel="stylesheet" href="../styles.css" />
+      </head>
+      <body>
+        <main class="page-shell">
+          <header class="site-header">
+            <p class="eyebrow">schema reference</p>
+            <h1>${escapeHtml(schemaDoc.title)}</h1>
+            <p class="lede">${escapeHtml(schemaDoc.description)}</p>
+          </header>
+
+          <section class="panel">
+            <h2>Schema Links</h2>
+            <nav class="link-grid" aria-label="schema links">
+              <a href="../index.html">docs home</a>
+              <a href="./index.html">schema index</a>
+              <a href="${escapeHtml(schemaDoc.rawUrl)}">raw schema</a>
+              ${peerLinks}
+            </nav>
+          </section>
+
+          <section class="panel">
+            <h2>Contents</h2>
+            <nav class="schema-toc" aria-label="schema contents">${nav}</nav>
+          </section>
+
+          ${allSections
+            .map(([name, schema]) => renderDefinitionSection(name, schema, schemaDoc.fileName))
+            .join('')}
+
+          <footer>
+            <span>generated from schemas/${escapeHtml(schemaDoc.fileName)}</span>
+            <a href="../index.html">footy-data-kit</a>
+          </footer>
+        </main>
+      </body>
+    </html>`,
+    { filepath: path.join(SCHEMA_OUTPUT_DIR, schemaDoc.docFile), parser: 'html' }
+  );
+}
+
+function renderSchemaIndex(schemaDocs) {
+  const rows = schemaDocs
+    .map(
+      (schemaDoc) => `<li>
+        <code>${escapeHtml(schemaDoc.fileName)}</code>
+        <span>${escapeHtml(schemaDoc.description)}</span>
+        <a href="./${escapeHtml(schemaDoc.docFile)}">view</a>
+        <a href="${escapeHtml(schemaDoc.rawUrl)}">raw</a>
+      </li>`
+    )
+    .join('');
+
+  return formatGenerated(
+    `<!DOCTYPE html>
+    <html lang="en">
+      <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Schema reference | footy-data-kit</title>
+        <meta name="description" content="Static schema reference for footy-data-kit JSON exports." />
+        <link rel="stylesheet" href="../styles.css" />
+      </head>
+      <body>
+        <main class="page-shell">
+          <header class="site-header">
+            <p class="eyebrow">data contract</p>
+            <h1>schema reference</h1>
+            <p class="lede">Human-readable JSON Schema documentation for the published data files.</p>
+          </header>
+
+          <section class="panel">
+            <h2>Schema Files</h2>
+            <ul class="download-list schema-list">${rows}</ul>
+          </section>
+
+          <section class="panel">
+            <h2>Use These Schemas</h2>
+            <p>The schemas document the generated JSON contract and can be used by validators that support JSON Schema Draft-07.</p>
+            <pre><code>schemas/football-data.schema.json
+schemas/club-metadata.schema.json</code></pre>
+          </section>
+
+          <footer>
+            <span>static schema docs</span>
+            <a href="../index.html">docs home</a>
+          </footer>
+        </main>
+      </body>
+    </html>`,
+    { filepath: path.join(SCHEMA_OUTPUT_DIR, 'index.html'), parser: 'html' }
+  );
+}
+
+function renderSchemaDocs(schemaDocs) {
+  return [
+    {
+      path: path.join(SCHEMA_OUTPUT_DIR, 'index.html'),
+      html: renderSchemaIndex(schemaDocs),
+    },
+    ...schemaDocs.map((schemaDoc) => ({
+      path: path.join(SCHEMA_OUTPUT_DIR, schemaDoc.docFile),
+      html: renderSchemaPage(schemaDoc, schemaDocs),
+    })),
+  ];
+}
+
 function buildRelease(tag, summary) {
   return {
     tag,
@@ -123,6 +396,13 @@ function buildSiteData() {
 
   const releaseDownloadBase = `${REPO_URL}/releases/latest/download`;
   const rawDownloadBase = `${RAW_MAIN_URL}`;
+  const schemaDocs = getSchemaFiles().map((schemaDoc) => ({
+    title: schemaDoc.title,
+    description: schemaDoc.description,
+    fileName: schemaDoc.fileName,
+    docUrl: schemaDoc.docUrl,
+    rawUrl: schemaDoc.rawUrl,
+  }));
 
   return {
     site: {
@@ -146,9 +426,11 @@ function buildSiteData() {
     links: [
       { label: 'GitHub repo', url: REPO_URL },
       { label: 'Releases', url: `${REPO_URL}/releases` },
+      { label: 'Schema docs', url: './schema/' },
       { label: 'README', url: `${REPO_URL}/blob/main/readme.md` },
       { label: 'Pipeline code', url: `${REPO_URL}/tree/main/wikipedia` },
     ],
+    schemaDocs,
     latestRelease,
     historicReleases,
     downloads: [
@@ -212,18 +494,20 @@ function buildSiteData() {
 function renderSite() {
   const template = fs.readFileSync(TEMPLATE_PATH, 'utf8');
   const siteData = buildSiteData();
+  const schemaDocs = renderSchemaDocs(getSchemaFiles());
   return {
     html: formatGenerated(Mustache.render(template, siteData), {
       filepath: OUTPUT_PATH,
       parser: 'html',
     }),
     siteData,
+    schemaDocs,
   };
 }
 
 function run(argv = process.argv) {
   const check = argv.includes('--check');
-  const { html, siteData } = renderSite();
+  const { html, siteData, schemaDocs } = renderSite();
   const siteDataJson = formatGenerated(JSON.stringify(siteData), {
     filepath: SITE_DATA_PATH,
     parser: 'json',
@@ -234,15 +518,26 @@ function run(argv = process.argv) {
     const currentSiteData = fs.existsSync(SITE_DATA_PATH)
       ? fs.readFileSync(SITE_DATA_PATH, 'utf8')
       : '';
-    if (currentHtml !== html || currentSiteData !== siteDataJson) {
+    const staleSchemaDoc = schemaDocs.find((schemaDoc) => {
+      const currentSchemaHtml = fs.existsSync(schemaDoc.path)
+        ? fs.readFileSync(schemaDoc.path, 'utf8')
+        : '';
+      return currentSchemaHtml !== schemaDoc.html;
+    });
+    if (currentHtml !== html || currentSiteData !== siteDataJson || staleSchemaDoc) {
       console.error('Docs site output is stale. Run `pnpm docs:build`.');
       process.exitCode = 1;
     }
     return;
   }
 
+  fs.mkdirSync(SCHEMA_OUTPUT_DIR, { recursive: true });
   fs.writeFileSync(OUTPUT_PATH, html);
   fs.writeFileSync(SITE_DATA_PATH, siteDataJson);
+  for (const schemaDoc of schemaDocs) {
+    fs.writeFileSync(schemaDoc.path, schemaDoc.html);
+    console.log(`Generated ${path.relative(ROOT_DIR, schemaDoc.path)}`);
+  }
   console.log(`Generated ${path.relative(ROOT_DIR, OUTPUT_PATH)}`);
   console.log(`Generated ${path.relative(ROOT_DIR, SITE_DATA_PATH)}`);
 }

--- a/wikipedia/__tests__/verify-json-schemas.test.js
+++ b/wikipedia/__tests__/verify-json-schemas.test.js
@@ -1,0 +1,185 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createSchemaValidator, validateSchemaTargets } from '../data/verify-json-schemas.js';
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function buildFootballDataFixture() {
+  return {
+    metadata: {
+      schemaVersion: 1,
+      generator: 'test',
+      generatedAt: '2026-06-18T00:00:00.000Z',
+    },
+    clubs: {
+      'example fc': {
+        canonicalName: 'Example FC',
+      },
+    },
+    seasons: {
+      1900: {
+        seasonInfo: {
+          season: 1900,
+          table: [],
+          promoted: [],
+          relegated: [],
+        },
+        tier1: {
+          season: 1900,
+          table: [
+            {
+              pos: 1,
+              team: 'Example FC',
+              played: 38,
+              won: 25,
+              drawn: 8,
+              lost: 5,
+              goalsFor: 80,
+              goalsAgainst: 32,
+              goalDifference: 48,
+              goalAverage: null,
+              points: 83,
+              notes: null,
+              wasRelegated: false,
+              wasPromoted: false,
+              isExpansionTeam: false,
+              wasReElected: false,
+              wasReprieved: false,
+            },
+          ],
+          promoted: [],
+          relegated: [],
+          metadata: {
+            source: 'wikipedia-overview',
+            seasonSlug: '1900-01',
+            leagueId: 'League_table',
+            title: 'Example League',
+            leagueLevel: 1,
+            tableIndex: 0,
+            tableCount: 1,
+            tierKey: 'tier1',
+          },
+        },
+      },
+    },
+  };
+}
+
+function buildClubMetadataFixture() {
+  return {
+    metadata: {
+      schemaVersion: 1,
+      generator: 'test',
+      generatedAt: '2026-06-18T00:00:00.000Z',
+    },
+    clubs: {
+      'example fc': {
+        clubId: 'example-fc',
+        canonicalName: 'Example FC',
+        status: {
+          current: 'active',
+          trackedFromSeason: 1900,
+          trackedToSeason: 1900,
+          hasUnexplainedGaps: false,
+        },
+        history: {
+          lifecycleEvents: [
+            {
+              type: 'renamed',
+              season: 1900,
+              label: 'Example lifecycle event',
+            },
+          ],
+          absenceExplanations: [],
+        },
+        derived: {
+          aliases: ['Example FC'],
+          firstSeenSeason: 1900,
+          lastSeenSeason: 1900,
+          seasonsSeen: [1900],
+          totalSeasonsSeen: 1,
+          tiersSeen: ['tier1'],
+          tierSeasons: [{ tierKey: 'tier1', seasons: [1900] }],
+          coverageGaps: [],
+        },
+      },
+    },
+  };
+}
+
+describe('verify-json-schemas', () => {
+  const tmpDirs = [];
+
+  afterEach(() => {
+    while (tmpDirs.length) {
+      fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+    }
+  });
+
+  test('validates FootballData and resolves embedded club metadata refs', () => {
+    const validator = createSchemaValidator(path.resolve(process.cwd(), 'schemas'));
+    const result = validator.validate('football-data.schema.json', buildFootballDataFixture());
+
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test('reports missing required fields', () => {
+    const validator = createSchemaValidator(path.resolve(process.cwd(), 'schemas'));
+    const result = validator.validate('football-data.schema.json', {});
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((error) => error.keyword === 'required')).toBe(true);
+  });
+
+  test('reports unexpected extra fields', () => {
+    const validator = createSchemaValidator(path.resolve(process.cwd(), 'schemas'));
+    const data = clone(buildFootballDataFixture());
+    data.seasons[1900].tier1.table[0].unexpectedField = true;
+
+    const result = validator.validate('football-data.schema.json', data);
+
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((error) => error.keyword === 'additionalProperties')).toBe(true);
+  });
+
+  test('validateSchemaTargets validates explicit data files', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'footy-schema-verify-'));
+    tmpDirs.push(tmpDir);
+
+    const dataDir = path.join(tmpDir, 'data-output');
+    const sidecarDir = path.join(tmpDir, 'data');
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.mkdirSync(sidecarDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(dataDir, 'all-seasons.json'),
+      JSON.stringify(buildFootballDataFixture())
+    );
+    fs.writeFileSync(
+      path.join(sidecarDir, 'club-metadata.json'),
+      JSON.stringify(buildClubMetadataFixture())
+    );
+
+    const results = validateSchemaTargets({
+      rootDir: tmpDir,
+      schemaDir: path.resolve(process.cwd(), 'schemas'),
+      targets: [
+        {
+          label: 'all-seasons.json',
+          schemaFile: 'football-data.schema.json',
+          dataFile: 'data-output/all-seasons.json',
+        },
+        {
+          label: 'club-metadata.json',
+          schemaFile: 'club-metadata.schema.json',
+          dataFile: 'data/club-metadata.json',
+        },
+      ],
+    });
+
+    expect(results.map((result) => result.valid)).toEqual([true, true]);
+  });
+});

--- a/wikipedia/data/verify-json-schemas.js
+++ b/wikipedia/data/verify-json-schemas.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+
+import Ajv from 'ajv';
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const SCHEMA_DIR = path.join(ROOT_DIR, 'schemas');
+
+export const DEFAULT_SCHEMA_TARGETS = [
+  {
+    label: 'all-seasons.json',
+    schemaFile: 'football-data.schema.json',
+    dataFile: 'data-output/all-seasons.json',
+  },
+  {
+    label: 'all-seasons.min.json',
+    schemaFile: 'football-data.schema.json',
+    dataFile: 'data-output/all-seasons.min.json',
+  },
+  {
+    label: 'wiki_overview_tables_by_season.json',
+    schemaFile: 'football-data.schema.json',
+    dataFile: 'data-output/wiki_overview_tables_by_season.json',
+  },
+  {
+    label: 'wiki_overview_tables_by_season.min.json',
+    schemaFile: 'football-data.schema.json',
+    dataFile: 'data-output/wiki_overview_tables_by_season.min.json',
+  },
+  {
+    label: 'club-metadata.json',
+    schemaFile: 'club-metadata.schema.json',
+    dataFile: 'data/club-metadata.json',
+  },
+];
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function createAjv() {
+  return new Ajv({
+    allErrors: true,
+    strict: false,
+    validateFormats: false,
+  });
+}
+
+function loadSchemaFiles(schemaDir = SCHEMA_DIR) {
+  return fs
+    .readdirSync(schemaDir)
+    .filter((fileName) => fileName.endsWith('.schema.json'))
+    .sort()
+    .map((fileName) => ({
+      fileName,
+      schema: readJson(path.join(schemaDir, fileName)),
+    }));
+}
+
+export function createSchemaValidator(schemaDir = SCHEMA_DIR) {
+  const ajv = createAjv();
+  const schemas = loadSchemaFiles(schemaDir);
+
+  for (const { fileName, schema } of schemas) {
+    ajv.addSchema(schema, fileName);
+  }
+
+  return {
+    validate(schemaFile, data) {
+      const validate = ajv.getSchema(schemaFile) || ajv.compile(readJson(path.join(schemaDir, schemaFile)));
+      const valid = validate(data);
+      return {
+        valid,
+        errors: valid ? [] : validate.errors || [],
+      };
+    },
+  };
+}
+
+function formatError(error) {
+  const pathLabel = error.instancePath || '/';
+  const params = error.params ? ` ${JSON.stringify(error.params)}` : '';
+  return `${pathLabel} ${error.message || 'failed schema validation'}${params}`;
+}
+
+export function validateSchemaTargets({
+  rootDir = ROOT_DIR,
+  schemaDir = path.join(rootDir, 'schemas'),
+  targets = DEFAULT_SCHEMA_TARGETS,
+} = {}) {
+  const validator = createSchemaValidator(schemaDir);
+
+  return targets.map((target) => {
+    const dataPath = path.resolve(rootDir, target.dataFile);
+    const data = readJson(dataPath);
+    const result = validator.validate(target.schemaFile, data);
+    return {
+      ...target,
+      dataPath,
+      valid: result.valid,
+      errors: result.errors,
+    };
+  });
+}
+
+function printReport(results) {
+  for (const result of results) {
+    console.log(`\n${result.dataFile}`);
+    if (result.valid) {
+      console.log(`  Schema: ${result.schemaFile}`);
+      console.log('  No schema issues detected ✅');
+      continue;
+    }
+
+    console.log(`  Schema: ${result.schemaFile}`);
+    console.log(`  Issues found: ${result.errors.length}`);
+    for (const error of result.errors.slice(0, 20)) {
+      console.log(`    - ${formatError(error)}`);
+    }
+    if (result.errors.length > 20) {
+      console.log(`    - ...and ${result.errors.length - 20} more issue(s)`);
+    }
+  }
+}
+
+export function runCli(argv = process.argv) {
+  const program = new Command();
+  program
+    .name('verify-json-schemas')
+    .description('Validate generated JSON data files against the repo JSON Schema contracts.')
+    .option('--schema-dir <dir>', 'Directory containing *.schema.json files', './schemas')
+    .option(
+      '--target <schema:file>',
+      'Validate an explicit schema/data pair. Repeatable. Example: football-data.schema.json:data-output/all-seasons.json',
+      (value, previous) => [...previous, value],
+      []
+    )
+    .option('--json', 'Print machine-readable JSON output', false);
+
+  program.parse(argv);
+  const options = program.opts();
+  const targets = options.target.length
+    ? options.target.map((entry) => {
+        const separatorIndex = entry.indexOf(':');
+        if (separatorIndex === -1) {
+          throw new Error(`Invalid --target value: ${entry}`);
+        }
+        const schemaFile = entry.slice(0, separatorIndex);
+        const dataFile = entry.slice(separatorIndex + 1);
+        return {
+          label: dataFile,
+          schemaFile,
+          dataFile,
+        };
+      })
+    : DEFAULT_SCHEMA_TARGETS;
+
+  const results = validateSchemaTargets({
+    rootDir: ROOT_DIR,
+    schemaDir: path.resolve(ROOT_DIR, options.schemaDir),
+    targets,
+  });
+  const hasIssues = results.some((result) => !result.valid);
+
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        results.map((result) => ({
+          dataFile: result.dataFile,
+          schemaFile: result.schemaFile,
+          valid: result.valid,
+          errors: result.errors,
+        })),
+        null,
+        2
+      )
+    );
+  } else {
+    printReport(results);
+  }
+
+  if (hasIssues) {
+    process.exitCode = 1;
+  }
+
+  return results;
+}
+
+const isDirectExecution = process.argv[1]
+  ? path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  : false;
+
+if (isDirectExecution) {
+  runCli(process.argv);
+}


### PR DESCRIPTION
## Summary
- Adds first-class JSON Schema contracts for the published season dataset and club metadata sidecar.
- Generates themed schema reference pages into the existing static docs site.

## What Changed
- Added `schemas/football-data.schema.json`.
- Added `schemas/club-metadata.schema.json`.
- Extended `scripts/build-docs-site.js` to render schema index/detail pages under `docs/schema/`.
- Added schema links to the docs landing page and `docs/site-data.json`.
- Added schema-specific styles that reuse the existing docs theme.
- Documented the new `schemas/` directory and generated schema docs in `readme.md`.

## Validation
- `pnpm -s docs:build`
- `pnpm -s docs:check`
- `pnpm -s lint`
- `pnpm -s format:check`
- `pnpm -s test:jest`
- Browser-checked schema index and FootballData schema page at desktop and mobile widths.

## Scope Notes
- This adds schema documentation and source schema files only.
- It does not add runtime JSON Schema validation to CI yet.
- The schema pages are custom generated to match the current docs theme rather than using an external generated theme.