### PR TITLE
Start TypeScript Migration & Plan Tier 3/4 build out

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -20,5 +20,15 @@ module.exports = {
         jest: true,
       },
     },
+    {
+      files: ['**/*.ts'],
+      parser: '@typescript-eslint/parser',
+      plugins: ['@typescript-eslint'],
+      extends: ['plugin:@typescript-eslint/recommended'],
+      rules: {
+        'no-unused-vars': 'off',
+        '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      },
+    },
   ],
 };

--- a/docs/lower-tier-coverage-analysis.md
+++ b/docs/lower-tier-coverage-analysis.md
@@ -1,0 +1,180 @@
+# Lower-Tier Coverage Analysis
+
+This note tracks current generated coverage and follow-up research for extending lower English football tiers through the maintained Wikipedia pipeline.
+
+## Current Generated Coverage Snapshot
+
+Source checked:
+
+- `data-output/all-seasons.json`
+
+Current coverage by level area:
+
+| Level area   | Current coverage                           | Main issue                                                      |
+| ------------ | ------------------------------------------ | --------------------------------------------------------------- |
+| Tier 1       | 1888-2025, excluding war gaps              | Mature coverage                                                 |
+| Tier 2       | 1890-2025, excluding war gaps              | Mature coverage                                                 |
+| Tier 3       | 1920-2025, excluding WWII gap              | Good coverage, but 1921-1957 has parallel North/South divisions |
+| Tier 4       | Stored from 1921, true level 4 starts 1958 | `tier4` is Third Division South, level 3, from 1921-1957        |
+| Tier 5       | 2012-2025 only                             | Missing 1979-2011 Alliance/Conference/National tier             |
+| Level 6      | 2021-2025 only                             | Missing 2004-2020 National League North/South                   |
+| True level 7 | Not really parsed                          | Current `tier7` is National League South, so level 6            |
+
+Important modeling issue:
+
+- `tierN` is sometimes a table slot, not the actual pyramid level.
+- From 1921-1957, `tier3` is Third Division North and `tier4` is Third Division South, but both have `metadata.leagueLevel: 3`.
+- From 2021-2025, National League North and National League South are stored as `tier6` and `tier7`, but both should be level 6 according to the repo's lower-level metadata model.
+
+Recommended lower-tier slice order from the coverage snapshot:
+
+1. Fix or lock the parallel-league metadata model so parser and verifier logic trust `metadata.leagueLevel`, not the `tierN` slot number.
+2. Backfill level 6 for 2012-2020 after the modern parallel-league model is stable.
+3. Backfill tier 5 for 2004-2011, plus level 6 National League North/South for the same range.
+4. Backfill tier 5 for 1979-2003.
+5. Defer true level 7 until level 5 and level 6 are stable, because level 7 has multiple parallel feeder leagues.
+
+Prep decision:
+
+- Before broad parser changes, patch the known domain facts into shared config and output normalization.
+- Keep this as a quick-win slice: league identity names, season boundary ranges, parallel-league metadata, and administrative special cases.
+- Use those shared facts as the base for later parser work instead of embedding one-off checks in table extraction code.
+
+## Tier 3 And Tier 4 Historical Timeline
+
+This section focuses on the third and fourth levels because those are the nearest lower-tier boundaries already present in generated data.
+
+### Level 3
+
+| Seasons      | League shape                                                                       | Generated representation                                | Notes                                                                      |
+| ------------ | ---------------------------------------------------------------------------------- | ------------------------------------------------------- | -------------------------------------------------------------------------- |
+| 1920-1921    | Football League Third Division                                                     | `tier3`, `leagueLevel: 3`                               | First third-tier season; no fourth tier                                    |
+| 1921-1958    | Third Division North and Third Division South, parallel regional level-3 divisions | `tier3` = North, `tier4` = South; both `leagueLevel: 3` | `tier4` is a table slot here, not level 4                                  |
+| 1958-1992    | National Football League Third Division                                            | `tier3`, `leagueLevel: 3`                               | Fourth Division begins in 1958, so `tier4` becomes a true level-4 division |
+| 1992-2004    | Football League Second Division                                                    | `tier3`, `leagueLevel: 3`                               | Premier League breakaway shifted Football League names down one level      |
+| 2004-present | Football League One / EFL League One                                               | `tier3`, `leagueLevel: 3`                               | Rebrand from the old Football League Second Division                       |
+
+### Level 4
+
+| Seasons      | League shape                               | Generated representation  | Notes                                                             |
+| ------------ | ------------------------------------------ | ------------------------- | ----------------------------------------------------------------- |
+| 1920-1958    | No true fourth tier in the Football League | No true level-4 table     | Current `tier4` from 1921-1957 is Third Division South at level 3 |
+| 1958-1992    | Football League Fourth Division            | `tier4`, `leagueLevel: 4` | Created from the regional Third Division North/South restructure  |
+| 1992-2004    | Football League Third Division             | `tier4`, `leagueLevel: 4` | Old Fourth Division renamed after Premier League formation        |
+| 2004-present | Football League Two / EFL League Two       | `tier4`, `leagueLevel: 4` | Rebrand from the old Football League Third Division               |
+
+## Generated Tier 3 And Tier 4 Data Observations
+
+Generated overview rows currently match the major structural boundaries:
+
+- `tier3` exists from 1920 onward except WWII suspension years.
+- `tier4` exists from 1921 onward, but only becomes true level 4 in 1958.
+- `tier3` row counts are expected at 22 in 1920, 20-22 in early Third Division North, then 24 from 1950 onward except special cases.
+- `tier4` row counts are expected at 22-24 for Third Division South before 1958, 24 for most true Fourth Division / League Two seasons, and lower during the early 1990s disruption.
+
+Static CSV coverage:
+
+| File                     | Season range | Gaps      | Notes                                                        |
+| ------------------------ | ------------ | --------- | ------------------------------------------------------------ |
+| `data/england_tier3.csv` | 1920-2021    | 1939-1945 | Includes regional North/South era as one tier-3 match corpus |
+| `data/england_tier4.csv` | 1958-2021    | none      | Starts only when the real fourth tier begins                 |
+
+Metadata/title cleanup candidates:
+
+- 2012 and 2013 have generic `League tables` titles for `tier3` and `tier4`.
+- Several 1990s/2000s overview pages use variant IDs such as `Division_Two_2`, `Football_League_Division_Two`, and `Football_League_Second_Division`; these are acceptable source IDs but need canonical comparison helpers if downstream code groups leagues by identity.
+
+## Tier 3 And Tier 4 Attention Points
+
+### 1921-1957 parallel level 3
+
+This is the most important tier semantics boundary already in the data.
+
+- Third Division North and Third Division South are parallel level-3 divisions.
+- Current output stores them as `tier3` and `tier4`.
+- Any logic that assumes `tier4` means level 4 will be wrong for these seasons.
+- Parser, verifier, and downstream analysis should prefer `metadata.leagueLevel`.
+
+Target seasons:
+
+- 1920: first single Third Division season.
+- 1921: first North/South split.
+- 1923: Third Division North expands from 20 to 22 clubs.
+- 1950: North/South divisions expand to 24 clubs.
+- 1957 and 1958: final North/South season and first national Third/Fourth Division season.
+
+### 1957-1958 restructure into true tiers 3 and 4
+
+The 1957-58 North/South season is a special movement case. The generated output marks many bottom-half North/South clubs as relegated because they moved into the new Fourth Division. That is directionally useful, but it is not the same as a normal season's bottom-club relegation pattern.
+
+Target work:
+
+- Add tests that distinguish `leagueLevel: 3` parallel divisions from the post-1958 true `tier4`.
+- Decide whether 1957-58 movement should be labeled as normal relegation or as restructure placement metadata.
+
+### 1986-1987 playoff and Conference boundary
+
+The late 1980s introduce two important level-4 changes:
+
+- Football League play-offs start in 1987.
+- Automatic relegation from the Fourth Division to the Football Conference starts in the same period.
+
+Target seasons:
+
+- 1986: last pre-playoff style season.
+- 1987: first playoff season and early automatic Conference relegation boundary.
+
+### 1991-1994 reduced fourth-tier sizes
+
+Generated `tier4` row counts drop during the early 1990s:
+
+- 1991: 23 rows.
+- 1992: 23 rows.
+- 1993: 22 rows.
+- 1994: 22 rows.
+
+These align with Football League disruption around Aldershot folding in 1991-92, Maidstone leaving in 1992, and the Premier League-era restructuring. Treat them as expected historical anomalies, not parser row-count failures.
+
+Target seasons:
+
+- 1991: Aldershot record/void handling.
+- 1992: first Premier League season; `tier3` becomes Second Division and `tier4` becomes Third Division.
+- 1994 and 1995: confirm transition back toward normal 24-team level-4 shape.
+
+### 2004 rebrand
+
+The 2004-05 season is the clean branding boundary:
+
+- level 3: Football League Second Division becomes Football League One.
+- level 4: Football League Third Division becomes Football League Two.
+
+Target season:
+
+- 2004: assert league titles, IDs, levels, and promoted/relegated extraction for both tiers.
+
+### 2019-2020 COVID and Bury/Macclesfield handling
+
+The 2019-20 season is not a normal row/status season.
+
+- League One operated with 23 active teams after Bury was expelled, but overview output still has 24 rows because Bury is represented.
+- League One and League Two were curtailed and final positions were decided on points per game.
+- Current generated `tier4.relegated` includes both Stevenage and Macclesfield Town, but the historical outcome was Macclesfield Town relegated and Stevenage reprieved after Macclesfield's points deductions.
+
+Target work:
+
+- Add a specific 2019-20 League Two regression test.
+- Treat Bury as expelled rather than a normal relegated club where status metadata allows.
+- Verify whether the generated `relegated` arrays should represent on-page table markers, final administrative outcome, or both.
+
+## Research Sources
+
+- Football League Third Division: https://en.wikipedia.org/wiki/Football_League_Third_Division
+- Football League Third Division North: https://en.wikipedia.org/wiki/Football_League_Third_Division_North
+- Football League Third Division South: https://en.wikipedia.org/wiki/Football_League_Third_Division_South
+- Football League Fourth Division: https://en.wikipedia.org/wiki/Football_League_Fourth_Division
+- English Football League division renaming history: https://en.wikipedia.org/wiki/English_Football_League
+- EFL League One: https://en.wikipedia.org/wiki/EFL_League_One
+- EFL League Two: https://en.wikipedia.org/wiki/EFL_League_Two
+- English Football League play-offs: https://en.wikipedia.org/wiki/English_Football_League_play-offs
+- 2019-20 EFL League One: https://en.wikipedia.org/wiki/2019%E2%80%9320_EFL_League_One
+- 2019-20 EFL League Two: https://en.wikipedia.org/wiki/2019%E2%80%9320_EFL_League_Two

--- a/docs/tier3-tier4-parser-readiness-plan.md
+++ b/docs/tier3-tier4-parser-readiness-plan.md
@@ -1,0 +1,303 @@
+# Tier 3 And Tier 4 Parser Readiness Plan
+
+This plan turns the lower-tier coverage findings into an implementation path for making the maintained Wikipedia parser ready to pull in tier 3 and tier 4 data more consistently.
+
+The evidence log lives in [lower-tier-coverage-analysis.md](./lower-tier-coverage-analysis.md). This file is the execution plan.
+
+## Scope
+
+Primary goal:
+
+- make the overview parser, generation flow, metadata model, and verifier trustworthy for English tier 3 and tier 4 coverage across the full Football League timeline
+
+Non-goals for this slice:
+
+- do not backfill tier 5, level 6, or true level 7 data yet
+- do not redesign the output JSON shape
+- do not hand-edit generated `data-output/` files
+- do not make the overview parser absorb non-Football-League competitions just because they appear on the same page
+
+Important model distinction:
+
+- `tierN` is the stored output slot
+- `metadata.leagueLevel` is the actual football pyramid level
+
+That distinction is required for historical parallel leagues. From 1921 through 1957, `tier3` and `tier4` are Third Division North and Third Division South, but both are level 3. From 2021 onward, current National League North and South output uses separate slots while both leagues are level 6.
+
+## Current State
+
+Already in place:
+
+- shared config knows the major lower-tier league names, level ranges, and special seasons
+- overview generation can attach `leagueStructureSpecialCases` into `seasonInfo`
+- output normalization preserves that special-case metadata
+- verifier logic accepts known parallel-league slots when `metadata.leagueLevel` is lower than the stored `tierN` slot
+- focused tests cover the current config and verifier behavior
+- current generated output passes verification with the new metadata rules
+
+Known parser limitation:
+
+- multiple tables under a generic page heading can inherit the same broad title and only differ by `tableIndex`
+- that is tolerable for current output, but not ideal for systematic lower-tier parsing because identity, level inference, and special-case handling become too dependent on fallback order
+
+## Architecture Decisions
+
+Keep the current output contract:
+
+- continue writing `tier1`, `tier2`, `tier3`, `tier4`, and later slots as top-level season record properties
+- represent historical parallel leagues by slot plus `metadata.leagueLevel`
+- attach source-specific context in metadata rather than changing the top-level shape
+
+Centralize domain facts:
+
+- use `wikipedia/config.js` helpers for league level ranges and special seasons
+- do not add one-off historical checks directly inside row parsing unless there is no reusable rule
+- keep naming aliases and structural exceptions near the existing Wikipedia config
+
+Separate parser identity from output slot:
+
+- parser output should preserve the source table title/id
+- generation should decide the output slot
+- metadata should carry canonical or inferred identity when source labels are ambiguous
+
+Regenerate only after parser behavior is locked:
+
+- tests and temporary dry runs come before checked-in generated data changes
+- generated JSON changes should be reviewed as data diffs, not mixed into unrelated parser refactors
+
+## Dependency Map
+
+Work should land in this order:
+
+1. Config and metadata model are stable.
+2. Parser table identity becomes reliable for tier 3 and tier 4 page shapes.
+3. Builder maps parsed tables into stable slots and levels.
+4. Verifier and comparison tooling understand expected historical anomalies.
+5. Boundary fixtures cover the major structural seasons.
+6. Temporary regeneration confirms the data diff.
+7. Checked-in generated output is refreshed in a dedicated slice.
+
+## Phase 1: Lock The Existing Tier 3 And Tier 4 Contract
+
+Goal:
+
+- make the current expected semantics explicit before changing parser behavior
+
+Tasks:
+
+- add or expand parser tests for representative tier 3 and tier 4 table structures
+- add builder tests that assert output slot and `metadata.leagueLevel` separately
+- add verifier tests for known historical anomalies rather than relying on broad tolerances
+
+Representative seasons:
+
+- `1920`: first single Third Division season
+- `1921`: first Third Division North and South split
+- `1923`: early North/South expansion period
+- `1957`: final regional Third Division season
+- `1958`: first national Third Division and Fourth Division season
+- `1992`: Premier League naming shift
+- `2004`: League One and League Two rebrand
+- `2019`: COVID, Bury, Macclesfield, and points-per-game handling
+
+Acceptance criteria:
+
+- tests prove `tier4` before 1958 is not treated as pyramid level 4
+- tests prove true level 4 starts in 1958
+- tests prove 1992 and 2004 name changes do not alter stored level semantics
+- verifier treats documented low row counts and parallel divisions as expected, not as parser failures
+
+Checkpoint:
+
+```sh
+pnpm test -- --runTestsByPath wikipedia/__tests__/wiki-overview-parser.test.js wikipedia/__tests__/parse-ext-season-overview-pages.test.js wikipedia/__tests__/season-rules.test.js wikipedia/__tests__/verify-football-data.test.js
+pnpm typecheck
+pnpm lint
+```
+
+## Phase 2: Improve Parser Table Identity
+
+Goal:
+
+- make ambiguous overview tables carry enough identity for deterministic level inference
+
+Tasks:
+
+- improve title/id resolution when several `wikitable` elements appear under one generic heading
+- make generic headings such as `League tables`, `Tables`, and `Final standings` inherit the nearest useful competition heading
+- preserve source labels while also exposing an inferred or canonical league identity when needed
+- ensure the parser stays anchored to Football League sections and does not pull in sibling competitions such as Southern League or cup sections
+
+Likely files:
+
+- `wikipedia/parser-core/wiki-overview-parser.js`
+- `wikipedia/builders/parse-ext-season-overview-pages.js`
+- `wikipedia/config.js`
+- `wikipedia/__tests__/wiki-overview-parser.test.js`
+- `wikipedia/__tests__/parse-ext-season-overview-pages.test.js`
+
+Acceptance criteria:
+
+- Third Division North and South tables infer as separate source identities and shared level 3
+- 1958 Fourth Division tables infer as true level 4
+- generic 2012 and 2013 `League tables` style labels no longer hide the intended league identity where the page exposes enough nearby context
+- 2021 and later National League North/South tables can be distinguished without depending only on `tableIndex`
+
+Checkpoint:
+
+```sh
+pnpm test -- --runTestsByPath wikipedia/__tests__/wiki-overview-parser.test.js wikipedia/__tests__/parse-ext-season-overview-pages.test.js
+pnpm wiki:verify
+```
+
+## Phase 3: Add Boundary Fixtures
+
+Goal:
+
+- protect the structural boundaries that are most likely to regress when parser coverage expands
+
+Tasks:
+
+- add compact fixture-style tests for target seasons instead of exhaustive year-by-year coverage
+- include row count, title/id, output slot, `leagueLevel`, promoted, and relegated assertions where the page supports them
+- keep fixtures representative and small enough to maintain
+
+Priority fixtures:
+
+- `1920`, `1921`, `1923`, `1950`, `1957`, `1958`
+- `1986`, `1987`
+- `1991`, `1992`, `1994`
+- `2004`
+- `2019`
+
+Acceptance criteria:
+
+- boundary seasons document the expected league structure in tests
+- tests fail clearly when a parser change swaps source identity, output slot, or pyramid level
+- fixture updates are not required for unrelated generated-data churn
+
+## Phase 4: Dry-Run Regeneration And Data Diff Review
+
+Goal:
+
+- prove parser changes produce expected data before touching checked-in generated JSON
+
+Tasks:
+
+- run targeted overview builds into temporary output directories for representative seasons
+- compare temporary output with current checked-in data
+- review row counts, movement arrays, table titles, league ids, and metadata levels
+- only then regenerate checked-in output in a separate, reviewable step
+
+Suggested dry-run command shape:
+
+```sh
+node wikipedia/cli/index.js overview --start 1921 --end 1923 --output /tmp/footy-tier34-dry-run --force-update --include-war-placeholders
+node wikipedia/cli/index.js overview --start 1957 --end 1958 --output /tmp/footy-tier34-dry-run --force-update --include-war-placeholders
+node wikipedia/cli/index.js overview --start 2019 --end 2021 --output /tmp/footy-tier34-dry-run --force-update --include-war-placeholders
+```
+
+Acceptance criteria:
+
+- temporary output reflects known tier 3 and tier 4 structure
+- no sibling non-Football-League competitions are numbered into `tierN`
+- generated changes can be explained by parser improvements or documented historical special cases
+
+## Phase 5: Regenerate Checked-In Data
+
+Goal:
+
+- update generated overview and combined data after parser behavior is verified
+
+Tasks:
+
+- regenerate overview output
+- regenerate combined output
+- minify generated JSON if that is part of the existing checked-in format
+- run data verification and schema verification
+- review generated diffs before commit
+
+Commands:
+
+```sh
+pnpm wiki:build:overview
+pnpm wiki:build:combined
+pnpm wiki:minify:overview
+pnpm wiki:minify:combined
+pnpm wiki:verify
+pnpm schema:verify
+```
+
+Acceptance criteria:
+
+- generated files contain the intended tier 3 and tier 4 metadata
+- `all-seasons.json` remains internally consistent
+- verifier passes without new broad exemptions
+- any unresolved data oddities are documented in `lower-tier-coverage-analysis.md`
+
+## Phase 6: Decide Remaining Semantic Corrections
+
+Goal:
+
+- separate parser readiness from historical interpretation decisions that could change dataset meaning
+
+Open decisions:
+
+- whether 1957-58 bottom-half movement into the new Fourth Division should be represented as normal relegation, restructure placement metadata, or both
+- whether 2019-20 relegation fields should represent table markers, final administrative outcomes, or both
+- whether to add a stable `canonicalLeagueId` or `leagueGroup` metadata field for variant source titles
+- whether generic source titles from pages such as 2012 and 2013 should be normalized in output or preserved with only supplemental metadata
+
+Acceptance criteria:
+
+- semantic corrections are made in dedicated commits with tests
+- parser mechanics do not silently decide historical policy
+- downstream users can distinguish output slots, pyramid levels, and administrative exceptions
+
+## Verification Plan
+
+For parser-only slices:
+
+```sh
+pnpm test -- --runTestsByPath wikipedia/__tests__/wiki-overview-parser.test.js wikipedia/__tests__/parse-ext-season-overview-pages.test.js
+pnpm typecheck
+pnpm lint
+```
+
+For builder, normalizer, verifier, or config slices:
+
+```sh
+pnpm test -- --runTestsByPath wikipedia/__tests__/wiki-overview-parser.test.js wikipedia/__tests__/parse-ext-season-overview-pages.test.js wikipedia/__tests__/season-rules.test.js wikipedia/__tests__/generate-output-files.test.js wikipedia/__tests__/verify-football-data.test.js
+pnpm wiki:verify
+pnpm typecheck
+pnpm lint
+```
+
+For generated-data slices:
+
+```sh
+pnpm wiki:verify
+pnpm schema:verify
+pnpm test
+pnpm typecheck
+pnpm lint
+```
+
+## Definition Of Ready For Parser Work
+
+The next parser implementation slice is ready when:
+
+- existing config rules for tier 3 and tier 4 are committed
+- this plan and the coverage analysis are committed
+- target seasons for the slice are named up front
+- expected output slot and `leagueLevel` behavior is written down before regeneration
+
+## Definition Of Done For The First Parser Slice
+
+The first parser-readiness implementation slice is done when:
+
+- ambiguous tier 3 and tier 4 tables have reliable titles, ids, or canonical metadata
+- representative boundary tests pass
+- current generated output still verifies
+- no checked-in generated data changes are included unless the slice explicitly targets regeneration
+- follow-up data regeneration work is documented with the exact seasons and commands to run

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,8 +3,11 @@
  */
 const config = {
   testEnvironment: 'node',
-  transform: {},
-  moduleFileExtensions: ['js', 'json'],
+  transform: {
+    '^.+\\.ts$': '<rootDir>/scripts/jest-typescript-transformer.cjs',
+  },
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleFileExtensions: ['js', 'ts', 'json'],
   setupFiles: ['<rootDir>/wikipedia/__tests__/test-setup.js'],
   testMatch: [
     '<rootDir>/wikipedia/__tests__/**/*.test.js',

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -3,8 +3,11 @@
  */
 const config = {
   testEnvironment: 'node',
-  transform: {},
-  moduleFileExtensions: ['js', 'json'],
+  transform: {
+    '^.+\\.ts$': '<rootDir>/scripts/jest-typescript-transformer.cjs',
+  },
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleFileExtensions: ['js', 'ts', 'json'],
   setupFiles: ['<rootDir>/wikipedia/__tests__/test-setup.js'],
   testMatch: ['<rootDir>/wikipedia/__integration_tests__/**/*.test.js'],
 };

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "test:integration:overview": "cross-env NODE_OPTIONS=--experimental-vm-modules WIKI_TEST_SOURCE=overview jest -c jest.integration.config.js",
     "test:coverage": "pnpm -s test:jest -- --coverage",
     "test:watch": "pnpm -s test:jest -- --watch",
-    "lint": "eslint . --ext .js,.mjs",
-    "lint:fix": "eslint . --ext .js,.mjs --fix",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint . --ext .js,.mjs,.ts",
+    "lint:fix": "eslint . --ext .js,.mjs,.ts --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "lefthook install"
@@ -66,6 +67,9 @@
     "wikipedia": "^2.4.2"
   },
   "devDependencies": {
+    "@types/node": "^22.19.21",
+    "@typescript-eslint/eslint-plugin": "^8.61.1",
+    "@typescript-eslint/parser": "^8.61.1",
     "ajv": "8.17.1",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.1",
@@ -75,14 +79,15 @@
     "lefthook": "^1.13.6",
     "lint-staged": "^16.2.6",
     "mustache": "^4.2.0",
-    "prettier": "^2.8.8"
+    "prettier": "^2.8.8",
+    "typescript": "^6.0.3"
   },
   "lint-staged": {
-    "*.{js,mjs,json,md}": [
+    "*.{js,mjs,ts,json,md}": [
       "prettier --write",
       "git add"
     ],
-    "*.{js,mjs}": [
+    "*.{js,mjs,ts}": [
       "eslint --fix",
       "git add"
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,15 @@ importers:
         specifier: ^2.4.2
         version: 2.4.2
     devDependencies:
+      '@types/node':
+        specifier: ^22.19.21
+        version: 22.19.21
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.61.1
+        version: 8.61.1(@typescript-eslint/parser@8.61.1(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.61.1
+        version: 8.61.1(eslint@8.57.1)(typescript@6.0.3)
       ajv:
         specifier: 8.17.1
         version: 8.17.1
@@ -41,7 +50,7 @@ importers:
         version: 4.2.5(eslint-config-prettier@8.10.2(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@24.7.1)
+        version: 29.7.0(@types/node@22.19.21)
       lefthook:
         specifier: ^1.13.6
         version: 1.13.6
@@ -54,6 +63,9 @@ importers:
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
 packages:
 
@@ -228,8 +240,18 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
+  '@eslint-community/eslint-utils@4.9.1':
+    resolution: {integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    peerDependencies:
+      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
+
   '@eslint-community/regexpp@4.12.1':
     resolution: {integrity: sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
+  '@eslint-community/regexpp@4.12.2':
+    resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   '@eslint/eslintrc@2.1.4':
@@ -394,8 +416,11 @@ packages:
   '@types/istanbul-reports@3.0.4':
     resolution: {integrity: sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==}
 
-  '@types/node@24.7.1':
-    resolution: {integrity: sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==}
+  '@types/node@22.19.21':
+    resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
+
+  '@types/node@25.9.3':
+    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
@@ -405,6 +430,65 @@ packages:
 
   '@types/yargs@17.0.33':
     resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
+
+  '@typescript-eslint/eslint-plugin@8.61.1':
+    resolution: {integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      '@typescript-eslint/parser': ^8.61.1
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/parser@8.61.1':
+    resolution: {integrity: sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/project-service@8.61.1':
+    resolution: {integrity: sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/scope-manager@8.61.1':
+    resolution: {integrity: sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.61.1':
+    resolution: {integrity: sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.61.1':
+    resolution: {integrity: sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/types@8.61.1':
+    resolution: {integrity: sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.61.1':
+    resolution: {integrity: sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.61.1':
+    resolution: {integrity: sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.61.1':
+    resolution: {integrity: sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -497,6 +581,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.8.16:
     resolution: {integrity: sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==}
     hasBin: true
@@ -506,6 +594,10 @@ packages:
 
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -772,6 +864,10 @@ packages:
     resolution: {integrity: sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  eslint-visitor-keys@5.0.1:
+    resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
   eslint@8.57.1:
     resolution: {integrity: sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
@@ -842,6 +938,15 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
@@ -972,6 +1077,10 @@ packages:
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   import-fresh@3.3.1:
@@ -1382,6 +1491,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -1489,6 +1602,10 @@ packages:
   picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
 
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
@@ -1699,12 +1816,22 @@ packages:
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tmpl@1.0.5:
     resolution: {integrity: sha512-3f0uOEAQwIqGuWW2MVzYg8fV/QNnc/IpuJNG837rLuczAaLVHslWHZQj4IGiEl5Hs3kkbhwL9Ab7Hrsmuj+Smw==}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  ts-api-utils@2.5.0:
+    resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
+    engines: {node: '>=18.12'}
+    peerDependencies:
+      typescript: '>=4.8.4'
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -1722,8 +1849,16 @@ packages:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
 
-  undici-types@7.14.0:
-    resolution: {integrity: sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici@7.15.0:
     resolution: {integrity: sha512-7oZJCPvvMvTd0OlqWsIxTuItTpJBpU1tcbVl24FMn3xt3+VSunwUasmfPJRE57oNO1KsZ4PgA1xTdAX4hq8NyQ==}
@@ -2001,7 +2136,14 @@ snapshots:
       eslint: 8.57.1
       eslint-visitor-keys: 3.4.3
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@8.57.1)':
+    dependencies:
+      eslint: 8.57.1
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/regexpp@4.12.1': {}
+
+  '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/eslintrc@2.1.4':
     dependencies:
@@ -2060,7 +2202,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -2073,14 +2215,14 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@24.7.1)
+      jest-config: 29.7.0(@types/node@25.9.3)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -2105,7 +2247,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -2123,7 +2265,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -2145,7 +2287,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -2215,7 +2357,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -2283,7 +2425,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -2295,9 +2437,13 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-report': 3.0.3
 
-  '@types/node@24.7.1':
+  '@types/node@22.19.21':
     dependencies:
-      undici-types: 7.14.0
+      undici-types: 6.21.0
+
+  '@types/node@25.9.3':
+    dependencies:
+      undici-types: 7.24.6
 
   '@types/stack-utils@2.0.3': {}
 
@@ -2306,6 +2452,97 @@ snapshots:
   '@types/yargs@17.0.33':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.61.1(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/type-utils': 8.61.1(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.61.1
+      eslint: 8.57.1
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@8.61.1(eslint@8.57.1)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.61.1
+      debug: 4.4.3
+      eslint: 8.57.1
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.61.1(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.1
+      debug: 4.4.3
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/scope-manager@8.61.1':
+    dependencies:
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/visitor-keys': 8.61.1
+
+  '@typescript-eslint/tsconfig-utils@8.61.1(typescript@6.0.3)':
+    dependencies:
+      typescript: 6.0.3
+
+  '@typescript-eslint/type-utils@8.61.1(eslint@8.57.1)(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@8.57.1)(typescript@6.0.3)
+      debug: 4.4.3
+      eslint: 8.57.1
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/types@8.61.1': {}
+
+  '@typescript-eslint/typescript-estree@8.61.1(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/visitor-keys': 8.61.1
+      debug: 4.4.3
+      minimatch: 10.2.5
+      semver: 7.7.3
+      tinyglobby: 0.2.17
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.61.1(eslint@8.57.1)(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@8.57.1)
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
+      eslint: 8.57.1
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/visitor-keys@8.61.1':
+    dependencies:
+      '@typescript-eslint/types': 8.61.1
+      eslint-visitor-keys: 5.0.1
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -2427,6 +2664,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.8.16: {}
 
   boolbase@1.0.0: {}
@@ -2435,6 +2674,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -2540,13 +2783,13 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  create-jest@29.7.0(@types/node@24.7.1):
+  create-jest@29.7.0(@types/node@22.19.21):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@24.7.1)
+      jest-config: 29.7.0(@types/node@22.19.21)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -2682,6 +2925,8 @@ snapshots:
 
   eslint-visitor-keys@3.4.3: {}
 
+  eslint-visitor-keys@5.0.1: {}
+
   eslint@8.57.1:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@8.57.1)
@@ -2791,6 +3036,10 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   file-entry-cache@6.0.1:
     dependencies:
@@ -2915,6 +3164,8 @@ snapshots:
 
   ignore@5.3.2: {}
 
+  ignore@7.0.5: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -3019,7 +3270,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.0
@@ -3039,16 +3290,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@24.7.1):
+  jest-cli@29.7.0(@types/node@22.19.21):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@24.7.1)
+      create-jest: 29.7.0(@types/node@22.19.21)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@24.7.1)
+      jest-config: 29.7.0(@types/node@22.19.21)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -3058,7 +3309,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@24.7.1):
+  jest-config@29.7.0(@types/node@22.19.21):
     dependencies:
       '@babel/core': 7.28.4
       '@jest/test-sequencer': 29.7.0
@@ -3083,7 +3334,37 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 24.7.1
+      '@types/node': 22.19.21
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@25.9.3):
+    dependencies:
+      '@babel/core': 7.28.4
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.4)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.9.3
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -3112,7 +3393,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -3122,7 +3403,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -3161,7 +3442,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -3196,7 +3477,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -3224,7 +3505,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -3270,7 +3551,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -3289,7 +3570,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -3298,17 +3579,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 24.7.1
+      '@types/node': 25.9.3
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@24.7.1):
+  jest@29.7.0(@types/node@22.19.21):
     dependencies:
       '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@24.7.1)
+      jest-cli: 29.7.0(@types/node@22.19.21)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -3480,6 +3761,10 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -3580,6 +3865,8 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
+
+  picomatch@4.0.4: {}
 
   pidtree@0.6.0: {}
 
@@ -3749,11 +4036,20 @@ snapshots:
 
   text-table@0.2.0: {}
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tmpl@1.0.5: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  ts-api-utils@2.5.0(typescript@6.0.3):
+    dependencies:
+      typescript: 6.0.3
 
   type-check@0.4.0:
     dependencies:
@@ -3765,7 +4061,11 @@ snapshots:
 
   type-fest@0.21.3: {}
 
-  undici-types@7.14.0: {}
+  typescript@6.0.3: {}
+
+  undici-types@6.21.0: {}
+
+  undici-types@7.24.6: {}
 
   undici@7.15.0: {}
 

--- a/scripts/jest-typescript-transformer.cjs
+++ b/scripts/jest-typescript-transformer.cjs
@@ -1,0 +1,19 @@
+const ts = require('typescript');
+
+module.exports = {
+  process(sourceText, sourcePath) {
+    const result = ts.transpileModule(sourceText, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        sourceMap: true,
+      },
+      fileName: sourcePath,
+    });
+
+    return {
+      code: result.outputText,
+      map: result.sourceMapText ? JSON.parse(result.sourceMapText) : null,
+    };
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "allowJs": true,
     "allowImportingTsExtensions": true,
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"]
+  },
+  "include": ["wikipedia/**/*.ts", "rsssf/**/*.ts", "scripts/**/*.ts", "shared/**/*.ts"]
+}

--- a/wikipedia/__tests__/generate-output-files.test.js
+++ b/wikipedia/__tests__/generate-output-files.test.js
@@ -142,6 +142,72 @@ describe('createFootballData', () => {
     expect(tier2[0].wasPromoted).toBe(true);
   });
 
+  test('normalises structured tier metadata and explicit outcome lists', () => {
+    const dataset = createFootballData({
+      seasons: {
+        1902: {
+          tier3: {
+            season: '1902',
+            table: [
+              null,
+              {
+                pos: '1',
+                team: 'Delta FC',
+                played: '34',
+                won: '22',
+                drawn: '5',
+                lost: '7',
+                goalsFor: '75',
+                goalsAgainst: '36',
+                points: '49',
+                notes: 'Promoted through election',
+              },
+              {
+                pos: '2',
+                team: 'Echo FC',
+                played: '34',
+                won: '20',
+                drawn: '7',
+                lost: '7',
+                goalsFor: '70',
+                goalsAgainst: '40',
+                points: '47',
+                notes: 'Relegated',
+              },
+            ],
+            promoted: ['Manual Promoted FC'],
+            relegated: ['Manual Relegated FC'],
+            sourceUrl: 'https://example.test/season',
+            seasonSlug: '1902-03_example',
+            tier: 'tier3',
+            title: 'Example Division',
+            seasonMetadata: {
+              leagueId: 'example-division',
+              tableIndex: 2,
+              tableCount: 4,
+            },
+          },
+        },
+      },
+    });
+
+    const tier3 = dataset.seasons['1902'].tier3;
+    expect(tier3.season).toBe(1902);
+    expect(tier3.table.map((row) => row.team)).toEqual(['Delta FC', 'Echo FC']);
+    expect(tier3.promoted).toEqual(['Manual Promoted FC']);
+    expect(tier3.relegated).toEqual(['Manual Relegated FC']);
+    expect(tier3.metadata).toMatchObject({
+      source: 'wikipedia-overview',
+      sourceUrl: 'https://example.test/season',
+      seasonSlug: '1902-03_example',
+      tierKey: 'tier3',
+      title: 'Example Division',
+      leagueId: 'example-division',
+      tableIndex: 2,
+      tableCount: 4,
+    });
+  });
+
   test('preserves top-level dataset metadata', () => {
     const dataset = createFootballData({
       metadata: {

--- a/wikipedia/__tests__/generate-output-files.test.js
+++ b/wikipedia/__tests__/generate-output-files.test.js
@@ -208,6 +208,51 @@ describe('createFootballData', () => {
     });
   });
 
+  test('normalises seasonInfo metadata and special competition lists', () => {
+    const dataset = createFootballData({
+      seasons: {
+        1915: {
+          seasonInfo: {
+            season: '1915',
+            promoted: ['Alpha FC', 'Alpha FC', ''],
+            relegated: ['Beta FC'],
+            seasonSlug: '1915-16_in_English_football',
+            sourceUrl: 'https://example.test/1915',
+            tableCount: '3',
+            competitionStatus: ' suspended ',
+            warSuspensionLabel: 'World War I',
+            officialLeagueTables: false,
+            officialCompetitionsSuspended: true,
+            officialCompetitionsAbandoned: false,
+            regionalBridgeSeason: true,
+            promotionRelegationApplies: false,
+            specialCompetitions: ['London Combination', 'London Combination', '', null],
+            notes: ' Wartime regional competitions only ',
+          },
+        },
+      },
+    });
+
+    expect(dataset.seasons['1915'].seasonInfo).toEqual({
+      season: 1915,
+      table: [],
+      promoted: ['Alpha FC'],
+      relegated: ['Beta FC'],
+      seasonSlug: '1915-16_in_English_football',
+      sourceUrl: 'https://example.test/1915',
+      tableCount: 3,
+      competitionStatus: 'suspended',
+      warSuspensionLabel: 'World War I',
+      officialLeagueTables: false,
+      officialCompetitionsSuspended: true,
+      officialCompetitionsAbandoned: false,
+      regionalBridgeSeason: true,
+      promotionRelegationApplies: false,
+      specialCompetitions: ['London Combination'],
+      notes: 'Wartime regional competitions only',
+    });
+  });
+
   test('preserves top-level dataset metadata', () => {
     const dataset = createFootballData({
       metadata: {

--- a/wikipedia/__tests__/generate-output-files.test.js
+++ b/wikipedia/__tests__/generate-output-files.test.js
@@ -495,6 +495,38 @@ describe('saveFootballData', () => {
   });
 });
 
+describe('buildDatasetMetadata', () => {
+  test('normalises source files and filters unsupported build options', () => {
+    expect(
+      buildDatasetMetadata({
+        generator: 'wikipedia-overview',
+        generatedAt: '2026-03-08T13:00:00.000Z',
+        gitSha: 'def5678',
+        sourceFiles: ['/tmp/a.json', '/tmp/a.json', ''],
+        buildOptions: {
+          startYear: 1991,
+          endYear: 2024,
+          ignoreWarYears: true,
+          nullValue: null,
+          nested: { unsupported: true },
+        },
+      })
+    ).toEqual({
+      schemaVersion: 1,
+      generator: 'wikipedia-overview',
+      generatedAt: '2026-03-08T13:00:00.000Z',
+      gitSha: 'def5678',
+      sourceFiles: ['/tmp/a.json'],
+      buildOptions: {
+        startYear: 1991,
+        endYear: 2024,
+        ignoreWarYears: true,
+        nullValue: null,
+      },
+    });
+  });
+});
+
 describe('setSeasonRecord', () => {
   test('preserves metadata fields on tier payloads', () => {
     const dataset = createFootballData();

--- a/wikipedia/__tests__/generate-output-files.test.js
+++ b/wikipedia/__tests__/generate-output-files.test.js
@@ -227,6 +227,15 @@ describe('createFootballData', () => {
             regionalBridgeSeason: true,
             promotionRelegationApplies: false,
             specialCompetitions: ['London Combination', 'London Combination', '', null],
+            leagueStructureSpecialCases: [
+              {
+                type: ' restructure-placement ',
+                levels: ['3', 4, 4, null],
+                tierKeys: ['tier3', 'tier4', 'tier4', ''],
+                notes: ' Final North/South season ',
+              },
+              null,
+            ],
             notes: ' Wartime regional competitions only ',
           },
         },
@@ -249,6 +258,14 @@ describe('createFootballData', () => {
       regionalBridgeSeason: true,
       promotionRelegationApplies: false,
       specialCompetitions: ['London Combination'],
+      leagueStructureSpecialCases: [
+        {
+          type: 'restructure-placement',
+          levels: [3, 4],
+          tierKeys: ['tier3', 'tier4'],
+          notes: 'Final North/South season',
+        },
+      ],
       notes: 'Wartime regional competitions only',
     });
   });

--- a/wikipedia/__tests__/generate-output-files.test.js
+++ b/wikipedia/__tests__/generate-output-files.test.js
@@ -9,7 +9,7 @@ import {
   loadFootballData,
   saveFootballData,
   setSeasonRecord,
-} from '../data/generate-output-files.js';
+} from '../data/generate-output-files.ts';
 
 describe('normaliseLeagueTableEntry', () => {
   test('derives promotion and relegation flags from notes when omitted', () => {

--- a/wikipedia/__tests__/generate-output-files.test.js
+++ b/wikipedia/__tests__/generate-output-files.test.js
@@ -33,6 +33,44 @@ describe('normaliseLeagueTableEntry', () => {
     expect(entry.wasRelegated).toBe(false);
     expect(entry.goalDifference).toBe(38);
   });
+
+  test('preserves explicit boolean flags and normalises numeric strings', () => {
+    const entry = normaliseLeagueTableEntry({
+      pos: '22',
+      team: 'Sample Town',
+      played: '42',
+      won: '10',
+      drawn: '8',
+      lost: '24',
+      goalsFor: '40',
+      goalsAgainst: '80',
+      goalAverage: '',
+      points: '28',
+      notes: null,
+      wasRelegated: true,
+      wasPromoted: false,
+    });
+
+    expect(entry.wasRelegated).toBe(true);
+    expect(entry.wasPromoted).toBe(false);
+    expect(entry.goalDifference).toBe(-40);
+    expect(entry.goalAverage).toBeNull();
+  });
+
+  test('rejects rows without a team name', () => {
+    expect(() =>
+      normaliseLeagueTableEntry({
+        pos: 1,
+        played: 42,
+        won: 25,
+        drawn: 10,
+        lost: 7,
+        goalsFor: 82,
+        goalsAgainst: 44,
+        points: 60,
+      })
+    ).toThrow('League table entry is missing a team name');
+  });
 });
 
 describe('createFootballData', () => {

--- a/wikipedia/__tests__/parse-ext-season-overview-pages.test.js
+++ b/wikipedia/__tests__/parse-ext-season-overview-pages.test.js
@@ -443,6 +443,164 @@ describe('parseOverviewLeagueTables', () => {
       leagueLevel: 3,
       tierKey: 'tier4',
     });
+    expect(seasonRecord.seasonInfo.leagueStructureSpecialCases).toEqual([
+      expect.objectContaining({
+        type: 'parallel-regional-level',
+        tierKeys: ['tier3', 'tier4'],
+      }),
+    ]);
+  });
+
+  test('annotates the 1957 regional-to-national tier restructure season', () => {
+    const seasonRecord = buildSeasonOverviewSeasonRecord({
+      seasonKey: '1957',
+      seasonYear: 1957,
+      seasonSlug: '1957–58_in_English_football',
+      tables: [
+        {
+          title: 'First Division',
+          id: 'First_Division',
+          tableIndex: 0,
+          rows: [{ pos: 1, team: 'Wolverhampton Wanderers', played: 42, points: 64 }],
+        },
+        {
+          title: 'Second Division',
+          id: 'Second_Division',
+          tableIndex: 1,
+          rows: [{ pos: 1, team: 'West Ham United', played: 42, points: 57 }],
+        },
+        {
+          title: 'Third Division North',
+          id: 'Third_Division_North',
+          tableIndex: 2,
+          rows: [{ pos: 1, team: 'Scunthorpe & Lindsey United', played: 46, points: 66 }],
+        },
+        {
+          title: 'Third Division South',
+          id: 'Third_Division_South',
+          tableIndex: 3,
+          rows: [{ pos: 1, team: 'Brighton & Hove Albion', played: 46, points: 60 }],
+        },
+      ],
+    });
+
+    expect(seasonRecord.tier4.metadata.leagueLevel).toBe(3);
+    expect(seasonRecord.seasonInfo.leagueStructureSpecialCases).toEqual([
+      expect.objectContaining({
+        type: 'restructure-placement',
+        levels: [3, 4],
+      }),
+    ]);
+  });
+
+  test('annotates the 2004 League One and League Two rebrand boundary', () => {
+    const seasonRecord = buildSeasonOverviewSeasonRecord({
+      seasonKey: '2004',
+      seasonYear: 2004,
+      seasonSlug: '2004–05_in_English_football',
+      tables: [
+        {
+          title: 'FA Premier League',
+          id: 'FA_Premier_League',
+          tableIndex: 0,
+          rows: [{ pos: 1, team: 'Chelsea', played: 38, points: 95 }],
+        },
+        {
+          title: 'Football League Championship',
+          id: 'Football_League_Championship',
+          tableIndex: 1,
+          rows: [{ pos: 1, team: 'Sunderland', played: 46, points: 94 }],
+        },
+        {
+          title: 'Football League One',
+          id: 'Football_League_One',
+          tableIndex: 2,
+          rows: [{ pos: 1, team: 'Luton Town', played: 46, points: 98 }],
+        },
+        {
+          title: 'Football League Two',
+          id: 'Football_League_Two',
+          tableIndex: 3,
+          rows: [{ pos: 1, team: 'Yeovil Town', played: 46, points: 83 }],
+        },
+      ],
+    });
+
+    expect(seasonRecord.tier3.metadata).toMatchObject({
+      title: 'Football League One',
+      leagueLevel: 3,
+    });
+    expect(seasonRecord.tier4.metadata).toMatchObject({
+      title: 'Football League Two',
+      leagueLevel: 4,
+    });
+    expect(seasonRecord.seasonInfo.leagueStructureSpecialCases).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'efl-rebrand' }),
+        expect.objectContaining({ type: 'national-league-system-restructure' }),
+      ])
+    );
+  });
+
+  test('stores National League North and South as parallel level 6 tables', () => {
+    const seasonRecord = buildSeasonOverviewSeasonRecord({
+      seasonKey: '2021',
+      seasonYear: 2021,
+      seasonSlug: '2021–22_in_English_football',
+      tables: [
+        {
+          title: 'Premier League',
+          id: 'Premier_League',
+          tableIndex: 0,
+          rows: [{ pos: 1, team: 'Manchester City', played: 38, points: 93 }],
+        },
+        {
+          title: 'Championship',
+          id: 'Championship',
+          tableIndex: 1,
+          rows: [{ pos: 1, team: 'Fulham', played: 46, points: 90 }],
+        },
+        {
+          title: 'League One',
+          id: 'League_One',
+          tableIndex: 2,
+          rows: [{ pos: 1, team: 'Wigan Athletic', played: 46, points: 92 }],
+        },
+        {
+          title: 'League Two',
+          id: 'League_Two',
+          tableIndex: 3,
+          rows: [{ pos: 1, team: 'Forest Green Rovers', played: 46, points: 84 }],
+        },
+        {
+          title: 'National League',
+          id: 'National_League',
+          tableIndex: 4,
+          rows: [{ pos: 1, team: 'Stockport County', played: 44, points: 94 }],
+        },
+        {
+          title: 'National League North',
+          id: 'National_League_North',
+          tableIndex: 5,
+          rows: [{ pos: 1, team: 'Gateshead', played: 42, points: 94 }],
+        },
+        {
+          title: 'National League South',
+          id: 'National_League_South',
+          tableIndex: 6,
+          rows: [{ pos: 1, team: 'Maidstone United', played: 40, points: 87 }],
+        },
+      ],
+    });
+
+    expect(seasonRecord.tier6.metadata).toMatchObject({
+      title: 'National League North',
+      leagueLevel: 6,
+    });
+    expect(seasonRecord.tier7.metadata).toMatchObject({
+      title: 'National League South',
+      leagueLevel: 6,
+    });
   });
 
   test('keeps pre-war four-division seasons aligned with second-tier top-flight movement', () => {
@@ -553,6 +711,62 @@ describe('parseOverviewLeagueTables', () => {
     const sunderland = seasonRecord.tier2.table.find((row) => row.team === 'Sunderland');
     expect(swindon.wasPromoted).toBe(false);
     expect(sunderland.wasPromoted).toBe(true);
+  });
+
+  test('applies config-driven administrative outcome overrides for 2019 League Two', () => {
+    const seasonRecord = buildSeasonOverviewSeasonRecord({
+      seasonKey: '2019',
+      seasonYear: 2019,
+      seasonSlug: '2019–20_in_English_football',
+      tables: [
+        {
+          title: 'Premier League',
+          id: 'Premier_League',
+          tableIndex: 0,
+          rows: [{ pos: 1, team: 'Liverpool', played: 38, points: 99 }],
+        },
+        {
+          title: 'Championship',
+          id: 'Championship',
+          tableIndex: 1,
+          rows: [{ pos: 1, team: 'Leeds United', played: 46, points: 93 }],
+        },
+        {
+          title: 'League One',
+          id: 'League_One',
+          tableIndex: 2,
+          rows: [
+            { pos: 1, team: 'Coventry City', played: 34, points: 67, wasPromoted: true },
+            { pos: 24, team: 'Bury', played: 0, points: 0, wasRelegated: true },
+          ],
+        },
+        {
+          title: 'League Two',
+          id: 'League_Two',
+          tableIndex: 3,
+          rows: [
+            { pos: 23, team: 'Stevenage', played: 36, points: 35, wasRelegated: true },
+            { pos: 24, team: 'Macclesfield Town', played: 37, points: 23, wasRelegated: true },
+          ],
+        },
+      ],
+    });
+
+    expect(seasonRecord.tier4.relegated).toEqual(['Macclesfield Town']);
+    expect(seasonRecord.tier4.table.find((row) => row.team === 'Stevenage')).toMatchObject({
+      wasRelegated: false,
+      outcomeStatus: 'reprieved',
+    });
+    expect(seasonRecord.tier4.table.find((row) => row.team === 'Macclesfield Town')).toMatchObject({
+      wasRelegated: true,
+      outcomeStatus: 'relegated-after-points-deduction',
+    });
+    expect(seasonRecord.seasonInfo.leagueStructureSpecialCases).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'covid-curtailed-season' }),
+        expect.objectContaining({ type: 'administrative-outcome' }),
+      ])
+    );
   });
 
   test('builds metadata-only placeholder records for abandoned and bridge seasons', () => {

--- a/wikipedia/__tests__/season-rules.test.js
+++ b/wikipedia/__tests__/season-rules.test.js
@@ -174,11 +174,16 @@ describe('season-rules', () => {
   });
 
   test('continuity and coverage helpers are stable', () => {
+    expect(getExpectedMinimumTierCount(2021)).toBe(7);
+    expect(getExpectedMinimumTierCount(2012)).toBe(5);
     expect(getExpectedMinimumTierCount(1991)).toBe(4);
+    expect(getExpectedMinimumTierCount(1958)).toBe(4);
+    expect(getExpectedMinimumTierCount(1950)).toBe(4);
+    expect(getExpectedMinimumTierCount(1921)).toBe(4);
+    expect(getExpectedMinimumTierCount(1920)).toBe(3);
     expect(getExpectedMinimumTierCount(1888)).toBe(1);
     expect(getExpectedMinimumTierCount(1889)).toBe(1);
     expect(getExpectedMinimumTierCount(1890)).toBe(2);
-    expect(getExpectedMinimumTierCount(1950)).toBe(2);
     expect(shouldIgnoreMissingSeasonData({ kind: 'promotion-only' }, '1915')).toBe(true);
     expect(shouldIgnoreMissingSeasonData({ kind: 'promotion-only' }, '2005')).toBe(false);
     expect(shouldSkipContinuityForSeason({ kind: 'promotion-only' }, 1991)).toBe(true);

--- a/wikipedia/__tests__/verify-football-data.test.js
+++ b/wikipedia/__tests__/verify-football-data.test.js
@@ -653,18 +653,18 @@ describe('verify-football-data', () => {
         generatedAt: '2026-03-08T05:00:00.000Z',
       },
       seasons: {
-        2021: {
+        2011: {
           seasonInfo: {
-            season: 2021,
+            season: 2011,
             table: [],
             promoted: [],
             relegated: [],
-            seasonSlug: '2021-22_in_English_football',
-            sourceUrl: 'https://example.com/2021',
+            seasonSlug: '2011-12_in_English_football',
+            sourceUrl: 'https://example.com/2011',
             tableCount: 4,
           },
           tier1: {
-            season: 2021,
+            season: 2011,
             table: [
               {
                 pos: 1,
@@ -690,8 +690,8 @@ describe('verify-football-data', () => {
             relegated: [],
             metadata: {
               source: 'wikipedia-overview',
-              seasonSlug: '2021-22',
-              sourceUrl: 'https://example.com/2021',
+              seasonSlug: '2011-12',
+              sourceUrl: 'https://example.com/2011',
               tierKey: 'tier1',
               title: 'Premier League',
               leagueId: 'Premier_League',
@@ -700,14 +700,14 @@ describe('verify-football-data', () => {
             },
           },
           tier2: {
-            season: 2021,
+            season: 2011,
             table: [],
             promoted: [],
             relegated: [],
             metadata: {
               source: 'wikipedia-overview',
-              seasonSlug: '2021-22',
-              sourceUrl: 'https://example.com/2021',
+              seasonSlug: '2011-12',
+              sourceUrl: 'https://example.com/2011',
               tierKey: 'tier2',
               title: 'Championship',
               leagueId: 'Championship',
@@ -716,14 +716,14 @@ describe('verify-football-data', () => {
             },
           },
           tier3: {
-            season: 2021,
+            season: 2011,
             table: [],
             promoted: [],
             relegated: [],
             metadata: {
               source: 'wikipedia-overview',
-              seasonSlug: '2021-22',
-              sourceUrl: 'https://example.com/2021',
+              seasonSlug: '2011-12',
+              sourceUrl: 'https://example.com/2011',
               tierKey: 'tier3',
               title: 'League One',
               leagueId: 'League_One',
@@ -732,14 +732,14 @@ describe('verify-football-data', () => {
             },
           },
           tier4: {
-            season: 2021,
+            season: 2011,
             table: [],
             promoted: [],
             relegated: [],
             metadata: {
               source: 'wikipedia-overview',
-              seasonSlug: '2021-22',
-              sourceUrl: 'https://example.com/2021',
+              seasonSlug: '2011-12',
+              sourceUrl: 'https://example.com/2011',
               tierKey: 'tier4',
               title: 'League Two',
               leagueId: 'League_Two',

--- a/wikipedia/__tests__/wiki-overview-parser.test.js
+++ b/wikipedia/__tests__/wiki-overview-parser.test.js
@@ -4,6 +4,7 @@ import {
   deriveMajorTierIndexes,
   findLeagueSectionHeading,
   headingHasLeagueKeyword,
+  inferOverviewTierNumber,
   isExcludedOverviewCompetitionLabel,
   parseOverviewTablesForHeading,
 } from '../parser-core/wiki-overview-parser.js';
@@ -114,6 +115,38 @@ describe('wiki-overview-parser', () => {
     const result = deriveMajorTierIndexes(tables);
     expect(result.topFlightIndex).toBe(0);
     expect(result.secondTierIndex).toBe(1);
+  });
+
+  test('infers historically renamed tier 3 and tier 4 league levels', () => {
+    expect(
+      inferOverviewTierNumber({ title: 'Third Division South', id: 'Third_Division_South' }, 1957)
+    ).toBe(3);
+    expect(inferOverviewTierNumber({ title: 'Fourth Division', id: 'Fourth_Division' }, 1958)).toBe(
+      4
+    );
+    expect(
+      inferOverviewTierNumber(
+        { title: 'Football League Second Division', id: 'Football_League_Second_Division' },
+        2003
+      )
+    ).toBe(3);
+    expect(
+      inferOverviewTierNumber({ title: 'Football League One', id: 'Football_League_One' }, 2004)
+    ).toBe(3);
+    expect(inferOverviewTierNumber({ title: 'League Two', id: 'League_Two' }, 2021)).toBe(4);
+  });
+
+  test('infers parallel National League North and South as level 6', () => {
+    expect(
+      inferOverviewTierNumber({ title: 'National League North', id: 'National_League_North' }, 2021)
+    ).toBe(6);
+    expect(inferOverviewTierNumber({ title: 'South', id: 'South' }, 2025)).toBe(6);
+    expect(
+      inferOverviewTierNumber(
+        { title: 'Northern Premier League Premier Division', id: 'Northern_Premier_League' },
+        2025
+      )
+    ).toBe(7);
   });
 
   test('collectOutcomeTeams filters by selected indexes and flags', () => {

--- a/wikipedia/builders/parse-ext-season-overview-pages.js
+++ b/wikipedia/builders/parse-ext-season-overview-pages.js
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import {
   buildOverviewSeasonSlug as buildOverviewSeasonSlugFromConfig,
   buildWikipediaArticleUrl,
+  getWikipediaLeagueStructureSpecialCases,
   resolveWikipediaDatasetPath,
   WIKIPEDIA_DATA_SOURCES,
 } from '../config.js';
@@ -250,6 +251,7 @@ export function buildSeasonOverviewSeasonRecord({ seasonKey, seasonYear, seasonS
       : [];
   const relegatedTeams =
     topFlightIndex != null ? collectTopFlightRelegations(normalizedTables[topFlightIndex]) : [];
+  const leagueStructureSpecialCases = getWikipediaLeagueStructureSpecialCases(safeSeason);
 
   const seasonInfo = buildSeasonInfo(safeSeason, {
     promoted: promotedTeams,
@@ -257,6 +259,7 @@ export function buildSeasonOverviewSeasonRecord({ seasonKey, seasonYear, seasonS
     metadata: {
       seasonSlug,
       tableCount: tables.length,
+      ...(leagueStructureSpecialCases.length ? { leagueStructureSpecialCases } : {}),
     },
   });
 

--- a/wikipedia/builders/parse-ext-season-overview-pages.js
+++ b/wikipedia/builders/parse-ext-season-overview-pages.js
@@ -7,7 +7,7 @@ import {
   WIKIPEDIA_DATA_SOURCES,
 } from '../config.js';
 import { createDatasetStore } from '../data/dataset-store.js';
-import { buildSeasonInfo, buildTierData } from '../data/generate-output-files.js';
+import { buildSeasonInfo, buildTierData } from '../data/generate-output-files.ts';
 import {
   applyOverviewSeasonOutcomeOverrides,
   buildHistoricalPlaceholderSeasonInfo,

--- a/wikipedia/builders/parse-season-pages.js
+++ b/wikipedia/builders/parse-season-pages.js
@@ -1,4 +1,4 @@
-import { buildSeasonInfo, buildTierData } from '../data/generate-output-files.js';
+import { buildSeasonInfo, buildTierData } from '../data/generate-output-files.ts';
 import {
   buildPromotionSeasonSlug,
   buildWikipediaArticleUrl,

--- a/wikipedia/cli/index.js
+++ b/wikipedia/cli/index.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
 import { isWikipediaWarSuspensionYear, WIKIPEDIA_DATA_SOURCES } from '../config.js';
-import { loadFootballData } from '../data/generate-output-files.js';
+import { loadFootballData } from '../data/generate-output-files.ts';
 import {
   buildSeasonOverview,
   buildSeasonOverviewForSlug,

--- a/wikipedia/config.js
+++ b/wikipedia/config.js
@@ -34,6 +34,13 @@ export const WIKIPEDIA_SEASON_RANGES = Object.freeze({
   classicPromotionFinalSeason: 1990,
   footballAllianceFinalSeason: 1891,
   premierLeagueStartSeason: 1992,
+  thirdDivisionStartSeason: 1920,
+  regionalThirdDivisionStartSeason: 1921,
+  regionalThirdDivisionFinalSeason: 1957,
+  fourthDivisionStartSeason: 1958,
+  footballLeagueRenumberStartSeason: 1992,
+  eflRebrandStartSeason: 2004,
+  nationalLeagueSystemRestructureStartSeason: 2004,
 });
 
 export const WIKIPEDIA_WAR_SUSPENSION_RANGES = Object.freeze([
@@ -136,6 +143,296 @@ export const WIKIPEDIA_OVERVIEW_SEASON_OUTCOME_OVERRIDES = Object.freeze({
       }),
     }),
   }),
+  2019: Object.freeze({
+    tiers: Object.freeze({
+      tier3: Object.freeze({
+        rowFlagOverrides: Object.freeze({
+          Bury: Object.freeze({
+            wasRelegated: true,
+            outcomeStatus: 'expelled',
+          }),
+        }),
+      }),
+      tier4: Object.freeze({
+        relegated: Object.freeze(['Macclesfield Town']),
+        rowFlagOverrides: Object.freeze({
+          Stevenage: Object.freeze({
+            wasRelegated: false,
+            outcomeStatus: 'reprieved',
+          }),
+          'Macclesfield Town': Object.freeze({
+            wasRelegated: true,
+            outcomeStatus: 'relegated-after-points-deduction',
+          }),
+        }),
+      }),
+    }),
+  }),
+});
+
+export const WIKIPEDIA_LEAGUE_LEVEL_RULES = Object.freeze([
+  Object.freeze({
+    level: 1,
+    startSeason: 1992,
+    labels: Object.freeze(['Premier League', 'FA Premier League', 'FA Premiership', 'Premiership']),
+  }),
+  Object.freeze({
+    level: 1,
+    endSeason: 1991,
+    labels: Object.freeze(['First Division', 'Football League First Division']),
+  }),
+  Object.freeze({
+    level: 2,
+    startSeason: 1890,
+    endSeason: 1891,
+    labels: Object.freeze(['Football Alliance', 'The Football Alliance']),
+  }),
+  Object.freeze({
+    level: 2,
+    startSeason: 1892,
+    endSeason: 1991,
+    labels: Object.freeze(['Second Division', 'Football League Second Division']),
+  }),
+  Object.freeze({
+    level: 2,
+    startSeason: 1992,
+    endSeason: 2003,
+    labels: Object.freeze([
+      'First Division',
+      'Division One',
+      'League Division One',
+      'Football League First Division',
+      'Football League Division One',
+    ]),
+  }),
+  Object.freeze({
+    level: 2,
+    startSeason: 2004,
+    labels: Object.freeze(['Championship', 'Football League Championship', 'EFL Championship']),
+  }),
+  Object.freeze({
+    level: 3,
+    startSeason: 1920,
+    endSeason: 1920,
+    labels: Object.freeze(['Third Division', 'Football League Third Division']),
+  }),
+  Object.freeze({
+    level: 3,
+    startSeason: 1921,
+    endSeason: 1957,
+    parallelGroup: 'third-division-north-south',
+    labels: Object.freeze([
+      'Third Division North',
+      'Football League Third Division North',
+      'Third Division South',
+      'Football League Third Division South',
+    ]),
+  }),
+  Object.freeze({
+    level: 3,
+    startSeason: 1958,
+    endSeason: 1991,
+    labels: Object.freeze(['Third Division', 'Football League Third Division']),
+  }),
+  Object.freeze({
+    level: 3,
+    startSeason: 1992,
+    endSeason: 2003,
+    labels: Object.freeze([
+      'Second Division',
+      'Division Two',
+      'League Division Two',
+      'Football League Second Division',
+      'Football League Division Two',
+    ]),
+  }),
+  Object.freeze({
+    level: 3,
+    startSeason: 2004,
+    labels: Object.freeze(['League One', 'Football League One', 'EFL League One']),
+  }),
+  Object.freeze({
+    level: 4,
+    startSeason: 1958,
+    endSeason: 1991,
+    labels: Object.freeze(['Fourth Division', 'Football League Fourth Division']),
+  }),
+  Object.freeze({
+    level: 4,
+    startSeason: 1992,
+    endSeason: 2003,
+    labels: Object.freeze([
+      'Third Division',
+      'Division Three',
+      'League Division Three',
+      'Football League Third Division',
+      'Football League Division Three',
+    ]),
+  }),
+  Object.freeze({
+    level: 4,
+    startSeason: 2004,
+    labels: Object.freeze(['League Two', 'Football League Two', 'EFL League Two']),
+  }),
+  Object.freeze({
+    level: 5,
+    startSeason: 1979,
+    endSeason: 1985,
+    labels: Object.freeze(['Alliance Premier League']),
+  }),
+  Object.freeze({
+    level: 5,
+    startSeason: 1986,
+    endSeason: 2003,
+    labels: Object.freeze(['Football Conference', 'Conference National']),
+  }),
+  Object.freeze({
+    level: 5,
+    startSeason: 2004,
+    endSeason: 2014,
+    labels: Object.freeze(['Conference Premier']),
+  }),
+  Object.freeze({
+    level: 5,
+    startSeason: 2015,
+    labels: Object.freeze(['National League Top Division', 'National League']),
+  }),
+  Object.freeze({
+    level: 6,
+    startSeason: 2004,
+    endSeason: 2014,
+    parallelGroup: 'conference-north-south',
+    labels: Object.freeze(['Conference North', 'Conference South']),
+  }),
+  Object.freeze({
+    level: 6,
+    startSeason: 2015,
+    parallelGroup: 'national-league-north-south',
+    labels: Object.freeze(['National League North', 'National League South']),
+  }),
+  Object.freeze({
+    level: 6,
+    startSeason: 2021,
+    parallelGroup: 'national-league-north-south',
+    labels: Object.freeze(['North', 'South']),
+  }),
+  Object.freeze({
+    level: 7,
+    startSeason: 2004,
+    parallelGroup: 'step-three-premier-divisions',
+    labels: Object.freeze([
+      'Northern Premier League Premier Division',
+      'Southern League Premier Division Central',
+      'Southern League Premier Division South',
+      'Isthmian League Premier Division',
+    ]),
+  }),
+]);
+
+export const WIKIPEDIA_LEAGUE_STRUCTURE_SPECIAL_SEASONS = Object.freeze({
+  1921: Object.freeze([
+    Object.freeze({
+      type: 'parallel-regional-level',
+      levels: Object.freeze([3]),
+      tierKeys: Object.freeze(['tier3', 'tier4']),
+      notes:
+        'Third Division North and Third Division South begin as parallel level-3 regional divisions.',
+    }),
+  ]),
+  1957: Object.freeze([
+    Object.freeze({
+      type: 'restructure-placement',
+      levels: Object.freeze([3, 4]),
+      tierKeys: Object.freeze(['tier3', 'tier4']),
+      notes:
+        'Final Third Division North/South season; bottom-half clubs moved into the new Fourth Division for 1958-59.',
+    }),
+  ]),
+  1958: Object.freeze([
+    Object.freeze({
+      type: 'new-national-fourth-tier',
+      levels: Object.freeze([3, 4]),
+      tierKeys: Object.freeze(['tier3', 'tier4']),
+      notes:
+        'Regional Third Division North/South structure replaced by national Third Division and Fourth Division.',
+    }),
+  ]),
+  1987: Object.freeze([
+    Object.freeze({
+      type: 'playoff-and-conference-relegation-boundary',
+      levels: Object.freeze([3, 4, 5]),
+      tierKeys: Object.freeze(['tier3', 'tier4']),
+      notes:
+        'Football League play-offs and automatic relegation from the Fourth Division to the Conference are active in this era.',
+    }),
+  ]),
+  1991: Object.freeze([
+    Object.freeze({
+      type: 'reduced-fourth-tier-size',
+      levels: Object.freeze([4]),
+      tierKeys: Object.freeze(['tier4']),
+      notes:
+        'Fourth Division table size was affected by Aldershot folding during the 1991-92 season.',
+    }),
+  ]),
+  1992: Object.freeze([
+    Object.freeze({
+      type: 'football-league-renumbering',
+      levels: Object.freeze([3, 4]),
+      tierKeys: Object.freeze(['tier3', 'tier4']),
+      notes:
+        'After the Premier League breakaway, level 3 became Football League Second Division and level 4 became Football League Third Division.',
+    }),
+  ]),
+  1993: Object.freeze([
+    Object.freeze({
+      type: 'reduced-fourth-tier-size',
+      levels: Object.freeze([4]),
+      tierKeys: Object.freeze(['tier4']),
+      notes:
+        'Early Premier League-era fourth tier remained below the normal 24-team shape after Aldershot and Maidstone disruption.',
+    }),
+  ]),
+  1994: Object.freeze([
+    Object.freeze({
+      type: 'reduced-fourth-tier-size',
+      levels: Object.freeze([4]),
+      tierKeys: Object.freeze(['tier4']),
+      notes: 'Fourth-tier row count remains below the normal 24-team shape before settling back.',
+    }),
+  ]),
+  2004: Object.freeze([
+    Object.freeze({
+      type: 'efl-rebrand',
+      levels: Object.freeze([2, 3, 4]),
+      tierKeys: Object.freeze(['tier2', 'tier3', 'tier4']),
+      notes:
+        'Football League First Division, Second Division, and Third Division were rebranded as Championship, League One, and League Two.',
+    }),
+    Object.freeze({
+      type: 'national-league-system-restructure',
+      levels: Object.freeze([5, 6]),
+      tierKeys: Object.freeze(['tier5', 'tier6']),
+      notes:
+        'Conference North and Conference South begin as parallel level-6 divisions beneath the Conference top division.',
+    }),
+  ]),
+  2019: Object.freeze([
+    Object.freeze({
+      type: 'covid-curtailed-season',
+      levels: Object.freeze([3, 4]),
+      tierKeys: Object.freeze(['tier3', 'tier4']),
+      notes:
+        'League One and League Two were curtailed and final positions were decided on points per game.',
+    }),
+    Object.freeze({
+      type: 'administrative-outcome',
+      levels: Object.freeze([3, 4]),
+      tierKeys: Object.freeze(['tier3', 'tier4']),
+      notes:
+        'Bury was expelled from League One; Macclesfield Town was relegated from League Two after points deductions and Stevenage was reprieved.',
+    }),
+  ]),
 });
 
 export const WIKIPEDIA_DIVISION_HEADER_SLUGS = Object.freeze({
@@ -201,8 +498,11 @@ export const WIKIPEDIA_OVERVIEW_CONFIG = Object.freeze({
   secondTierPostPremierKeywords: Object.freeze(['championship', 'division one', 'first division']),
   secondTierPreFirstDivisionKeywords: Object.freeze(['football alliance']),
   fifthTierKeywords: Object.freeze([
-    'national league top division',
+    'alliance premier league',
+    'football conference',
     'conference national',
+    'national league top division',
+    'national league',
     'conference premier',
   ]),
   excludedCompetitionKeywords: Object.freeze([
@@ -259,9 +559,52 @@ export function buildOverviewSeasonSlug(year) {
   return `${year}\u2013${nextYearPart}_in_English_football`;
 }
 
+function normalizeLeagueLabel(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function seasonIsInRuleRange(rule, seasonNumber) {
+  if (!Number.isFinite(seasonNumber)) return true;
+  if (Number.isFinite(rule.startSeason) && seasonNumber < rule.startSeason) return false;
+  if (Number.isFinite(rule.endSeason) && seasonNumber > rule.endSeason) return false;
+  return true;
+}
+
+export function getWikipediaLeagueLevelRule(label, seasonNumber) {
+  const text = normalizeLeagueLabel(label);
+  if (!text) return null;
+
+  const matches = [];
+  for (const rule of WIKIPEDIA_LEAGUE_LEVEL_RULES) {
+    if (!seasonIsInRuleRange(rule, seasonNumber)) continue;
+    for (const leagueLabel of rule.labels) {
+      const normalizedLabel = normalizeLeagueLabel(leagueLabel);
+      if (normalizedLabel && text.includes(normalizedLabel)) {
+        matches.push({ rule, matchLength: normalizedLabel.length });
+      }
+    }
+  }
+
+  matches.sort((a, b) => b.matchLength - a.matchLength);
+  return matches[0]?.rule || null;
+}
+
+export function getWikipediaLeagueStructureSpecialCases(seasonNumber) {
+  if (!Number.isFinite(seasonNumber)) return [];
+  const specialCases = WIKIPEDIA_LEAGUE_STRUCTURE_SPECIAL_SEASONS[seasonNumber];
+  return specialCases ? [...specialCases] : [];
+}
+
 export function inferEnglishLeagueTier(label, seasonNumber) {
   const text = String(label || '').toLowerCase();
   if (!text.trim()) return null;
+
+  const configuredRule = getWikipediaLeagueLevelRule(label, seasonNumber);
+  if (configuredRule) return configuredRule.level;
 
   if (WIKIPEDIA_OVERVIEW_CONFIG.topFlightKeywords.some((keyword) => text.includes(keyword))) {
     return 1;

--- a/wikipedia/data/build-release-notes.js
+++ b/wikipedia/data/build-release-notes.js
@@ -5,7 +5,7 @@ import * as fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { getTierKeys, sortSeasonKeys } from './season-rules.js';
-import { loadFootballData } from './generate-output-files.js';
+import { loadFootballData } from './generate-output-files.ts';
 
 const RELEASE_ASSETS = [
   'all-seasons.json',

--- a/wikipedia/data/combine-output-files.js
+++ b/wikipedia/data/combine-output-files.js
@@ -11,7 +11,7 @@ import {
   mergeClubsMap,
   normaliseClubsMap,
   saveFootballData,
-} from './generate-output-files.js';
+} from './generate-output-files.ts';
 import {
   getSeasonCompetitionStatus,
   normaliseGoalDifference,

--- a/wikipedia/data/compare-football-data.js
+++ b/wikipedia/data/compare-football-data.js
@@ -3,7 +3,7 @@
 import { Command } from 'commander';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { loadFootballData } from './generate-output-files.js';
+import { loadFootballData } from './generate-output-files.ts';
 import { canonicalizeTeamName } from './data-quality-config.js';
 import { getTierKeys as getTierKeysFromRules, sortSeasonKeys } from './season-rules.js';
 

--- a/wikipedia/data/dataset-store.js
+++ b/wikipedia/data/dataset-store.js
@@ -3,7 +3,7 @@ import {
   loadFootballData,
   saveFootballData,
   setSeasonRecord,
-} from './generate-output-files.js';
+} from './generate-output-files.ts';
 
 export function createDatasetStore(filePath, { generator, buildOptions } = {}) {
   const dataset = loadFootballData(filePath);

--- a/wikipedia/data/generate-club-metadata-seed.js
+++ b/wikipedia/data/generate-club-metadata-seed.js
@@ -14,7 +14,7 @@ import {
   TEMPORAL_CLUB_IDENTITY_RULES,
 } from './club-identity-config.js';
 import { canonicalizeTeamName, normalizeTeamNameText } from './data-quality-config.js';
-import { buildDatasetMetadata, loadFootballData, normaliseClubsMap } from './generate-output-files.js';
+import { buildDatasetMetadata, loadFootballData, normaliseClubsMap } from './generate-output-files.ts';
 import { getTierKeys, getTierTable, sortSeasonKeys } from './season-rules.js';
 
 const DEFAULT_INPUT_FILE = './data-output/all-seasons.json';

--- a/wikipedia/data/generate-club-metadata-seed.js
+++ b/wikipedia/data/generate-club-metadata-seed.js
@@ -528,8 +528,8 @@ function isOfficialCompetitionPausedSeason(seasonRecord) {
 }
 
 /**
- * @param {import('./models/output-file').FootballData} dataset
- * @returns {import('./models/output-file').ClubsMap}
+ * @param {import('../models/output-file.ts').FootballData} dataset
+ * @returns {import('../models/output-file.ts').ClubsMap}
  */
 export function buildClubMetadataSeed(dataset) {
   const clubs = new Map();

--- a/wikipedia/data/generate-output-files.js
+++ b/wikipedia/data/generate-output-files.js
@@ -6,15 +6,15 @@ import * as path from 'node:path';
 import { WIKIPEDIA_DATA_SOURCES } from '../config.js';
 import { isExpansionTeam, wasPromoted, wasRelegated } from '../utils.js';
 
-/** @typedef {import('./models/output-file').LeagueTableEntry} LeagueTableEntry */
-/** @typedef {import('./models/output-file').TierData} TierData */
-/** @typedef {import('./models/output-file').SeasonData} SeasonData */
-/** @typedef {import('./models/output-file').SeasonsMap} SeasonsMap */
-/** @typedef {import('./models/output-file').FootballData} FootballData */
-/** @typedef {import('./models/output-file').SeasonInfo} SeasonInfo */
-/** @typedef {import('./models/output-file').DatasetMetadata} DatasetMetadata */
-/** @typedef {import('./models/output-file').ClubMetadata} ClubMetadata */
-/** @typedef {import('./models/output-file').ClubsMap} ClubsMap */
+/** @typedef {import('../models/output-file.ts').LeagueTableEntry} LeagueTableEntry */
+/** @typedef {import('../models/output-file.ts').TierData} TierData */
+/** @typedef {import('../models/output-file.ts').SeasonData} SeasonData */
+/** @typedef {import('../models/output-file.ts').SeasonsMap} SeasonsMap */
+/** @typedef {import('../models/output-file.ts').FootballData} FootballData */
+/** @typedef {import('../models/output-file.ts').SeasonInfo} SeasonInfo */
+/** @typedef {import('../models/output-file.ts').DatasetMetadata} DatasetMetadata */
+/** @typedef {import('../models/output-file.ts').ClubMetadata} ClubMetadata */
+/** @typedef {import('../models/output-file.ts').ClubsMap} ClubsMap */
 
 const NUMBER_FIELDS = [
   'pos',

--- a/wikipedia/data/generate-output-files.ts
+++ b/wikipedia/data/generate-output-files.ts
@@ -6,12 +6,12 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
 import {
-  isTierData,
   normaliseOutcomeList,
   normaliseTierData,
   normaliseTierMetadata,
   sanitizeRows,
 } from './output-tier-normalizer.ts';
+import { normaliseSeasonInfo, normaliseSeasonRecord } from './output-season-normalizer.ts';
 export { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
 
 /** @typedef {import('../models/output-file.ts').LeagueTableEntry} LeagueTableEntry */
@@ -708,105 +708,6 @@ export function buildDatasetMetadata({
     sourceFiles,
     buildOptions,
   });
-}
-
-/**
- * @param {Record<string, unknown>} seasonInfoValue
- * @param {string} seasonKey
- * @returns {SeasonInfo}
- */
-function normaliseSeasonInfo(seasonInfoValue, seasonKey) {
-  const parsedSeason = Number.parseInt(String(seasonInfoValue.season ?? seasonKey), 10);
-  const fallbackSeason = Number.parseInt(seasonKey, 10);
-  const season = Number.isFinite(parsedSeason)
-    ? parsedSeason
-    : Number.isFinite(fallbackSeason)
-    ? fallbackSeason
-    : 0;
-
-  const specialCompetitions = Array.isArray(seasonInfoValue.specialCompetitions)
-    ? Array.from(
-        new Set(
-          seasonInfoValue.specialCompetitions
-            .map((value) => toStringValue(value))
-            .filter((value) => value != null)
-        )
-      )
-    : [];
-
-  return /** @type {SeasonInfo} */ ({
-    season,
-    table: [],
-    relegated: normaliseOutcomeList(seasonInfoValue.relegated, [], 'wasRelegated'),
-    promoted: normaliseOutcomeList(seasonInfoValue.promoted, [], 'wasPromoted'),
-    seasonSlug: toStringValue(seasonInfoValue.seasonSlug),
-    sourceUrl: toStringValue(seasonInfoValue.sourceUrl),
-    tableCount: Number.isFinite(Number(seasonInfoValue.tableCount))
-      ? Number(seasonInfoValue.tableCount)
-      : null,
-    competitionStatus: toStringValue(seasonInfoValue.competitionStatus),
-    warSuspensionLabel: toStringValue(seasonInfoValue.warSuspensionLabel),
-    officialLeagueTables:
-      typeof seasonInfoValue.officialLeagueTables === 'boolean'
-        ? seasonInfoValue.officialLeagueTables
-        : null,
-    officialCompetitionsSuspended:
-      typeof seasonInfoValue.officialCompetitionsSuspended === 'boolean'
-        ? seasonInfoValue.officialCompetitionsSuspended
-        : null,
-    officialCompetitionsAbandoned:
-      typeof seasonInfoValue.officialCompetitionsAbandoned === 'boolean'
-        ? seasonInfoValue.officialCompetitionsAbandoned
-        : null,
-    regionalBridgeSeason:
-      typeof seasonInfoValue.regionalBridgeSeason === 'boolean'
-        ? seasonInfoValue.regionalBridgeSeason
-        : null,
-    promotionRelegationApplies:
-      typeof seasonInfoValue.promotionRelegationApplies === 'boolean'
-        ? seasonInfoValue.promotionRelegationApplies
-        : null,
-    specialCompetitions,
-    notes: toStringValue(seasonInfoValue.notes),
-  });
-}
-
-/**
- * Normalise raw season data into a SeasonData map.
- * @param {Record<string, unknown>} seasonValue
- * @param {string} seasonKey
- * @returns {SeasonData}
- */
-function normaliseSeasonRecord(seasonValue, seasonKey) {
-  /** @type {SeasonData} */
-  const result = {};
-  const entries = seasonValue && typeof seasonValue === 'object' ? seasonValue : {};
-
-  for (const [tierKey, tierValue] of Object.entries(entries)) {
-    if (
-      tierKey === 'seasonInfo' &&
-      tierValue &&
-      typeof tierValue === 'object' &&
-      !Array.isArray(tierValue)
-    ) {
-      result[tierKey] = normaliseSeasonInfo(
-        /** @type {Record<string, unknown>} */ (tierValue),
-        seasonKey
-      );
-    } else if (Array.isArray(tierValue)) {
-      const sanitized = sanitizeRows(tierValue);
-      result[tierKey] = sanitized.map((row) => normaliseLeagueTableEntry(row));
-    } else if (isTierData(tierValue)) {
-      result[tierKey] = normaliseTierData(tierValue, seasonKey);
-    } else if (tierValue && typeof tierValue === 'object') {
-      result[tierKey] = normaliseTierData(
-        /** @type {Record<string, unknown>} */ (tierValue),
-        seasonKey
-      );
-    }
-  }
-
-  return result;
 }
 
 /**

--- a/wikipedia/data/generate-output-files.ts
+++ b/wikipedia/data/generate-output-files.ts
@@ -1,9 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment -- TODO: remove as generator normalizers are typed incrementally.
 // @ts-nocheck
 
-import { execSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { buildDatasetMetadata, normaliseDatasetMetadata } from './output-dataset-metadata.ts';
 import { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
 import {
   normaliseOutcomeList,
@@ -12,6 +12,7 @@ import {
   sanitizeRows,
 } from './output-tier-normalizer.ts';
 import { normaliseSeasonInfo, normaliseSeasonRecord } from './output-season-normalizer.ts';
+export { buildDatasetMetadata } from './output-dataset-metadata.ts';
 export { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
 
 /** @typedef {import('../models/output-file.ts').LeagueTableEntry} LeagueTableEntry */
@@ -23,9 +24,6 @@ export { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
 /** @typedef {import('../models/output-file.ts').DatasetMetadata} DatasetMetadata */
 /** @typedef {import('../models/output-file.ts').ClubMetadata} ClubMetadata */
 /** @typedef {import('../models/output-file.ts').ClubsMap} ClubsMap */
-
-const DATASET_SCHEMA_VERSION = 1;
-let cachedGitSha;
 
 /**
  * @param {unknown} value
@@ -61,43 +59,6 @@ function toSeasonNumberOrNull(value) {
   if (value == null || value === '') return null;
   const parsed = Number.parseInt(String(value), 10);
   return Number.isFinite(parsed) ? parsed : null;
-}
-
-function normalizeBuildOptions(value) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
-  const entries = Object.entries(value)
-    .map(([key, entry]) => {
-      if (entry == null) return [key, null];
-      if (['string', 'number', 'boolean'].includes(typeof entry)) return [key, entry];
-      return null;
-    })
-    .filter(Boolean);
-
-  if (!entries.length) return undefined;
-  return Object.fromEntries(entries);
-}
-
-function normaliseDatasetMetadata(value) {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
-
-  const schemaVersion = Number(value.schemaVersion);
-  const metadata = {
-    schemaVersion: Number.isFinite(schemaVersion) ? schemaVersion : DATASET_SCHEMA_VERSION,
-    generator: toStringValue(value.generator),
-    generatedAt: toStringValue(value.generatedAt),
-    gitSha: toStringValue(value.gitSha),
-    sourceFiles: normalizeStringArray(value.sourceFiles),
-    buildOptions: normalizeBuildOptions(value.buildOptions),
-  };
-
-  return Object.fromEntries(
-    Object.entries(metadata).filter(([, entry]) => {
-      if (entry == null) return false;
-      if (Array.isArray(entry)) return entry.length > 0;
-      if (typeof entry === 'object') return Object.keys(entry).length > 0;
-      return true;
-    })
-  );
 }
 
 /**
@@ -675,39 +636,6 @@ export function mergeClubsMap(target, source) {
   }
 
   return merged;
-}
-
-function getCurrentGitSha(cwd = process.cwd()) {
-  if (cachedGitSha !== undefined) return cachedGitSha;
-
-  try {
-    cachedGitSha = execSync('git rev-parse --short HEAD', {
-      cwd,
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-  } catch {
-    cachedGitSha = null;
-  }
-
-  return cachedGitSha;
-}
-
-export function buildDatasetMetadata({
-  generator,
-  sourceFiles,
-  buildOptions,
-  generatedAt = new Date().toISOString(),
-  gitSha = getCurrentGitSha(),
-} = {}) {
-  return normaliseDatasetMetadata({
-    schemaVersion: DATASET_SCHEMA_VERSION,
-    generator,
-    generatedAt,
-    gitSha,
-    sourceFiles,
-    buildOptions,
-  });
 }
 
 /**

--- a/wikipedia/data/generate-output-files.ts
+++ b/wikipedia/data/generate-output-files.ts
@@ -5,7 +5,8 @@ import { execSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { WIKIPEDIA_DATA_SOURCES } from '../config.js';
-import { isExpansionTeam, wasPromoted, wasRelegated } from '../utils.js';
+import { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
+export { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
 
 /** @typedef {import('../models/output-file.ts').LeagueTableEntry} LeagueTableEntry */
 /** @typedef {import('../models/output-file.ts').TierData} TierData */
@@ -17,42 +18,8 @@ import { isExpansionTeam, wasPromoted, wasRelegated } from '../utils.js';
 /** @typedef {import('../models/output-file.ts').ClubMetadata} ClubMetadata */
 /** @typedef {import('../models/output-file.ts').ClubsMap} ClubsMap */
 
-const NUMBER_FIELDS = [
-  'pos',
-  'played',
-  'won',
-  'drawn',
-  'lost',
-  'goalsFor',
-  'goalsAgainst',
-  'points',
-];
-const OPTIONAL_NUMBER_FIELDS = ['goalDifference', 'goalAverage'];
-const BOOLEAN_FIELDS = [
-  'wasRelegated',
-  'wasPromoted',
-  'isExpansionTeam',
-  'wasReElected',
-  'wasReprieved',
-];
 const DATASET_SCHEMA_VERSION = 1;
 let cachedGitSha;
-
-/**
- * @param {string | number | null | undefined} value
- * @param {boolean} allowNull
- */
-function toNumber(value, allowNull) {
-  if (value == null || value === '') {
-    if (allowNull) return null;
-    return 0;
-  }
-
-  const parsed = Number(value);
-  if (Number.isFinite(parsed)) return parsed;
-
-  throw new TypeError(`Expected numeric value, received: ${value}`);
-}
 
 /**
  * @param {unknown} value
@@ -738,22 +705,6 @@ export function buildDatasetMetadata({
 }
 
 /**
- * @param {unknown} value
- */
-function toBoolean(value) {
-  if (typeof value === 'boolean') return value;
-  if (value == null) return false;
-  if (typeof value === 'number') return value !== 0;
-  if (typeof value === 'string') {
-    const normalized = value.trim().toLowerCase();
-    if (!normalized.length) return false;
-    if (['true', 'yes', 'y', 'promoted', 'relegated'].includes(normalized)) return true;
-    if (['false', 'no', 'n'].includes(normalized)) return false;
-  }
-  return Boolean(value);
-}
-
-/**
  * Ensure we have a string array with no duplicates.
  * @param {unknown} value
  * @param {LeagueTableEntry[]} fallbackRows
@@ -798,99 +749,6 @@ function sanitizeRows(rows) {
   }
 
   return sanitized;
-}
-
-/**
- * Normalise a single league table entry.
- * @param {Partial<LeagueTableEntry> & Record<string, unknown>} raw
- * @returns {LeagueTableEntry}
- */
-export function normaliseLeagueTableEntry(raw) {
-  if (!raw || typeof raw !== 'object') {
-    throw new TypeError('Expected an object to normalise LeagueTableEntry');
-  }
-
-  /** @type {Record<string, unknown>} */
-  const record = { ...raw };
-  const notes = toStringValue(record.notes);
-
-  for (const key of NUMBER_FIELDS) {
-    record[key] = toNumber(record[key], false);
-  }
-  for (const key of OPTIONAL_NUMBER_FIELDS) {
-    record[key] = toNumber(record[key], true);
-  }
-
-  const goalsForNumber = Number.isFinite(record.goalsFor) ? record.goalsFor : null;
-  const goalsAgainstNumber = Number.isFinite(record.goalsAgainst) ? record.goalsAgainst : null;
-  if (goalsForNumber != null && goalsAgainstNumber != null) {
-    record.goalDifference = goalsForNumber - goalsAgainstNumber;
-  }
-
-  const teamName = toStringValue(record.team);
-  if (!teamName) {
-    throw new TypeError('League table entry is missing a team name');
-  }
-
-  record.team = teamName;
-  record.notes = notes;
-
-  const derivedRelegated = wasRelegated(notes);
-  const derivedPromoted = wasPromoted(notes);
-  const derivedExpansion = isExpansionTeam(notes);
-  const derivedReElected = notes ? notes.toLowerCase().includes('re-elected') : false;
-  const derivedReprieved = notes
-    ? /repriv(?:ed|e)d from re-election/i.test(notes.toLowerCase())
-    : false;
-
-  for (const key of BOOLEAN_FIELDS) {
-    const value = record[key];
-    if (typeof value === 'boolean') continue;
-
-    switch (key) {
-      case 'wasRelegated':
-        record[key] = derivedRelegated;
-        break;
-      case 'wasPromoted':
-        record[key] = derivedPromoted;
-        break;
-      case 'isExpansionTeam':
-        record[key] = derivedExpansion;
-        break;
-      case 'wasReElected':
-        record[key] = derivedReElected;
-        break;
-      case 'wasReprieved':
-        record[key] = derivedReprieved;
-        break;
-      default:
-        record[key] = false;
-    }
-  }
-
-  for (const key of BOOLEAN_FIELDS) {
-    record[key] = toBoolean(record[key]);
-  }
-
-  return /** @type {LeagueTableEntry} */ ({
-    pos: record.pos,
-    team: record.team,
-    played: record.played,
-    won: record.won,
-    drawn: record.drawn,
-    lost: record.lost,
-    goalsFor: record.goalsFor,
-    goalsAgainst: record.goalsAgainst,
-    goalDifference: record.goalDifference,
-    goalAverage: record.goalAverage,
-    points: record.points,
-    notes: record.notes,
-    wasRelegated: record.wasRelegated,
-    wasPromoted: record.wasPromoted,
-    isExpansionTeam: record.isExpansionTeam,
-    wasReElected: record.wasReElected,
-    wasReprieved: record.wasReprieved,
-  });
 }
 
 /**

--- a/wikipedia/data/generate-output-files.ts
+++ b/wikipedia/data/generate-output-files.ts
@@ -4,8 +4,14 @@
 import { execSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { WIKIPEDIA_DATA_SOURCES } from '../config.js';
 import { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
+import {
+  isTierData,
+  normaliseOutcomeList,
+  normaliseTierData,
+  normaliseTierMetadata,
+  sanitizeRows,
+} from './output-tier-normalizer.ts';
 export { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
 
 /** @typedef {import('../models/output-file.ts').LeagueTableEntry} LeagueTableEntry */
@@ -705,120 +711,6 @@ export function buildDatasetMetadata({
 }
 
 /**
- * Ensure we have a string array with no duplicates.
- * @param {unknown} value
- * @param {LeagueTableEntry[]} fallbackRows
- * @param {'wasRelegated' | 'wasPromoted'} flag
- */
-function normaliseOutcomeList(value, fallbackRows, flag) {
-  /** @type {Set<string>} */
-  const results = new Set();
-
-  if (Array.isArray(value)) {
-    for (const entry of value) {
-      const name = toStringValue(entry);
-      if (name) results.add(name);
-    }
-  }
-
-  if (!results.size && fallbackRows.length) {
-    for (const row of fallbackRows) {
-      if (row[flag] && toStringValue(row.team)) {
-        results.add(row.team);
-      }
-    }
-  }
-
-  return Array.from(results);
-}
-
-/**
- * Remove malformed rows and ensure every row has a team name before normalisation.
- * @param {Array<Partial<LeagueTableEntry> & Record<string, unknown>>} rows
- */
-function sanitizeRows(rows) {
-  const list = Array.isArray(rows) ? rows : [];
-  /** @type {Array<Partial<LeagueTableEntry> & Record<string, unknown>>} */
-  const sanitized = [];
-
-  for (const row of list) {
-    if (!row || typeof row !== 'object') continue;
-    const teamName = toStringValue(row.team);
-    if (!teamName) continue;
-    sanitized.push({ ...row, team: teamName });
-  }
-
-  return sanitized;
-}
-
-/**
- * @param {unknown} tierValue
- * @returns {tierValue is TierData}
- */
-function isTierData(tierValue) {
-  return (
-    tierValue != null &&
-    typeof tierValue === 'object' &&
-    'season' in tierValue &&
-    'table' in tierValue
-  );
-}
-
-/**
- * @param {Record<string, unknown>} value
- */
-function normaliseTierMetadata(value) {
-  const directMetadata =
-    value.metadata && typeof value.metadata === 'object'
-      ? { .../** @type {Record<string, unknown>} */ (value.metadata) }
-      : {};
-  const legacySeasonMetadata =
-    value.seasonMetadata && typeof value.seasonMetadata === 'object'
-      ? { .../** @type {Record<string, unknown>} */ (value.seasonMetadata) }
-      : {};
-
-  const metadata = {
-    ...directMetadata,
-  };
-
-  if (value.sourceUrl != null && metadata.sourceUrl == null) {
-    metadata.sourceUrl = value.sourceUrl;
-  }
-  if (value.seasonSlug != null && metadata.seasonSlug == null) {
-    metadata.seasonSlug = value.seasonSlug;
-  }
-  if (value.tier != null && metadata.tierKey == null) {
-    metadata.tierKey = value.tier;
-  }
-  if (value.title != null && metadata.title == null) {
-    metadata.title = value.title;
-  }
-  if (legacySeasonMetadata.leagueId != null && metadata.leagueId == null) {
-    metadata.leagueId = legacySeasonMetadata.leagueId;
-  }
-  if (legacySeasonMetadata.tableIndex != null && metadata.tableIndex == null) {
-    metadata.tableIndex = legacySeasonMetadata.tableIndex;
-  }
-  if (legacySeasonMetadata.tableCount != null && metadata.tableCount == null) {
-    metadata.tableCount = legacySeasonMetadata.tableCount;
-  }
-  if (legacySeasonMetadata.seasonSlug != null && metadata.seasonSlug == null) {
-    metadata.seasonSlug = legacySeasonMetadata.seasonSlug;
-  }
-
-  if (metadata.source == null) {
-    if (metadata.leagueId != null || metadata.title != null || value.seasonMetadata != null) {
-      metadata.source = WIKIPEDIA_DATA_SOURCES.overview.sourceId;
-    } else if (metadata.sourceUrl != null || metadata.tierKey != null) {
-      metadata.source = WIKIPEDIA_DATA_SOURCES.promotion.sourceId;
-    }
-  }
-
-  const cleaned = Object.fromEntries(Object.entries(metadata).filter(([, entry]) => entry != null));
-  return Object.keys(cleaned).length ? cleaned : undefined;
-}
-
-/**
  * @param {Record<string, unknown>} seasonInfoValue
  * @param {string} seasonKey
  * @returns {SeasonInfo}
@@ -876,46 +768,6 @@ function normaliseSeasonInfo(seasonInfoValue, seasonKey) {
         : null,
     specialCompetitions,
     notes: toStringValue(seasonInfoValue.notes),
-  });
-}
-
-/**
- * @param {Record<string, unknown>} tierValue
- * @param {string} seasonKey
- */
-function normaliseTierData(tierValue, seasonKey) {
-  const table = sanitizeRows(tierValue.table);
-  const normalisedTable = table.map((row) => normaliseLeagueTableEntry(row));
-
-  const parsedSeason = Number.parseInt(String(tierValue.season ?? seasonKey), 10);
-  const fallbackSeason = Number.parseInt(seasonKey, 10);
-  const season = Number.isFinite(parsedSeason)
-    ? parsedSeason
-    : Number.isFinite(fallbackSeason)
-    ? fallbackSeason
-    : 0;
-
-  const extra = { ...tierValue };
-  delete extra.table;
-  delete extra.season;
-  delete extra.relegated;
-  delete extra.promoted;
-  delete extra.metadata;
-  delete extra.sourceUrl;
-  delete extra.seasonSlug;
-  delete extra.tier;
-  delete extra.title;
-  delete extra.seasonMetadata;
-
-  const metadata = normaliseTierMetadata(tierValue);
-
-  return /** @type {TierData} */ ({
-    ...extra,
-    season,
-    table: normalisedTable,
-    relegated: normaliseOutcomeList(tierValue.relegated, normalisedTable, 'wasRelegated'),
-    promoted: normaliseOutcomeList(tierValue.promoted, normalisedTable, 'wasPromoted'),
-    ...(metadata ? { metadata } : {}),
   });
 }
 

--- a/wikipedia/data/generate-output-files.ts
+++ b/wikipedia/data/generate-output-files.ts
@@ -1,8 +1,17 @@
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- TODO: remove as generator normalizers are typed incrementally.
-// @ts-nocheck
-
+/* eslint-disable @typescript-eslint/no-explicit-any -- Club metadata normalization accepts legacy schema-loose JSON input. */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import type {
+  ClubMetadata,
+  ClubsMap,
+  DatasetMetadata,
+  FootballData,
+  LeagueTableEntry,
+  SeasonData,
+  SeasonInfo,
+  SeasonsMap,
+  TierData,
+} from '../models/output-file.ts';
 import { buildDatasetMetadata, normaliseDatasetMetadata } from './output-dataset-metadata.ts';
 import { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
 import {
@@ -15,39 +24,47 @@ import { normaliseSeasonInfo, normaliseSeasonRecord } from './output-season-norm
 export { buildDatasetMetadata } from './output-dataset-metadata.ts';
 export { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
 
-/** @typedef {import('../models/output-file.ts').LeagueTableEntry} LeagueTableEntry */
-/** @typedef {import('../models/output-file.ts').TierData} TierData */
-/** @typedef {import('../models/output-file.ts').SeasonData} SeasonData */
-/** @typedef {import('../models/output-file.ts').SeasonsMap} SeasonsMap */
-/** @typedef {import('../models/output-file.ts').FootballData} FootballData */
-/** @typedef {import('../models/output-file.ts').SeasonInfo} SeasonInfo */
-/** @typedef {import('../models/output-file.ts').DatasetMetadata} DatasetMetadata */
-/** @typedef {import('../models/output-file.ts').ClubMetadata} ClubMetadata */
-/** @typedef {import('../models/output-file.ts').ClubsMap} ClubsMap */
+type AnyRecord = Record<string, any>;
+type SaveFootballDataOptions = {
+  pretty?: boolean | number;
+  metadata?: DatasetMetadata | Record<string, unknown>;
+};
+type BuildTierDataOptions = {
+  promoted?: unknown;
+  relegated?: unknown;
+  metadata?: Record<string, unknown>;
+};
+type BuildSeasonInfoOptions = {
+  promoted?: unknown;
+  relegated?: unknown;
+  metadata?: Record<string, unknown>;
+};
 
 /**
  * @param {unknown} value
  */
-function toStringValue(value) {
+function toStringValue(value: unknown): string | null {
   if (value == null) return null;
   const text = String(value).trim();
   return text.length ? text : null;
 }
 
-function normalizeStringArray(value) {
+function normalizeStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) return [];
   return Array.from(
-    new Set(value.map((entry) => toStringValue(entry)).filter((entry) => entry != null))
+    new Set(
+      value.map((entry) => toStringValue(entry)).filter((entry): entry is string => entry != null)
+    )
   );
 }
 
-function normalizeSeasonNumberArray(value) {
+function normalizeSeasonNumberArray(value: unknown): number[] {
   if (!Array.isArray(value)) return [];
   return Array.from(
     new Set(
       value
         .map((entry) => toSeasonNumberOrNull(entry))
-        .filter((entry) => Number.isInteger(entry))
+        .filter((entry): entry is number => Number.isInteger(entry))
     )
   ).sort((a, b) => a - b);
 }
@@ -55,7 +72,7 @@ function normalizeSeasonNumberArray(value) {
 /**
  * @param {unknown} value
  */
-function toSeasonNumberOrNull(value) {
+function toSeasonNumberOrNull(value: unknown): number | null {
   if (value == null || value === '') return null;
   const parsed = Number.parseInt(String(value), 10);
   return Number.isFinite(parsed) ? parsed : null;
@@ -64,10 +81,10 @@ function toSeasonNumberOrNull(value) {
 /**
  * @param {unknown} value
  */
-function normaliseClubNameHistory(value) {
+function normaliseClubNameHistory(value: any): any[] {
   if (!Array.isArray(value)) return [];
   const seen = new Set();
-  const history = [];
+  const history: AnyRecord[] = [];
 
   for (const item of value) {
     if (!item || typeof item !== 'object') continue;
@@ -95,9 +112,9 @@ function normaliseClubNameHistory(value) {
 /**
  * @param {unknown} value
  */
-function normaliseClubFinancialEvents(value) {
+function normaliseClubFinancialEvents(value: any): any[] {
   if (!Array.isArray(value)) return [];
-  const events = [];
+  const events: AnyRecord[] = [];
   const seen = new Set();
 
   for (const item of value) {
@@ -108,9 +125,9 @@ function normaliseClubFinancialEvents(value) {
     const seasonsMissed = Array.isArray(item.seasonsMissed)
       ? Array.from(
           new Set(
-            item.seasonsMissed
-              .map((entry) => toSeasonNumberOrNull(entry))
-              .filter((entry) => Number.isInteger(entry))
+            (item.seasonsMissed as unknown[])
+              .map((entry: unknown) => toSeasonNumberOrNull(entry))
+              .filter((entry): entry is number => Number.isInteger(entry))
           )
         ).sort((a, b) => a - b)
       : [];
@@ -142,9 +159,9 @@ function normaliseClubFinancialEvents(value) {
 /**
  * @param {unknown} value
  */
-function normaliseClubLifecycleEvents(value) {
+function normaliseClubLifecycleEvents(value: any): any[] {
   if (!Array.isArray(value)) return [];
-  const events = [];
+  const events: AnyRecord[] = [];
   const seen = new Set();
 
   for (const item of value) {
@@ -195,9 +212,9 @@ function normaliseClubLifecycleEvents(value) {
 /**
  * @param {unknown} value
  */
-function normaliseClubTrackedMembership(value) {
+function normaliseClubTrackedMembership(value: any): any[] {
   if (!Array.isArray(value)) return [];
-  const memberships = [];
+  const memberships: AnyRecord[] = [];
   const seen = new Set();
 
   for (const item of value) {
@@ -235,9 +252,9 @@ function normaliseClubTrackedMembership(value) {
 /**
  * @param {unknown} value
  */
-function normaliseClubAbsenceExplanations(value) {
+function normaliseClubAbsenceExplanations(value: any): any[] {
   if (!Array.isArray(value)) return [];
-  const explanations = [];
+  const explanations: AnyRecord[] = [];
   const seen = new Set();
 
   for (const item of value) {
@@ -276,7 +293,7 @@ function normaliseClubAbsenceExplanations(value) {
 /**
  * @param {unknown} value
  */
-function normaliseClubHistory(value) {
+function normaliseClubHistory(value: any): AnyRecord {
   const source = value && typeof value === 'object' && !Array.isArray(value) ? value : {};
   return {
     nameHistory: normaliseClubNameHistory(source.nameHistory),
@@ -289,7 +306,7 @@ function normaliseClubHistory(value) {
 /**
  * @param {unknown} value
  */
-function normaliseClubStatus(value) {
+function normaliseClubStatus(value: any): AnyRecord | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
   const current = toStringValue(value.current);
   const status = {
@@ -318,9 +335,9 @@ function normaliseClubStatus(value) {
 /**
  * @param {unknown} value
  */
-function normaliseObservedNamePeriods(value) {
+function normaliseObservedNamePeriods(value: any): any[] {
   if (!Array.isArray(value)) return [];
-  const periods = [];
+  const periods: AnyRecord[] = [];
 
   for (const item of value) {
     if (!item || typeof item !== 'object') continue;
@@ -337,9 +354,9 @@ function normaliseObservedNamePeriods(value) {
 /**
  * @param {unknown} value
  */
-function normaliseObservedNames(value) {
+function normaliseObservedNames(value: any): any[] {
   if (!Array.isArray(value)) return [];
-  const names = [];
+  const names: AnyRecord[] = [];
 
   for (const item of value) {
     if (!item || typeof item !== 'object') continue;
@@ -365,9 +382,9 @@ function normaliseObservedNames(value) {
 /**
  * @param {unknown} value
  */
-function normaliseIdentitySources(value) {
+function normaliseIdentitySources(value: any): any[] {
   if (!Array.isArray(value)) return [];
-  const sources = [];
+  const sources: AnyRecord[] = [];
   const seen = new Set();
 
   for (const item of value) {
@@ -397,9 +414,9 @@ function normaliseIdentitySources(value) {
 /**
  * @param {unknown} value
  */
-function normaliseClubRelationships(value) {
+function normaliseClubRelationships(value: any): any[] {
   if (!Array.isArray(value)) return [];
-  const relationships = [];
+  const relationships: AnyRecord[] = [];
   const seen = new Set();
 
   for (const item of value) {
@@ -443,9 +460,9 @@ function normaliseClubRelationships(value) {
 /**
  * @param {unknown} value
  */
-function normaliseTierSeasons(value) {
+function normaliseTierSeasons(value: any): any[] {
   if (!Array.isArray(value)) return [];
-  const tiers = [];
+  const tiers: AnyRecord[] = [];
 
   for (const item of value) {
     if (!item || typeof item !== 'object') continue;
@@ -461,9 +478,9 @@ function normaliseTierSeasons(value) {
 /**
  * @param {unknown} value
  */
-function normaliseCoverageGaps(value) {
+function normaliseCoverageGaps(value: any): any[] {
   if (!Array.isArray(value)) return [];
-  const gaps = [];
+  const gaps: AnyRecord[] = [];
 
   for (const item of value) {
     if (!item || typeof item !== 'object') continue;
@@ -480,7 +497,7 @@ function normaliseCoverageGaps(value) {
 /**
  * @param {unknown} value
  */
-function normaliseClubDerivedMetadata(value) {
+function normaliseClubDerivedMetadata(value: any): AnyRecord | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
 
   const seasonsSeen = normalizeSeasonNumberArray(value.seasonsSeen);
@@ -519,7 +536,7 @@ function normaliseClubDerivedMetadata(value) {
  * @param {string} fallbackKey
  * @returns {ClubMetadata | null}
  */
-function normaliseClubRecord(value, fallbackKey) {
+function normaliseClubRecord(value: any, fallbackKey: string): ClubMetadata | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
 
   const canonicalName = toStringValue(value.canonicalName) || toStringValue(fallbackKey);
@@ -566,18 +583,17 @@ function normaliseClubRecord(value, fallbackKey) {
     })
   );
 
-  return /** @type {ClubMetadata} */ (cleaned);
+  return cleaned as unknown as ClubMetadata;
 }
 
 /**
  * @param {unknown} value
  * @returns {ClubsMap | undefined}
  */
-export function normaliseClubsMap(value) {
+export function normaliseClubsMap(value: any): ClubsMap | undefined {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
 
-  /** @type {ClubsMap} */
-  const clubs = {};
+  const clubs: ClubsMap = {};
 
   for (const [key, clubValue] of Object.entries(value)) {
     const normalized = normaliseClubRecord(clubValue, key);
@@ -593,13 +609,15 @@ export function normaliseClubsMap(value) {
  * @param {ClubsMap | undefined} source
  * @returns {ClubsMap | undefined}
  */
-export function mergeClubsMap(target, source) {
+export function mergeClubsMap(
+  target: ClubsMap | undefined,
+  source: ClubsMap | undefined
+): ClubsMap | undefined {
   if (!source || !Object.keys(source).length) return target;
   if (!target || !Object.keys(target).length) return { ...source };
 
-  /** @type {ClubsMap} */
-  const merged = { ...target };
-  const sourceEntries = Object.entries(source);
+  const merged: ClubsMap = { ...target };
+  const sourceEntries = Object.entries(source) as [string, ClubMetadata][];
 
   for (const [clubKey, incomingClub] of sourceEntries) {
     const existingClub = merged[clubKey];
@@ -643,7 +661,7 @@ export function mergeClubsMap(target, source) {
  * @param {Partial<FootballData> | Record<string, unknown>} [initial]
  * @returns {FootballData}
  */
-export function createFootballData(initial) {
+export function createFootballData(initial: Partial<FootballData> | Record<string, unknown> = {}): FootballData {
   const metadata =
     initial && typeof initial === 'object' && 'metadata' in initial
       ? normaliseDatasetMetadata(initial.metadata)
@@ -652,19 +670,18 @@ export function createFootballData(initial) {
     initial && typeof initial === 'object' && 'clubs' in initial
       ? normaliseClubsMap(initial.clubs)
       : undefined;
-  const seasonsSource =
+  const seasonsSource: Record<string, unknown> =
     initial && typeof initial === 'object' && 'seasons' in initial
-      ? /** @type {Record<string, unknown>} */ (initial?.seasons)
+      ? ((initial as AnyRecord).seasons as Record<string, unknown>)
       : initial && typeof initial === 'object' && ('clubs' in initial || 'metadata' in initial)
-      ? {}
-      : /** @type {Record<string, unknown>} */ (initial || {});
+        ? {}
+        : (initial as Record<string, unknown>);
 
-  /** @type {SeasonsMap} */
-  const seasons = {};
+  const seasons: SeasonsMap = {};
   for (const [seasonKey, seasonValue] of Object.entries(seasonsSource)) {
     if (!seasonValue || typeof seasonValue !== 'object') continue;
     seasons[seasonKey] = normaliseSeasonRecord(
-      /** @type {Record<string, unknown>} */ (seasonValue),
+      seasonValue as Record<string, unknown>,
       seasonKey
     );
   }
@@ -687,7 +704,11 @@ export function createFootballData(initial) {
  * }} [options]
  * @returns {TierData}
  */
-export function buildTierData(season, tableRows, options = {}) {
+export function buildTierData(
+  season: string | number,
+  tableRows: Array<Partial<LeagueTableEntry> & Record<string, unknown>>,
+  options: BuildTierDataOptions = {}
+): TierData {
   const seasonNumber = Number.parseInt(String(season), 10);
   const safeSeason = Number.isFinite(seasonNumber) ? seasonNumber : 0;
   const sanitizedRows = sanitizeRows(tableRows);
@@ -696,12 +717,12 @@ export function buildTierData(season, tableRows, options = {}) {
   const promoted = normaliseOutcomeList(options.promoted, normalizedTable, 'wasPromoted');
   const relegated = normaliseOutcomeList(options.relegated, normalizedTable, 'wasRelegated');
 
-  const tierData = /** @type {TierData} */ ({
+  const tierData: TierData = {
     season: safeSeason,
     table: normalizedTable,
     promoted,
     relegated,
-  });
+  };
 
   if (options.metadata && typeof options.metadata === 'object') {
     const metadata = normaliseTierMetadata({ metadata: options.metadata });
@@ -723,7 +744,10 @@ export function buildTierData(season, tableRows, options = {}) {
  * }} [options]
  * @returns {SeasonInfo}
  */
-export function buildSeasonInfo(season, options = {}) {
+export function buildSeasonInfo(
+  season: string | number,
+  options: BuildSeasonInfoOptions = {}
+): SeasonInfo {
   const seasonNumber = Number.parseInt(String(season), 10);
   const safeSeason = Number.isFinite(seasonNumber) ? seasonNumber : 0;
 
@@ -744,11 +768,11 @@ export function buildSeasonInfo(season, options = {}) {
  * @param {FootballData} data
  * @param {string} seasonKey
  */
-function ensureSeason(data, seasonKey) {
+function ensureSeason(data: FootballData, seasonKey: string): SeasonData {
   if (!data.seasons[seasonKey]) {
-    data.seasons[seasonKey] = /** @type {SeasonData} */ ({});
+    data.seasons[seasonKey] = {} as SeasonData;
   }
-  return /** @type {SeasonData} */ (data.seasons[seasonKey]);
+  return data.seasons[seasonKey] as SeasonData;
 }
 
 /**
@@ -758,7 +782,12 @@ function ensureSeason(data, seasonKey) {
  * @param {string} tierKey
  * @param {TierData | LeagueTableEntry[]} tierValue
  */
-export function upsertSeasonTier(dataset, seasonKey, tierKey, tierValue) {
+export function upsertSeasonTier(
+  dataset: FootballData,
+  seasonKey: string | number,
+  tierKey: string,
+  tierValue: TierData | LeagueTableEntry[]
+): FootballData {
   if (!dataset || typeof dataset !== 'object' || !dataset.seasons) {
     throw new TypeError('Dataset must be a FootballData object');
   }
@@ -767,10 +796,12 @@ export function upsertSeasonTier(dataset, seasonKey, tierKey, tierValue) {
   const seasonRecord = ensureSeason(dataset, key);
 
   if (Array.isArray(tierValue)) {
-    seasonRecord[tierKey] = tierValue.map((row) => normaliseLeagueTableEntry(row));
+    (seasonRecord as AnyRecord)[tierKey] = tierValue.map((row) =>
+      normaliseLeagueTableEntry(row as unknown as Partial<LeagueTableEntry> & Record<string, unknown>)
+    );
   } else if (tierValue && typeof tierValue === 'object') {
-    seasonRecord[tierKey] = normaliseTierData(
-      /** @type {Record<string, unknown>} */ (tierValue),
+    (seasonRecord as AnyRecord)[tierKey] = normaliseTierData(
+      tierValue as unknown as Record<string, unknown>,
       key
     );
   } else {
@@ -786,7 +817,11 @@ export function upsertSeasonTier(dataset, seasonKey, tierKey, tierValue) {
  * @param {string | number} seasonKey
  * @param {SeasonData} seasonValue
  */
-export function setSeasonRecord(dataset, seasonKey, seasonValue) {
+export function setSeasonRecord(
+  dataset: FootballData,
+  seasonKey: string | number,
+  seasonValue: SeasonData
+): FootballData {
   if (!dataset || typeof dataset !== 'object') {
     throw new TypeError('Dataset must be a FootballData object');
   }
@@ -804,7 +839,7 @@ export function setSeasonRecord(dataset, seasonKey, seasonValue) {
  * @param {FootballData} target
  * @param {FootballData} source
  */
-export function mergeFootballData(target, source) {
+export function mergeFootballData(target: FootballData, source: FootballData): FootballData {
   if (!target || !target.seasons) {
     throw new TypeError('Target must include a seasons map');
   }
@@ -829,13 +864,13 @@ export function mergeFootballData(target, source) {
  * @param {string} filePath
  * @returns {FootballData}
  */
-export function loadFootballData(filePath) {
+export function loadFootballData(filePath: string): FootballData {
   try {
     const raw = fs.readFileSync(filePath, 'utf8');
     const parsed = JSON.parse(raw);
     return createFootballData(parsed);
-  } catch (err) {
-    if (err && /** @type {{ code?: string }} */ (err).code === 'ENOENT') {
+  } catch (err: any) {
+    if (err && err.code === 'ENOENT') {
       return createFootballData();
     }
     throw err;
@@ -848,7 +883,11 @@ export function loadFootballData(filePath) {
  * @param {FootballData} data
  * @param {{ pretty?: boolean | number, metadata?: DatasetMetadata | Record<string, unknown> }} [options]
  */
-export function saveFootballData(filePath, data, options) {
+export function saveFootballData(
+  filePath: string,
+  data: FootballData,
+  options?: SaveFootballDataOptions
+): void {
   const pretty = options?.pretty ?? true;
   const spacing = typeof pretty === 'number' ? pretty : pretty ? 2 : 0;
   const metadata = options?.metadata
@@ -874,7 +913,13 @@ export function saveFootballData(filePath, data, options) {
  * @param {{ pretty?: boolean | number }} [options]
  * @returns {FootballData}
  */
-export function updateFootballDataFile(filePath, seasonKey, tierKey, tierValue, options) {
+export function updateFootballDataFile(
+  filePath: string,
+  seasonKey: string | number,
+  tierKey: string,
+  tierValue: TierData | LeagueTableEntry[],
+  options?: SaveFootballDataOptions
+): FootballData {
   const footballData = loadFootballData(filePath);
   upsertSeasonTier(footballData, seasonKey, tierKey, tierValue);
   saveFootballData(filePath, footballData, options);

--- a/wikipedia/data/generate-output-files.ts
+++ b/wikipedia/data/generate-output-files.ts
@@ -1,4 +1,5 @@
-// @ts-check
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment -- TODO: remove as generator normalizers are typed incrementally.
+// @ts-nocheck
 
 import { execSync } from 'node:child_process';
 import * as fs from 'node:fs';

--- a/wikipedia/data/output-dataset-metadata.ts
+++ b/wikipedia/data/output-dataset-metadata.ts
@@ -1,0 +1,104 @@
+import { execSync } from 'node:child_process';
+import type { DatasetMetadata } from '../models/output-file.ts';
+
+type BuildOptionValue = string | number | boolean | null;
+
+export const DATASET_SCHEMA_VERSION = 1;
+
+let cachedGitSha: string | null | undefined;
+
+function toStringValue(value: unknown): string | null {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text.length ? text : null;
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return Array.from(
+    new Set(value.map((entry) => toStringValue(entry)).filter((entry): entry is string => entry != null))
+  );
+}
+
+function normalizeBuildOptions(value: unknown): Record<string, BuildOptionValue> | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const entries = Object.entries(value)
+    .map(([key, entry]): [string, BuildOptionValue] | null => {
+      if (entry == null) return [key, null];
+      if (['string', 'number', 'boolean'].includes(typeof entry)) {
+        return [key, entry as string | number | boolean];
+      }
+      return null;
+    })
+    .filter((entry): entry is [string, BuildOptionValue] => entry != null);
+
+  if (!entries.length) return undefined;
+  return Object.fromEntries(entries);
+}
+
+export function normaliseDatasetMetadata(value: unknown): DatasetMetadata | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+
+  const source = value as Record<string, unknown>;
+  const schemaVersion = Number(source.schemaVersion);
+  const metadata: DatasetMetadata = {
+    schemaVersion: Number.isFinite(schemaVersion) ? schemaVersion : DATASET_SCHEMA_VERSION,
+    generator: toStringValue(source.generator),
+    generatedAt: toStringValue(source.generatedAt),
+    gitSha: toStringValue(source.gitSha),
+    sourceFiles: normalizeStringArray(source.sourceFiles),
+    buildOptions: normalizeBuildOptions(source.buildOptions),
+  };
+
+  const cleaned = Object.fromEntries(
+    Object.entries(metadata).filter(([, entry]) => {
+      if (entry == null) return false;
+      if (Array.isArray(entry)) return entry.length > 0;
+      if (typeof entry === 'object') return Object.keys(entry).length > 0;
+      return true;
+    })
+  );
+
+  return Object.keys(cleaned).length ? (cleaned as DatasetMetadata) : undefined;
+}
+
+function getCurrentGitSha(cwd = process.cwd()): string | null {
+  if (cachedGitSha !== undefined) return cachedGitSha;
+
+  try {
+    cachedGitSha = execSync('git rev-parse --short HEAD', {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    cachedGitSha = null;
+  }
+
+  return cachedGitSha;
+}
+
+export function buildDatasetMetadata({
+  generator,
+  sourceFiles,
+  buildOptions,
+  generatedAt = new Date().toISOString(),
+  gitSha = getCurrentGitSha(),
+}: {
+  generator?: string | null;
+  sourceFiles?: unknown;
+  buildOptions?: unknown;
+  generatedAt?: string | null;
+  gitSha?: string | null;
+} = {}): DatasetMetadata {
+  return (
+    normaliseDatasetMetadata({
+      schemaVersion: DATASET_SCHEMA_VERSION,
+      generator,
+      generatedAt,
+      gitSha,
+      sourceFiles,
+      buildOptions,
+    }) ?? { schemaVersion: DATASET_SCHEMA_VERSION }
+  );
+}

--- a/wikipedia/data/output-entry-normalizer.ts
+++ b/wikipedia/data/output-entry-normalizer.ts
@@ -1,0 +1,166 @@
+import type { LeagueTableEntry } from '../models/output-file.ts';
+import { isExpansionTeam, wasPromoted, wasRelegated } from '../utils.js';
+
+type LeagueTableEntryInput = Partial<LeagueTableEntry> & Record<string, unknown>;
+type NumberField =
+  | 'pos'
+  | 'played'
+  | 'won'
+  | 'drawn'
+  | 'lost'
+  | 'goalsFor'
+  | 'goalsAgainst'
+  | 'points';
+type OptionalNumberField = 'goalDifference' | 'goalAverage';
+type BooleanField =
+  | 'wasRelegated'
+  | 'wasPromoted'
+  | 'isExpansionTeam'
+  | 'wasReElected'
+  | 'wasReprieved';
+
+const NUMBER_FIELDS: readonly NumberField[] = [
+  'pos',
+  'played',
+  'won',
+  'drawn',
+  'lost',
+  'goalsFor',
+  'goalsAgainst',
+  'points',
+];
+const OPTIONAL_NUMBER_FIELDS: readonly OptionalNumberField[] = ['goalDifference', 'goalAverage'];
+const BOOLEAN_FIELDS: readonly BooleanField[] = [
+  'wasRelegated',
+  'wasPromoted',
+  'isExpansionTeam',
+  'wasReElected',
+  'wasReprieved',
+];
+
+function toNumber(value: string | number | null | undefined, allowNull: true): number | null;
+function toNumber(value: string | number | null | undefined, allowNull: false): number;
+function toNumber(value: string | number | null | undefined, allowNull: boolean): number | null {
+  if (value == null || value === '') {
+    if (allowNull) return null;
+    return 0;
+  }
+
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) return parsed;
+
+  throw new TypeError(`Expected numeric value, received: ${value}`);
+}
+
+function toStringValue(value: unknown): string | null {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text.length ? text : null;
+}
+
+function toBoolean(value: unknown): boolean {
+  if (typeof value === 'boolean') return value;
+  if (value == null) return false;
+  if (typeof value === 'number') return value !== 0;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized.length) return false;
+    if (['true', 'yes', 'y', 'promoted', 'relegated'].includes(normalized)) return true;
+    if (['false', 'no', 'n'].includes(normalized)) return false;
+  }
+  return Boolean(value);
+}
+
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value);
+}
+
+/**
+ * Normalise a single league table entry.
+ */
+export function normaliseLeagueTableEntry(raw: LeagueTableEntryInput): LeagueTableEntry {
+  if (!raw || typeof raw !== 'object') {
+    throw new TypeError('Expected an object to normalise LeagueTableEntry');
+  }
+
+  const record: Record<string, unknown> = { ...raw };
+  const notes = toStringValue(record.notes);
+
+  for (const key of NUMBER_FIELDS) {
+    record[key] = toNumber(record[key] as string | number | null | undefined, false);
+  }
+  for (const key of OPTIONAL_NUMBER_FIELDS) {
+    record[key] = toNumber(record[key] as string | number | null | undefined, true);
+  }
+
+  const goalsForNumber = isFiniteNumber(record.goalsFor) ? record.goalsFor : null;
+  const goalsAgainstNumber = isFiniteNumber(record.goalsAgainst) ? record.goalsAgainst : null;
+  if (goalsForNumber != null && goalsAgainstNumber != null) {
+    record.goalDifference = goalsForNumber - goalsAgainstNumber;
+  }
+
+  const teamName = toStringValue(record.team);
+  if (!teamName) {
+    throw new TypeError('League table entry is missing a team name');
+  }
+
+  record.team = teamName;
+  record.notes = notes;
+
+  const derivedRelegated = wasRelegated(notes);
+  const derivedPromoted = wasPromoted(notes);
+  const derivedExpansion = isExpansionTeam(notes);
+  const derivedReElected = notes ? notes.toLowerCase().includes('re-elected') : false;
+  const derivedReprieved = notes
+    ? /repriv(?:ed|e)d from re-election/i.test(notes.toLowerCase())
+    : false;
+
+  for (const key of BOOLEAN_FIELDS) {
+    const value = record[key];
+    if (typeof value === 'boolean') continue;
+
+    switch (key) {
+      case 'wasRelegated':
+        record[key] = derivedRelegated;
+        break;
+      case 'wasPromoted':
+        record[key] = derivedPromoted;
+        break;
+      case 'isExpansionTeam':
+        record[key] = derivedExpansion;
+        break;
+      case 'wasReElected':
+        record[key] = derivedReElected;
+        break;
+      case 'wasReprieved':
+        record[key] = derivedReprieved;
+        break;
+      default:
+        record[key] = false;
+    }
+  }
+
+  for (const key of BOOLEAN_FIELDS) {
+    record[key] = toBoolean(record[key]);
+  }
+
+  return {
+    pos: record.pos as number,
+    team: record.team as string,
+    played: record.played as number,
+    won: record.won as number,
+    drawn: record.drawn as number,
+    lost: record.lost as number,
+    goalsFor: record.goalsFor as number,
+    goalsAgainst: record.goalsAgainst as number,
+    goalDifference: record.goalDifference as number | null,
+    goalAverage: record.goalAverage as number | null,
+    points: record.points as number,
+    notes: record.notes as string | null,
+    wasRelegated: record.wasRelegated as boolean,
+    wasPromoted: record.wasPromoted as boolean,
+    isExpansionTeam: record.isExpansionTeam as boolean,
+    wasReElected: record.wasReElected as boolean,
+    wasReprieved: record.wasReprieved as boolean,
+  };
+}

--- a/wikipedia/data/output-season-normalizer.ts
+++ b/wikipedia/data/output-season-normalizer.ts
@@ -15,6 +15,45 @@ function toStringValue(value: unknown): string | null {
   return text.length ? text : null;
 }
 
+function normalizeNumberList(values: unknown): number[] {
+  if (!Array.isArray(values)) return [];
+  return Array.from(
+    new Set(
+      values
+        .filter((value) => value != null)
+        .map((value) => Number(value))
+        .filter((value): value is number => Number.isFinite(value))
+    )
+  );
+}
+
+function normalizeStringList(values: unknown): string[] {
+  if (!Array.isArray(values)) return [];
+  return Array.from(
+    new Set(
+      values
+        .map((value) => toStringValue(value))
+        .filter((value): value is string => value != null)
+    )
+  );
+}
+
+function normalizeLeagueStructureSpecialCases(values: unknown): SeasonInfo['leagueStructureSpecialCases'] {
+  if (!Array.isArray(values)) return [];
+
+  return values
+    .filter((value): value is Record<string, unknown> => {
+      return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+    })
+    .map((value) => ({
+      type: toStringValue(value.type) || 'unknown',
+      levels: normalizeNumberList(value.levels),
+      tierKeys: normalizeStringList(value.tierKeys),
+      notes: toStringValue(value.notes),
+    }))
+    .filter((value) => value.type !== 'unknown' || value.levels.length || value.tierKeys.length);
+}
+
 export function normaliseSeasonInfo(
   seasonInfoValue: Record<string, unknown>,
   seasonKey: string
@@ -28,13 +67,7 @@ export function normaliseSeasonInfo(
       : 0;
 
   const specialCompetitions = Array.isArray(seasonInfoValue.specialCompetitions)
-    ? Array.from(
-        new Set(
-          seasonInfoValue.specialCompetitions
-            .map((value) => toStringValue(value))
-            .filter((value): value is string => value != null)
-        )
-      )
+    ? normalizeStringList(seasonInfoValue.specialCompetitions)
     : [];
 
   return {
@@ -70,6 +103,9 @@ export function normaliseSeasonInfo(
         ? seasonInfoValue.promotionRelegationApplies
         : null,
     specialCompetitions,
+    leagueStructureSpecialCases: normalizeLeagueStructureSpecialCases(
+      seasonInfoValue.leagueStructureSpecialCases
+    ),
     notes: toStringValue(seasonInfoValue.notes),
   };
 }

--- a/wikipedia/data/output-season-normalizer.ts
+++ b/wikipedia/data/output-season-normalizer.ts
@@ -1,0 +1,106 @@
+import type { LeagueTableEntry, SeasonData, SeasonInfo } from '../models/output-file.ts';
+import { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
+import {
+  isTierData,
+  normaliseOutcomeList,
+  normaliseTierData,
+  sanitizeRows,
+} from './output-tier-normalizer.ts';
+
+type SeasonRecordValue = SeasonInfo | ReturnType<typeof normaliseTierData> | LeagueTableEntry[];
+
+function toStringValue(value: unknown): string | null {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text.length ? text : null;
+}
+
+export function normaliseSeasonInfo(
+  seasonInfoValue: Record<string, unknown>,
+  seasonKey: string
+): SeasonInfo {
+  const parsedSeason = Number.parseInt(String(seasonInfoValue.season ?? seasonKey), 10);
+  const fallbackSeason = Number.parseInt(seasonKey, 10);
+  const season = Number.isFinite(parsedSeason)
+    ? parsedSeason
+    : Number.isFinite(fallbackSeason)
+      ? fallbackSeason
+      : 0;
+
+  const specialCompetitions = Array.isArray(seasonInfoValue.specialCompetitions)
+    ? Array.from(
+        new Set(
+          seasonInfoValue.specialCompetitions
+            .map((value) => toStringValue(value))
+            .filter((value): value is string => value != null)
+        )
+      )
+    : [];
+
+  return {
+    season,
+    table: [],
+    relegated: normaliseOutcomeList(seasonInfoValue.relegated, [], 'wasRelegated'),
+    promoted: normaliseOutcomeList(seasonInfoValue.promoted, [], 'wasPromoted'),
+    seasonSlug: toStringValue(seasonInfoValue.seasonSlug),
+    sourceUrl: toStringValue(seasonInfoValue.sourceUrl),
+    tableCount: Number.isFinite(Number(seasonInfoValue.tableCount))
+      ? Number(seasonInfoValue.tableCount)
+      : null,
+    competitionStatus: toStringValue(seasonInfoValue.competitionStatus),
+    warSuspensionLabel: toStringValue(seasonInfoValue.warSuspensionLabel),
+    officialLeagueTables:
+      typeof seasonInfoValue.officialLeagueTables === 'boolean'
+        ? seasonInfoValue.officialLeagueTables
+        : null,
+    officialCompetitionsSuspended:
+      typeof seasonInfoValue.officialCompetitionsSuspended === 'boolean'
+        ? seasonInfoValue.officialCompetitionsSuspended
+        : null,
+    officialCompetitionsAbandoned:
+      typeof seasonInfoValue.officialCompetitionsAbandoned === 'boolean'
+        ? seasonInfoValue.officialCompetitionsAbandoned
+        : null,
+    regionalBridgeSeason:
+      typeof seasonInfoValue.regionalBridgeSeason === 'boolean'
+        ? seasonInfoValue.regionalBridgeSeason
+        : null,
+    promotionRelegationApplies:
+      typeof seasonInfoValue.promotionRelegationApplies === 'boolean'
+        ? seasonInfoValue.promotionRelegationApplies
+        : null,
+    specialCompetitions,
+    notes: toStringValue(seasonInfoValue.notes),
+  };
+}
+
+/**
+ * Normalise raw season data into a SeasonData map.
+ */
+export function normaliseSeasonRecord(
+  seasonValue: Record<string, unknown>,
+  seasonKey: string
+): SeasonData {
+  const result: Record<string, SeasonRecordValue | undefined> = {};
+  const entries = seasonValue && typeof seasonValue === 'object' ? seasonValue : {};
+
+  for (const [tierKey, tierValue] of Object.entries(entries)) {
+    if (
+      tierKey === 'seasonInfo' &&
+      tierValue &&
+      typeof tierValue === 'object' &&
+      !Array.isArray(tierValue)
+    ) {
+      result[tierKey] = normaliseSeasonInfo(tierValue as Record<string, unknown>, seasonKey);
+    } else if (Array.isArray(tierValue)) {
+      const sanitized = sanitizeRows(tierValue);
+      result[tierKey] = sanitized.map((row) => normaliseLeagueTableEntry(row));
+    } else if (isTierData(tierValue)) {
+      result[tierKey] = normaliseTierData(tierValue as unknown as Record<string, unknown>, seasonKey);
+    } else if (tierValue && typeof tierValue === 'object') {
+      result[tierKey] = normaliseTierData(tierValue as Record<string, unknown>, seasonKey);
+    }
+  }
+
+  return result as unknown as SeasonData;
+}

--- a/wikipedia/data/output-tier-normalizer.ts
+++ b/wikipedia/data/output-tier-normalizer.ts
@@ -1,0 +1,153 @@
+import { WIKIPEDIA_DATA_SOURCES } from '../config.js';
+import type { LeagueTableEntry, TierData, TierMetadata } from '../models/output-file.ts';
+import { normaliseLeagueTableEntry } from './output-entry-normalizer.ts';
+
+type LeagueTableEntryInput = Partial<LeagueTableEntry> & Record<string, unknown>;
+type TierOutcomeFlag = 'wasRelegated' | 'wasPromoted';
+
+function toStringValue(value: unknown): string | null {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text.length ? text : null;
+}
+
+/**
+ * Ensure we have a string array with no duplicates.
+ */
+export function normaliseOutcomeList(
+  value: unknown,
+  fallbackRows: LeagueTableEntry[],
+  flag: TierOutcomeFlag
+): string[] {
+  const results = new Set<string>();
+
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      const name = toStringValue(entry);
+      if (name) results.add(name);
+    }
+  }
+
+  if (!results.size && fallbackRows.length) {
+    for (const row of fallbackRows) {
+      if (row[flag] && toStringValue(row.team)) {
+        results.add(row.team);
+      }
+    }
+  }
+
+  return Array.from(results);
+}
+
+/**
+ * Remove malformed rows and ensure every row has a team name before normalisation.
+ */
+export function sanitizeRows(rows: unknown): LeagueTableEntryInput[] {
+  const list = Array.isArray(rows) ? rows : [];
+  const sanitized: LeagueTableEntryInput[] = [];
+
+  for (const row of list) {
+    if (!row || typeof row !== 'object') continue;
+    const teamName = toStringValue((row as Record<string, unknown>).team);
+    if (!teamName) continue;
+    sanitized.push({ ...(row as Record<string, unknown>), team: teamName });
+  }
+
+  return sanitized;
+}
+
+export function isTierData(tierValue: unknown): tierValue is TierData {
+  return (
+    tierValue != null &&
+    typeof tierValue === 'object' &&
+    'season' in tierValue &&
+    'table' in tierValue
+  );
+}
+
+export function normaliseTierMetadata(value: Record<string, unknown>): TierMetadata | undefined {
+  const directMetadata =
+    value.metadata && typeof value.metadata === 'object'
+      ? { ...(value.metadata as Record<string, unknown>) }
+      : {};
+  const legacySeasonMetadata =
+    value.seasonMetadata && typeof value.seasonMetadata === 'object'
+      ? { ...(value.seasonMetadata as Record<string, unknown>) }
+      : {};
+
+  const metadata: Record<string, unknown> = {
+    ...directMetadata,
+  };
+
+  if (value.sourceUrl != null && metadata.sourceUrl == null) {
+    metadata.sourceUrl = value.sourceUrl;
+  }
+  if (value.seasonSlug != null && metadata.seasonSlug == null) {
+    metadata.seasonSlug = value.seasonSlug;
+  }
+  if (value.tier != null && metadata.tierKey == null) {
+    metadata.tierKey = value.tier;
+  }
+  if (value.title != null && metadata.title == null) {
+    metadata.title = value.title;
+  }
+  if (legacySeasonMetadata.leagueId != null && metadata.leagueId == null) {
+    metadata.leagueId = legacySeasonMetadata.leagueId;
+  }
+  if (legacySeasonMetadata.tableIndex != null && metadata.tableIndex == null) {
+    metadata.tableIndex = legacySeasonMetadata.tableIndex;
+  }
+  if (legacySeasonMetadata.tableCount != null && metadata.tableCount == null) {
+    metadata.tableCount = legacySeasonMetadata.tableCount;
+  }
+  if (legacySeasonMetadata.seasonSlug != null && metadata.seasonSlug == null) {
+    metadata.seasonSlug = legacySeasonMetadata.seasonSlug;
+  }
+
+  if (metadata.source == null) {
+    if (metadata.leagueId != null || metadata.title != null || value.seasonMetadata != null) {
+      metadata.source = WIKIPEDIA_DATA_SOURCES.overview.sourceId;
+    } else if (metadata.sourceUrl != null || metadata.tierKey != null) {
+      metadata.source = WIKIPEDIA_DATA_SOURCES.promotion.sourceId;
+    }
+  }
+
+  const cleaned = Object.fromEntries(Object.entries(metadata).filter(([, entry]) => entry != null));
+  return Object.keys(cleaned).length ? (cleaned as TierMetadata) : undefined;
+}
+
+export function normaliseTierData(tierValue: Record<string, unknown>, seasonKey: string): TierData {
+  const table = sanitizeRows(tierValue.table);
+  const normalisedTable = table.map((row) => normaliseLeagueTableEntry(row));
+
+  const parsedSeason = Number.parseInt(String(tierValue.season ?? seasonKey), 10);
+  const fallbackSeason = Number.parseInt(seasonKey, 10);
+  const season = Number.isFinite(parsedSeason)
+    ? parsedSeason
+    : Number.isFinite(fallbackSeason)
+      ? fallbackSeason
+      : 0;
+
+  const extra = { ...tierValue };
+  delete extra.table;
+  delete extra.season;
+  delete extra.relegated;
+  delete extra.promoted;
+  delete extra.metadata;
+  delete extra.sourceUrl;
+  delete extra.seasonSlug;
+  delete extra.tier;
+  delete extra.title;
+  delete extra.seasonMetadata;
+
+  const metadata = normaliseTierMetadata(tierValue);
+
+  return {
+    ...extra,
+    season,
+    table: normalisedTable,
+    relegated: normaliseOutcomeList(tierValue.relegated, normalisedTable, 'wasRelegated'),
+    promoted: normaliseOutcomeList(tierValue.promoted, normalisedTable, 'wasPromoted'),
+    ...(metadata ? { metadata } : {}),
+  };
+}

--- a/wikipedia/data/season-rules.js
+++ b/wikipedia/data/season-rules.js
@@ -420,11 +420,16 @@ export function reconcileSeasonInfoContinuity(dataset, options = {}) {
 }
 
 export function getExpectedMinimumTierCount(seasonNumber) {
-  if (seasonNumber >= WIKIPEDIA_SEASON_RANGES.premierLeagueStartSeason - 1) return 4;
   if (WIKIPEDIA_MINIMUM_TIER_OVERRIDES[seasonNumber] != null) {
     return WIKIPEDIA_MINIMUM_TIER_OVERRIDES[seasonNumber];
   }
-  if (seasonNumber >= 1888) return 2;
+  if (seasonNumber >= 2021) return 7;
+  if (seasonNumber >= 2012) return 5;
+  if (seasonNumber >= WIKIPEDIA_SEASON_RANGES.fourthDivisionStartSeason) return 4;
+  if (seasonNumber >= WIKIPEDIA_SEASON_RANGES.regionalThirdDivisionStartSeason) return 4;
+  if (seasonNumber >= WIKIPEDIA_SEASON_RANGES.thirdDivisionStartSeason) return 3;
+  if (seasonNumber >= 1890) return 2;
+  if (seasonNumber >= 1888) return 1;
   return null;
 }
 

--- a/wikipedia/data/verify-club-continuity.js
+++ b/wikipedia/data/verify-club-continuity.js
@@ -5,7 +5,7 @@ import { Command } from 'commander';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { loadFootballData } from './generate-output-files.js';
+import { loadFootballData } from './generate-output-files.ts';
 import { isHistoricalPlaceholderSeason, parseSeasonNumber, sortSeasonKeys } from './season-rules.js';
 import { addWikipediaStatusReasonSuggestions } from './suggest-club-status-reasons.js';
 

--- a/wikipedia/data/verify-football-data.js
+++ b/wikipedia/data/verify-football-data.js
@@ -4,7 +4,7 @@ import { Command } from 'commander';
 import * as fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { WIKIPEDIA_DATA_SOURCES } from '../config.js';
+import { getWikipediaLeagueLevelRule, WIKIPEDIA_DATA_SOURCES } from '../config.js';
 import { canonicalizeTeamName } from './data-quality-config.js';
 import { loadFootballData } from './generate-output-files.ts';
 import {
@@ -684,6 +684,7 @@ function analyzeSeasonLeagueOrdering(seasonKey, seasonValue) {
       continue;
     }
     if (inferredTier == null || inferredTier === tierNumber) continue;
+    if (isKnownParallelLeagueSlot(metadata, seasonNumber, inferredTier, tierNumber)) continue;
 
     issues.push(
       createIssue({
@@ -696,6 +697,20 @@ function analyzeSeasonLeagueOrdering(seasonKey, seasonValue) {
   }
 
   return issues;
+}
+
+function isKnownParallelLeagueSlot(metadata, seasonNumber, inferredTier, tierNumber) {
+  if (inferredTier == null || inferredTier >= tierNumber) return false;
+
+  const configuredRule = getWikipediaLeagueLevelRule(
+    `${metadata?.title || ''} ${metadata?.leagueId || ''}`,
+    seasonNumber
+  );
+  if (configuredRule?.parallelGroup) return true;
+
+  const tableIndex = Number(metadata?.tableIndex);
+  const leagueId = String(metadata?.leagueId || '');
+  return seasonNumber >= 2021 && leagueId === 'National_League' && tableIndex > 0;
 }
 
 /**

--- a/wikipedia/data/verify-football-data.js
+++ b/wikipedia/data/verify-football-data.js
@@ -97,7 +97,7 @@ export function analyzeFile(filePath) {
 }
 
 /**
- * @param {import('./models/output-file.js').FootballData} dataset
+ * @param {import('../models/output-file.ts').FootballData} dataset
  * @param {{ profile?: DatasetProfile }} [options]
  * @returns {Issue[]}
  */
@@ -146,7 +146,7 @@ export function analyzeDataset(dataset, options = {}) {
 }
 
 /**
- * @param {import('./models/output-file.js').FootballData} dataset
+ * @param {import('../models/output-file.ts').FootballData} dataset
  * @param {DatasetProfile} profile
  * @returns {Issue[]}
  */
@@ -194,7 +194,7 @@ function analyzeDatasetContract(dataset, profile) {
 /**
  * @param {string} seasonKey
  * @param {string} tierKey
- * @param {import('./models/output-file.js').TierData | import('./models/output-file.js').LeagueTableEntry[]} tierValue
+ * @param {import('../models/output-file.ts').TierData | import('../models/output-file.ts').LeagueTableEntry[]} tierValue
  * @returns {TierAnalysis}
  */
 function analyzeTier(seasonKey, tierKey, tierValue) {
@@ -416,7 +416,7 @@ function analyzeTier(seasonKey, tierKey, tierValue) {
 }
 
 /**
- * @param {import('./models/output-file.js').TierData | import('./models/output-file.js').LeagueTableEntry[]} tierValue
+ * @param {import('../models/output-file.ts').TierData | import('../models/output-file.ts').LeagueTableEntry[]} tierValue
  * @param {string} seasonKey
  */
 function extractTierMeta(tierValue, seasonKey) {
@@ -479,7 +479,7 @@ function isPointsOrderExempt(seasonKey, tierKey) {
 
 /**
  * @param {string} seasonKey
- * @param {import('./models/output-file.js').SeasonData} seasonValue
+ * @param {import('../models/output-file.ts').SeasonData} seasonValue
  * @returns {Issue[]}
  */
 function analyzeSeasonContract(seasonKey, seasonValue) {
@@ -625,7 +625,7 @@ function analyzeSeasonContract(seasonKey, seasonValue) {
 
 /**
  * @param {string} seasonKey
- * @param {import('./models/output-file.js').SeasonData} seasonValue
+ * @param {import('../models/output-file.ts').SeasonData} seasonValue
  * @param {DatasetProfile} profile
  * @returns {Issue[]}
  */
@@ -651,7 +651,7 @@ function analyzeSeasonTierCoverage(seasonKey, seasonValue, profile) {
 
 /**
  * @param {string} seasonKey
- * @param {import('./models/output-file.js').SeasonData} seasonValue
+ * @param {import('../models/output-file.ts').SeasonData} seasonValue
  * @returns {Issue[]}
  */
 function analyzeSeasonLeagueOrdering(seasonKey, seasonValue) {
@@ -699,7 +699,7 @@ function analyzeSeasonLeagueOrdering(seasonKey, seasonValue) {
 }
 
 /**
- * @param {import('./models/output-file.js').FootballData} dataset
+ * @param {import('../models/output-file.ts').FootballData} dataset
  * @param {DatasetProfile} profile
  * @returns {Issue[]}
  */
@@ -772,7 +772,7 @@ function analyzeSeasonContinuity(dataset, profile) {
 }
 
 /**
- * @param {import('./models/output-file.js').FootballData} dataset
+ * @param {import('../models/output-file.ts').FootballData} dataset
  * @returns {DatasetProfile}
  */
 function detectDatasetProfile(dataset) {

--- a/wikipedia/data/verify-football-data.js
+++ b/wikipedia/data/verify-football-data.js
@@ -6,7 +6,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { WIKIPEDIA_DATA_SOURCES } from '../config.js';
 import { canonicalizeTeamName } from './data-quality-config.js';
-import { loadFootballData } from './generate-output-files.js';
+import { loadFootballData } from './generate-output-files.ts';
 import {
   compareSeasonKeys,
   getExpectedMinimumTierCount,

--- a/wikipedia/models/output-file.ts
+++ b/wikipedia/models/output-file.ts
@@ -54,6 +54,14 @@ export interface SeasonInfo {
   regionalBridgeSeason?: boolean | null;
   promotionRelegationApplies?: boolean | null;
   specialCompetitions?: string[];
+  leagueStructureSpecialCases?: LeagueStructureSpecialCase[];
+  notes?: string | null;
+}
+
+export interface LeagueStructureSpecialCase {
+  type: string;
+  levels: number[];
+  tierKeys: string[];
   notes?: string | null;
 }
 


### PR DESCRIPTION
## Summary

- Adds lower-tier league structure metadata and planning docs for upcoming tier 3/4 parser work.
- Teaches the Wikipedia pipeline about historical parallel league structures, special seasons, and expected tier-depth changes.
- Preserves current output semantics while preparing parser, verifier, and UI consumers for `tierN` vs `metadata.leagueLevel` distinctions.

## What Changed

- Added lower-tier coverage and parser-readiness docs.
- Added Wikipedia league level rules and structure special-case config.
- Preserved `leagueStructureSpecialCases` through season normalization and output models.
- Updated overview generation to attach lower-tier structure metadata.
- Updated verifier and season rules for known parallel-slot and historical tier-count behavior.
- Expanded focused tests around overview parsing, output generation, season rules, and verification.

## Validation

- `pnpm test -- --runTestsByPath wikipedia/__tests__/wiki-overview-parser.test.js wikipedia/__tests__/parse-ext-season-overview-pages.test.js wikipedia/__tests__/season-rules.test.js wikipedia/__tests__/generate-output-files.test.js wikipedia/__tests__/verify-football-data.test.js`
- `pnpm wiki:verify`
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
- pre-commit `lint-staged` passed with Prettier and ESLint

## Scope Notes

- This does not regenerate checked-in `data-output/` files.
- This does not backfill tier 5, level 6, or true level 7 data yet.
- The key UI-facing caveat is that `tier4` from 1921-1957 stores Third Division South but represents pyramid level 3.