### PR TITLE
Harden lower-tier release coverage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
           rm -rf data-output
           mkdir -p data-output
           pnpm wiki:build:overview
+          pnpm wiki:build:lower-tiers
           pnpm wiki:build:combined
           pnpm wiki:club-seed
           pnpm wiki:minify:combined

--- a/docs/lower-tier-coverage-analysis.md
+++ b/docs/lower-tier-coverage-analysis.md
@@ -17,13 +17,15 @@ Current coverage by level area:
 | Tier 3       | 1920-2025, excluding WWII gap | Good coverage; 1921-1957 uses `tier3.divisions[]` for North/South |
 | Tier 4       | 1958-2025, excluding WWII gap | True level 4 starts with the 1958 Fourth Division                 |
 | Tier 5       | 1979-2025                     | Backfilled from Alliance/Conference/National League season pages  |
-| Level 6      | 2004-2025                     | Backfilled as `tier6.divisions[]` from North/South season pages   |
+| Level 6      | 1979-2025                     | Backfilled as `tier6.divisions[]` from feeder/North/South pages   |
 | True level 7 | Not really parsed             | Configured but not currently emitted as a v1 coverage target      |
 
 Important modeling rule:
 
 - `tierN` represents the actual pyramid level.
 - From 1921-1957, Third Division North and Third Division South are stored under `tier3.divisions[]`.
+- From 1979-1981, Northern Premier, Southern Midland, Southern Southern, and Isthmian Premier are stored under `tier6.divisions[]`.
+- From 1982-2003, Northern Premier, Southern Premier, and Isthmian Premier are stored under `tier6.divisions[]`.
 - From 2004-2025, Conference/National League North and South are stored under `tier6.divisions[]`.
 
 Recommended lower-tier slice order from the original coverage snapshot:
@@ -209,11 +211,13 @@ Final generated coverage:
 | Area   | Coverage  | Shape                                                                                                                   |
 | ------ | --------- | ----------------------------------------------------------------------------------------------------------------------- |
 | Tier 5 | 1979-2025 | Single `tier5.table` for Alliance Premier League, Football Conference, Conference National/Premier, and National League |
-| Tier 6 | 2004-2025 | Parallel `tier6.divisions[]` for Conference/National League North and South                                             |
+| Tier 6 | 1979-2025 | Parallel `tier6.divisions[]` for pre-2004 feeder leagues, then Conference/National League North and South               |
 
 Dry-run and checked-in output checks confirmed no gaps in either range. The
-2014-15 Conference South table has 21 rows in source output; this is treated as
-an observed source shape rather than a parser failure.
+1979-1981 Southern League split emits separate Midland and Southern divisions;
+1982-2003 emits the Southern Premier division. The 2014-15 Conference South
+table has 21 rows in source output; this is treated as an observed source shape
+rather than a parser failure.
 
 Club metadata sidecar expansion now follows the expanded `all-seasons.json`
 scope. Lower-tier membership is represented as observed stints, and

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -8,18 +8,20 @@ release plan and source of truth.
 1. Finish review and release preparation for the completed phase 0 through
    phase 3 branch in
    [post-v1-phase-0-3-plan.md](/Users/dsteele/repos/footy-data-kit/docs/post-v1-phase-0-3-plan.md).
-2. Review the generated-output diff for the lower-tier backfill: tier 5 now
-   covers 1979-2025 and level 6 now covers 2004-2025.
+2. Review the generated-output diff for the lower-tier backfill: tier 5 and
+   level 6 now both cover 1979-2025.
 3. Continue TypeScript migration with the next implementation slice: convert
    shared config/season-rule boundaries or the parser/builder boundary before
    parser-heavy rewrites.
-4. Decide whether the next data expansion target is true level 7, or a cleanup
-   pass over tier 5/6 metadata and source-diff review.
-5. Work through `data/club-metadata-review.json` to convert lower-tier manual
-   review findings into curated lifecycle/status rules.
-6. Use
+4. Decide whether the next data expansion target is true level 7, or a source
+   spot-check pass over the now-complete tier 5/6 coverage.
+5. Confirm `data/club-metadata-review.json` remains clean after the next data
+   refresh, then convert any new lower-tier manual review findings into curated
+   lifecycle/status rules.
+6. Treat
    [pre-2004-tier6-source-spike.md](/Users/dsteele/repos/footy-data-kit/docs/pre-2004-tier6-source-spike.md)
-   as the source-availability input for the pre-2004 feeder-league backfill.
+   as the completed source-availability input for the pre-2004 feeder-league
+   backfill.
 7. Track confirmed or suspected upstream Wikipedia defects in
    [wikipedia-source-issues.md](/Users/dsteele/repos/footy-data-kit/docs/wikipedia-source-issues.md)
    before adding local workarounds.

--- a/docs/post-v1-phase-0-3-plan.md
+++ b/docs/post-v1-phase-0-3-plan.md
@@ -24,7 +24,7 @@ the checked-in generated output from source pages.
 | Phase 0 | Complete                  | Roadmap and next-work docs now point at the post-v1 baseline and this plan.                                                                                       |
 | Phase 1 | Complete for branch scope | Shared TypeScript contracts exist for Wikipedia tier/config/parser boundaries, with output metadata aligned to those contracts.                                   |
 | Phase 2 | Complete                  | Focused tests lock tier 1-4 boundaries, including 1921/1957 parallel level 3, 1958 true tier 4, 1992 renumbering, 2004 rebrand, and 2019 administrative outcomes. |
-| Phase 3 | Complete for branch scope | Lower-tier competition pages now backfill tier 5 from 1979-2025 and level 6 from 2004-2025; refreshed generated output verifies cleanly.                          |
+| Phase 3 | Complete for branch scope | Lower-tier competition pages now backfill tier 5 and level 6 from 1979-2025; refreshed generated output verifies cleanly.                                         |
 
 Checked-in `data-output/` is intentionally refreshed on this branch after the
 parser/config/test gates and lower-tier dry runs proved the backfill path.
@@ -136,7 +136,7 @@ validation.
 
 1. Backfill level 6 for `2012-2020`, because `tier5` already exists there.
 2. Backfill `tier5` and level 6 for `2004-2011`.
-3. Backfill `tier5` for `1979-2003`.
+3. Backfill `tier5` and pre-2004 feeder-league level 6 for `1979-2003`.
 4. Defer true level 7 until tier 5 and level 6 are vetted.
 
 **Acceptance criteria:**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -62,8 +62,8 @@ Current state:
   [post-v1-phase-0-3-plan.md](./post-v1-phase-0-3-plan.md): reset the planning
   baseline, advance TypeScript contracts, lock tier 1-4 semantics, and backfill
   generated tier 5 and level 6 output from per-competition source pages.
-- Lower-tier generated coverage now includes tier 5 from 1979-2025 and level 6
-  from 2004-2025, with level 6 represented as `tier6.divisions[]`.
+- Lower-tier generated coverage now includes tier 5 and level 6 from 1979-2025,
+  with level 6 represented as `tier6.divisions[]`.
 - Club metadata now regenerates across the expanded season scope, using observed
   membership stints and `data/club-metadata-review.json` for lower-tier status
   findings that need curated rules.

--- a/scripts/release-dry-run-data.js
+++ b/scripts/release-dry-run-data.js
@@ -12,6 +12,7 @@ import { fileURLToPath } from 'node:url';
 const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const DEFAULT_OUTPUT_DIR = path.join(os.tmpdir(), 'footy-data-kit-release-dry-run');
 const DEFAULT_MIN_CLUB_COUNT = 1;
+const LOWER_TIER_START_SEASON = 1979;
 
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
@@ -81,6 +82,17 @@ export function assertReleaseDryRunCompleteness(options) {
   return summary;
 }
 
+export function buildLowerTierDryRunRange(start, end) {
+  const startSeason = parseInteger(start);
+  const endSeason = parseInteger(end);
+  if (endSeason == null || endSeason < LOWER_TIER_START_SEASON) return null;
+
+  return {
+    start: Math.max(startSeason ?? LOWER_TIER_START_SEASON, LOWER_TIER_START_SEASON),
+    end: endSeason,
+  };
+}
+
 function run(command, args, options = {}) {
   const display = [command, ...args].join(' ');
   console.log(`\n$ ${display}`);
@@ -105,6 +117,8 @@ export function runReleaseDryRun({
   const allSeasonsMinFile = path.join(outputDir, 'all-seasons.min.json');
   const overviewMinFile = path.join(outputDir, 'wiki_overview_tables_by_season.min.json');
   const clubMetadataFile = path.join(outputDir, 'club-metadata.json');
+  const clubMetadataReviewFile = path.join(outputDir, 'club-metadata-review.json');
+  const lowerTierRange = buildLowerTierDryRunRange(start, end);
 
   if (!skipClean) {
     fs.rmSync(outputDir, { recursive: true, force: true });
@@ -123,12 +137,29 @@ export function runReleaseDryRun({
     '--force-update',
     '--include-war-placeholders',
   ]);
+  if (lowerTierRange) {
+    run('node', [
+      'wikipedia/cli/index.js',
+      'lower-tiers',
+      '--start',
+      String(lowerTierRange.start),
+      '--end',
+      String(lowerTierRange.end),
+      '--output',
+      outputDir,
+      '--force-update',
+    ]);
+  } else {
+    console.log('\n⏭️ Skipping lower-tier supplements; dry-run range ends before 1979.');
+  }
   run('node', ['wikipedia/data/combine-output-files.js', '--output', allSeasonsFile, overviewFile]);
   run('node', [
     'wikipedia/data/generate-club-metadata-seed.js',
     allSeasonsFile,
     '--output',
     clubMetadataFile,
+    '--review-output',
+    clubMetadataReviewFile,
   ]);
   const completeness = assertReleaseDryRunCompleteness({
     allSeasonsFile,
@@ -204,6 +235,7 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
 
 export default {
   assertReleaseDryRunCompleteness,
+  buildLowerTierDryRunRange,
   buildReleaseDryRunCompletenessSummary,
   runReleaseDryRun,
   runCli,

--- a/wikipedia/__tests__/release-dry-run-data.test.js
+++ b/wikipedia/__tests__/release-dry-run-data.test.js
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import {
   assertReleaseDryRunCompleteness,
+  buildLowerTierDryRunRange,
   buildReleaseDryRunCompletenessSummary,
 } from '../../scripts/release-dry-run-data.js';
 
@@ -84,5 +85,11 @@ describe('release-dry-run-data completeness checks', () => {
         minClubCount: 1,
       })
     ).toThrow('Expected a non-negative integer, got many');
+  });
+
+  test('builds lower-tier dry-run range only for supported release seasons', () => {
+    expect(buildLowerTierDryRunRange('1888', '1978')).toBeNull();
+    expect(buildLowerTierDryRunRange('1888', '2025')).toEqual({ start: 1979, end: 2025 });
+    expect(buildLowerTierDryRunRange('2004', '2014')).toEqual({ start: 2004, end: 2014 });
   });
 });

--- a/wikipedia/__tests__/verify-football-data.test.js
+++ b/wikipedia/__tests__/verify-football-data.test.js
@@ -1447,4 +1447,173 @@ describe('verify-football-data', () => {
 
     expect(issues.map((issue) => issue.type)).toContain('administrative-outcome-mismatch');
   });
+
+  test('analyzeDataset accepts release lower-tier coverage across supported eras', () => {
+    const issues = analyzeDataset(
+      {
+        metadata: {
+          schemaVersion: 1,
+          generator: 'wikipedia-overview',
+          generatedAt: '2026-06-18T00:00:00.000Z',
+        },
+        seasons: {
+          1979: buildLowerTierSeasonFixture(1979, [
+            'northern-premier',
+            'southern-midland',
+            'southern-southern',
+            'isthmian-premier',
+          ]),
+          1982: buildLowerTierSeasonFixture(1982, [
+            'northern-premier',
+            'southern-premier',
+            'isthmian-premier',
+          ]),
+          2004: buildLowerTierSeasonFixture(2004, ['north', 'south'], {
+            parallelGroup: 'conference-north-south',
+          }),
+          2015: buildLowerTierSeasonFixture(2015, ['north', 'south'], {
+            parallelGroup: 'national-league-north-south',
+          }),
+        },
+      },
+      { enforceLowerTierCoverage: true }
+    );
+
+    expect(issues.filter((issue) => issue.type.startsWith('lower-tier'))).toEqual([]);
+    expect(issues.filter((issue) => issue.type.startsWith('missing-lower-tier'))).toEqual([]);
+  });
+
+  test('analyzeDataset reports malformed release lower-tier coverage', () => {
+    const malformedSeason = buildLowerTierSeasonFixture(1982, ['northern-premier', 'isthmian']);
+    malformedSeason.tier5.metadata.leagueLevel = 4;
+    malformedSeason.tier6.metadata.divisionCount = 3;
+    malformedSeason.tier6.divisions[0].table = buildRows(10, 'Short Division');
+
+    const issues = analyzeDataset(
+      {
+        metadata: {
+          schemaVersion: 1,
+          generator: 'wikipedia-overview',
+          generatedAt: '2026-06-18T00:00:00.000Z',
+        },
+        seasons: {
+          1979: {
+            seasonInfo: {
+              season: 1979,
+              table: [],
+              promoted: [],
+              relegated: [],
+            },
+            tier5: buildSingleTierFixture(1979, 'tier5', 5, 'Alliance Premier League'),
+          },
+          1982: malformedSeason,
+        },
+      },
+      { enforceLowerTierCoverage: true }
+    );
+
+    expect(issues.map((issue) => issue.type)).toEqual(
+      expect.arrayContaining([
+        'missing-lower-tier-coverage',
+        'lower-tier-level-mismatch',
+        'lower-tier-division-count-mismatch',
+        'lower-tier-division-key-mismatch',
+        'lower-tier-row-count-mismatch',
+      ])
+    );
+  });
 });
+
+function buildLowerTierSeasonFixture(season, divisionKeys, options = {}) {
+  const parallelGroup = options.parallelGroup || 'pre-2004-conference-feeders';
+  return {
+    seasonInfo: {
+      season,
+      table: [],
+      promoted: [],
+      relegated: [],
+    },
+    tier5: buildSingleTierFixture(season, 'tier5', 5, 'National League System Top Division'),
+    tier6: {
+      season,
+      promoted: [],
+      relegated: [],
+      metadata: {
+        source: 'wikipedia-overview',
+        seasonSlug: `${season}-lower-tier-fixture`,
+        sourceUrl: `https://example.com/${season}`,
+        tierKey: 'tier6',
+        title: 'Lower-tier parallel leagues',
+        leagueLevel: 6,
+        structure: 'parallel-leagues',
+        parallelGroup,
+        divisionCount: divisionKeys.length,
+        tableCount: divisionKeys.length,
+      },
+      divisions: divisionKeys.map((divisionKey) => ({
+        season,
+        table: buildRows(20, divisionKey),
+        promoted: [],
+        relegated: [],
+        metadata: {
+          source: 'wikipedia-overview',
+          seasonSlug: `${season}-lower-tier-fixture`,
+          sourceUrl: `https://example.com/${season}`,
+          tierKey: 'tier6',
+          title: divisionKey,
+          leagueId: divisionKey,
+          leagueLevel: 6,
+          structure: 'single-league',
+          parallelGroup,
+          divisionKey,
+          tableIndex: 0,
+          tableCount: 1,
+        },
+      })),
+    },
+  };
+}
+
+function buildSingleTierFixture(season, tierKey, leagueLevel, title) {
+  return {
+    season,
+    table: buildRows(20, title),
+    promoted: [],
+    relegated: [],
+    metadata: {
+      source: 'wikipedia-overview',
+      seasonSlug: `${season}-${tierKey}-fixture`,
+      sourceUrl: `https://example.com/${season}`,
+      tierKey,
+      title,
+      leagueId: title.replaceAll(' ', '_'),
+      leagueLevel,
+      tableIndex: 0,
+      tableCount: 1,
+      structure: 'single-league',
+    },
+  };
+}
+
+function buildRows(count, prefix) {
+  return Array.from({ length: count }, (_, index) => ({
+    pos: index + 1,
+    team: `${prefix} ${index + 1}`,
+    played: 38,
+    won: count - index,
+    drawn: 0,
+    lost: 38 - (count - index),
+    goalsFor: count * 2 - index,
+    goalsAgainst: index,
+    goalDifference: count * 2 - index * 2,
+    goalAverage: null,
+    points: (count - index) * 3,
+    notes: null,
+    wasRelegated: false,
+    wasPromoted: false,
+    isExpansionTeam: false,
+    wasReElected: false,
+    wasReprieved: false,
+    outcomeStatus: null,
+  }));
+}

--- a/wikipedia/data/verify-football-data.js
+++ b/wikipedia/data/verify-football-data.js
@@ -47,6 +47,39 @@ const CONTINUITY_CONFIG = {
   seasonPromotedPath: 'promoted',
   seasonRelegatedPath: 'relegated',
 };
+const LOWER_TIER_CONTRACT_START_SEASON = 1979;
+const LOWER_TIER_FULL_EXPORT_MIN_SEASONS = 100;
+const LOWER_TIER_MIN_TABLE_ROWS = 18;
+const LOWER_TIER_CONTRACTS = Object.freeze([
+  Object.freeze({
+    startSeason: 1979,
+    endSeason: 1981,
+    parallelGroup: 'pre-2004-conference-feeders',
+    divisionKeys: Object.freeze([
+      'northern-premier',
+      'southern-midland',
+      'southern-southern',
+      'isthmian-premier',
+    ]),
+  }),
+  Object.freeze({
+    startSeason: 1982,
+    endSeason: 2003,
+    parallelGroup: 'pre-2004-conference-feeders',
+    divisionKeys: Object.freeze(['northern-premier', 'southern-premier', 'isthmian-premier']),
+  }),
+  Object.freeze({
+    startSeason: 2004,
+    endSeason: 2014,
+    parallelGroup: 'conference-north-south',
+    divisionKeys: Object.freeze(['north', 'south']),
+  }),
+  Object.freeze({
+    startSeason: 2015,
+    parallelGroup: 'national-league-north-south',
+    divisionKeys: Object.freeze(['north', 'south']),
+  }),
+]);
 
 /**
  * @param {string[]} targets
@@ -218,6 +251,10 @@ export function analyzeDataset(dataset, options = {}) {
     for (const tierAnalysis of tierAnalyses) {
       issues.push(...tierAnalysis.issues);
     }
+  }
+
+  if (shouldAnalyzeLowerTierCoverageContract(seasonEntries, profile, options)) {
+    issues.push(...analyzeLowerTierCoverageContract(dataset, seasonEntries));
   }
 
   issues.push(...analyzeSeasonContinuity(dataset, profile));
@@ -1085,6 +1122,243 @@ function isKnownParallelLeagueSlot(metadata, seasonNumber, inferredTier, tierNum
   const tableIndex = Number(metadata?.tableIndex);
   const leagueId = String(metadata?.leagueId || '');
   return seasonNumber >= 2021 && leagueId === 'National_League' && tableIndex > 0;
+}
+
+/**
+ * @param {Array<[string, import('../models/output-file.ts').SeasonData]>} seasonEntries
+ * @param {DatasetProfile} profile
+ * @param {{ enforceLowerTierCoverage?: boolean }} options
+ */
+function shouldAnalyzeLowerTierCoverageContract(seasonEntries, profile, options) {
+  if (profile.kind === 'promotion-only') return false;
+  if (options.enforceLowerTierCoverage === true) return true;
+  if (options.enforceLowerTierCoverage === false) return false;
+
+  const seasonNumbers = seasonEntries
+    .map(([seasonKey]) => parseSeasonNumber(seasonKey))
+    .filter((seasonNumber) => seasonNumber != null);
+
+  return (
+    seasonEntries.length >= LOWER_TIER_FULL_EXPORT_MIN_SEASONS &&
+    seasonNumbers.includes(LOWER_TIER_CONTRACT_START_SEASON)
+  );
+}
+
+/**
+ * @param {import('../models/output-file.ts').FootballData} dataset
+ * @param {Array<[string, import('../models/output-file.ts').SeasonData]>} seasonEntries
+ * @returns {Issue[]}
+ */
+function analyzeLowerTierCoverageContract(_dataset, seasonEntries) {
+  /** @type {Issue[]} */
+  const issues = [];
+
+  for (const [seasonKey, seasonValue] of seasonEntries) {
+    if (isHistoricalPlaceholderSeason(seasonValue, seasonKey)) continue;
+
+    const seasonNumber = parseSeasonNumber(seasonKey);
+    if (seasonNumber == null || seasonNumber < LOWER_TIER_CONTRACT_START_SEASON) continue;
+
+    issues.push(...analyzeTierFiveContract(seasonKey, seasonValue.tier5));
+    issues.push(...analyzeTierSixContract(seasonKey, seasonNumber, seasonValue.tier6));
+  }
+
+  return issues;
+}
+
+function analyzeTierFiveContract(seasonKey, tierValue) {
+  /** @type {Issue[]} */
+  const issues = [];
+  if (!tierValue || typeof tierValue !== 'object' || Array.isArray(tierValue)) {
+    return [
+      createIssue({
+        type: 'missing-lower-tier-coverage',
+        season: seasonKey,
+        tier: 'tier5',
+        message: 'Expected tier5 National League System coverage for this season',
+      }),
+    ];
+  }
+
+  const rows = getTierRows(tierValue);
+  if (rows.length < LOWER_TIER_MIN_TABLE_ROWS) {
+    issues.push(
+      createIssue({
+        type: 'lower-tier-row-count-mismatch',
+        season: seasonKey,
+        tier: 'tier5',
+        message: `Expected tier5 to contain a full league table, found ${rows.length} rows`,
+      })
+    );
+  }
+
+  issues.push(...analyzeLowerTierMetadataContract(seasonKey, 'tier5', tierValue.metadata, 5));
+  return issues;
+}
+
+function analyzeTierSixContract(seasonKey, seasonNumber, tierValue) {
+  /** @type {Issue[]} */
+  const issues = [];
+  const contract = getTierSixContract(seasonNumber);
+
+  if (!tierValue || typeof tierValue !== 'object' || Array.isArray(tierValue)) {
+    return [
+      createIssue({
+        type: 'missing-lower-tier-coverage',
+        season: seasonKey,
+        tier: 'tier6',
+        message: 'Expected tier6 parallel lower-tier coverage for this season',
+      }),
+    ];
+  }
+
+  issues.push(...analyzeLowerTierMetadataContract(seasonKey, 'tier6', tierValue.metadata, 6));
+
+  const metadata = tierValue.metadata || {};
+  if (metadata.structure !== 'parallel-leagues') {
+    issues.push(
+      createIssue({
+        type: 'lower-tier-structure-mismatch',
+        season: seasonKey,
+        tier: 'tier6',
+        message: 'Expected tier6 to use metadata.structure "parallel-leagues"',
+      })
+    );
+  }
+
+  if (contract && metadata.parallelGroup !== contract.parallelGroup) {
+    issues.push(
+      createIssue({
+        type: 'lower-tier-parallel-group-mismatch',
+        season: seasonKey,
+        tier: 'tier6',
+        message: `Expected tier6 parallelGroup ${contract.parallelGroup}, found ${
+          metadata.parallelGroup || 'missing'
+        }`,
+      })
+    );
+  }
+
+  const divisions = Array.isArray(tierValue.divisions) ? tierValue.divisions : [];
+  if (!divisions.length) {
+    issues.push(
+      createIssue({
+        type: 'missing-lower-tier-divisions',
+        season: seasonKey,
+        tier: 'tier6',
+        message: 'Expected tier6.divisions[] to contain parallel league tables',
+      })
+    );
+    return issues;
+  }
+
+  if (metadata.divisionCount != null && Number(metadata.divisionCount) !== divisions.length) {
+    issues.push(
+      createIssue({
+        type: 'lower-tier-division-count-mismatch',
+        season: seasonKey,
+        tier: 'tier6',
+        message: `metadata.divisionCount (${metadata.divisionCount}) does not match divisions length (${divisions.length})`,
+      })
+    );
+  }
+
+  if (contract) {
+    const actualDivisionKeys = divisions.map((division) => division?.metadata?.divisionKey);
+    const missingDivisionKeys = contract.divisionKeys.filter(
+      (divisionKey) => !actualDivisionKeys.includes(divisionKey)
+    );
+    const unexpectedDivisionKeys = actualDivisionKeys.filter(
+      (divisionKey) => divisionKey && !contract.divisionKeys.includes(divisionKey)
+    );
+
+    if (missingDivisionKeys.length || unexpectedDivisionKeys.length) {
+      issues.push(
+        createIssue({
+          type: 'lower-tier-division-key-mismatch',
+          season: seasonKey,
+          tier: 'tier6',
+          message: `Expected tier6 divisions ${contract.divisionKeys.join(', ')}; missing ${
+            missingDivisionKeys.join(', ') || 'none'
+          }; unexpected ${unexpectedDivisionKeys.join(', ') || 'none'}`,
+        })
+      );
+    }
+  }
+
+  divisions.forEach((division, index) => {
+    const divisionKey = division?.metadata?.divisionKey || `division-${index + 1}`;
+    const tierLabel = `tier6:${divisionKey}`;
+    issues.push(...analyzeLowerTierMetadataContract(seasonKey, tierLabel, division?.metadata, 6));
+
+    const rows = getTierRows(division);
+    if (rows.length < LOWER_TIER_MIN_TABLE_ROWS) {
+      issues.push(
+        createIssue({
+          type: 'lower-tier-row-count-mismatch',
+          season: seasonKey,
+          tier: tierLabel,
+          message: `Expected ${tierLabel} to contain a full league table, found ${rows.length} rows`,
+        })
+      );
+    }
+  });
+
+  return issues;
+}
+
+function getTierSixContract(seasonNumber) {
+  return (
+    LOWER_TIER_CONTRACTS.find((contract) => {
+      if (seasonNumber < contract.startSeason) return false;
+      return contract.endSeason == null || seasonNumber <= contract.endSeason;
+    }) || null
+  );
+}
+
+function analyzeLowerTierMetadataContract(seasonKey, tierLabel, metadata, expectedLeagueLevel) {
+  /** @type {Issue[]} */
+  const issues = [];
+
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return [
+      createIssue({
+        type: 'missing-lower-tier-metadata',
+        season: seasonKey,
+        tier: tierLabel,
+        message: 'Expected lower-tier metadata to describe source, tier key, and league level',
+      }),
+    ];
+  }
+
+  const expectedTierKey = tierLabel.startsWith('tier5') ? 'tier5' : 'tier6';
+  if (metadata.tierKey !== expectedTierKey) {
+    issues.push(
+      createIssue({
+        type: 'lower-tier-metadata-mismatch',
+        season: seasonKey,
+        tier: tierLabel,
+        message: `Expected metadata.tierKey ${expectedTierKey}, found ${
+          metadata.tierKey || 'missing'
+        }`,
+      })
+    );
+  }
+
+  if (Number(metadata.leagueLevel) !== expectedLeagueLevel) {
+    issues.push(
+      createIssue({
+        type: 'lower-tier-level-mismatch',
+        season: seasonKey,
+        tier: tierLabel,
+        message: `Expected leagueLevel ${expectedLeagueLevel}, found ${
+          metadata.leagueLevel || 'missing'
+        }`,
+      })
+    );
+  }
+
+  return issues;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds release-gate coverage checks for lower-tier data before the next data release.
- Updates release build automation so regenerated release assets include lower-tier supplements.

## What Changed
- Added verifier coverage for tier5/tier6 `1979-2025`, including era-specific tier6 division groups.
- Added focused Jest coverage for valid and malformed lower-tier release shapes.
- Updated release dry-run flow to run `lower-tiers` before combining data.
- Updated official release workflow to run `pnpm wiki:build:lower-tiers`.
- Kept dry-run club metadata review output inside the temp dry-run directory.
- Updated planning docs to reflect tier5 and tier6 coverage from `1979-2025`.

## Validation
- `fnm exec --using=22.22.1 -- pnpm -s test:jest -- --runTestsByPath wikipedia/__tests__/verify-football-data.test.js`
- `fnm exec --using=22.22.1 -- pnpm -s test:jest -- --runTestsByPath wikipedia/__tests__/release-dry-run-data.test.js`
- `fnm exec --using=22.22.1 -- pnpm -s lint`
- `fnm exec --using=22.22.1 -- pnpm -s verify:data`
- `fnm exec --using=22.22.1 -- pnpm -s docs:check`
- `fnm exec --using=22.22.1 -- pnpm -s release:dry-run-data --output /tmp/footy-data-kit-release-dry-run-full --min-season-count 138 --min-club-count 1`

## Scope Notes
- No release notes were changed.
- Full release-style dry run completed with `138` seasons, `375` club metadata records, and `0` club metadata review issues.
- Branch is clean and pushed to `origin/codex/lower-tier-hardening`.