### PR TITLE
Add club crest asset metadata and review workflow

### DIFF
--- a/data/club-assets-review.json
+++ b/data/club-assets-review.json
@@ -2,8 +2,8 @@
   "metadata": {
     "schemaVersion": 1,
     "generator": "club-assets-review",
-    "generatedAt": "2026-06-20T20:01:39.482Z",
-    "gitSha": "b94ecf2",
+    "generatedAt": "2026-06-20T21:13:53.189Z",
+    "gitSha": "4f08010",
     "sourceFiles": [
       "/Users/dsteele/repos/footy-data-kit-club-assets/data/club-metadata.json"
     ],
@@ -13,75 +13,15 @@
     }
   },
   "clubCount": 375,
-  "issueCount": 458,
+  "issueCount": 386,
   "issueCounts": {
-    "club-asset-identity-uncertain": 25,
+    "club-asset-identity-uncertain": 6,
     "club-asset-license-restricted": 338,
-    "club-asset-missing": 7,
-    "club-asset-multiple-review-candidates": 30,
-    "club-asset-non-crest-candidate": 58
+    "club-asset-multiple-review-candidates": 11,
+    "club-asset-needs-more-research": 20,
+    "club-asset-non-crest-candidate": 11
   },
   "issues": [
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "accrington",
-      "clubId": "accrington",
-      "canonicalName": "Accrington",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Crown_Ground_sign-geograph-1761360.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Accrington crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "accrington stanley 1891",
-      "clubId": "accrington-stanley-1891",
-      "canonicalName": "Accrington Stanley (1891)",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Accrington Stanley (1891) crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "altrincham",
-      "clubId": "altrincham",
-      "canonicalName": "Altrincham",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Exeter_City_match.JPG",
-      "source": "wikipedia-pageimage-free",
-      "message": "Altrincham crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "chester city",
-      "clubId": "chester-city",
-      "canonicalName": "Chester City",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Chester City crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "dagenham",
-      "clubId": "dagenham",
-      "canonicalName": "Dagenham",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Beam_valley_park_and_turbine_1.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Dagenham crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "darlington 1883",
-      "clubId": "darlington-1883",
-      "canonicalName": "Darlington (1883)",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Darlington (1883) crest candidate identity is uncertain"
-    },
     {
       "type": "club-asset-identity-uncertain",
       "clubKey": "dunstable town",
@@ -104,32 +44,12 @@
     },
     {
       "type": "club-asset-identity-uncertain",
-      "clubKey": "farsley celtic",
-      "clubId": "farsley-celtic",
-      "canonicalName": "Farsley Celtic",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Citadel-1.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Farsley Celtic crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
       "clubKey": "glossop",
       "clubId": "glossop",
       "canonicalName": "Glossop",
       "assetKind": "crest",
       "assetId": "wikipedia-pageimage-any:GNE_afc_badge.png",
       "source": "wikipedia-pageimage-any",
-      "message": "Glossop crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "glossop",
-      "clubId": "glossop",
-      "canonicalName": "Glossop",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
       "message": "Glossop crest candidate identity is uncertain"
     },
     {
@@ -144,96 +64,6 @@
     },
     {
       "type": "club-asset-identity-uncertain",
-      "clubKey": "leamington",
-      "clubId": "leamington",
-      "canonicalName": "Leamington",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:New_North_Bank.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Leamington crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "leeds city",
-      "clubId": "leeds-city",
-      "canonicalName": "Leeds City",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Leeds_old_arms.png",
-      "source": "wikipedia-pageimage-free",
-      "message": "Leeds City crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "lewes",
-      "clubId": "lewes",
-      "canonicalName": "Lewes",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:DrippingPan.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Lewes crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "loughborough",
-      "clubId": "loughborough",
-      "canonicalName": "Loughborough",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Town_Hall_-_Market_Place_(geograph_2938168).jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Loughborough crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "maidenhead united",
-      "clubId": "maidenhead-united",
-      "canonicalName": "Maidenhead United",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Maidenhead_v_Barnet_022.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Maidenhead United crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "maidstone united 1897",
-      "clubId": "maidstone-united-1897",
-      "canonicalName": "Maidstone United (1897)",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Maidstone United (1897) crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "middlesbrough",
-      "clubId": "middlesbrough",
-      "canonicalName": "Middlesbrough",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Middlesborough_Town_Hall_image_by_Robert_Eva.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Middlesbrough crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "newport county 1912",
-      "clubId": "newport-county-1912",
-      "canonicalName": "Newport County (1912)",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Newport County (1912) crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "oxford city",
-      "clubId": "oxford-city",
-      "canonicalName": "Oxford City",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:The_Main_Stand_at_Court_Place_Farm_-_geograph.org.uk_-_1245335.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Oxford City crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
       "clubKey": "queens park rangers",
       "clubId": "queens-park-rangers",
       "canonicalName": "Queens Park Rangers",
@@ -244,16 +74,6 @@
     },
     {
       "type": "club-asset-identity-uncertain",
-      "clubKey": "shepshed dynamo",
-      "clubId": "shepshed-dynamo",
-      "canonicalName": "Shepshed Dynamo",
-      "assetKind": "crest",
-      "assetId": "wikidata-image:Shepshed Ground 001 Small.jpg",
-      "source": "wikidata-image",
-      "message": "Shepshed Dynamo crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
       "clubKey": "stafford rangers",
       "clubId": "stafford-rangers",
       "canonicalName": "Stafford Rangers",
@@ -261,16 +81,6 @@
       "assetId": "wikipedia-pageimage-any:Staffordfc.png",
       "source": "wikipedia-pageimage-any",
       "message": "Stafford Rangers crest candidate identity is uncertain"
-    },
-    {
-      "type": "club-asset-identity-uncertain",
-      "clubKey": "staines town",
-      "clubId": "staines-town",
-      "canonicalName": "Staines Town",
-      "assetKind": "crest",
-      "assetId": "wikidata-image:DovervStaines.jpg",
-      "source": "wikidata-image",
-      "message": "Staines Town crest candidate identity is uncertain"
     },
     {
       "type": "club-asset-license-restricted",
@@ -3653,132 +3463,13 @@
       "message": "York City crest candidate is license restricted"
     },
     {
-      "type": "club-asset-missing",
-      "clubKey": "leicester united",
-      "clubId": "leicester-united",
-      "canonicalName": "Leicester United",
-      "assetKind": "crest",
-      "message": "Leicester United has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "milton keynes city",
-      "clubId": "milton-keynes-city",
-      "canonicalName": "Milton Keynes City",
-      "assetKind": "crest",
-      "message": "Milton Keynes City has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "rothwell town",
-      "clubId": "rothwell-town",
-      "canonicalName": "Rothwell Town",
-      "assetKind": "crest",
-      "message": "Rothwell Town has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "team bath",
-      "clubId": "team-bath",
-      "canonicalName": "Team Bath",
-      "assetKind": "crest",
-      "message": "Team Bath has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "walthamstow avenue",
-      "clubId": "walthamstow-avenue",
-      "canonicalName": "Walthamstow Avenue",
-      "assetKind": "crest",
-      "message": "Walthamstow Avenue has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "whitby town",
-      "clubId": "whitby-town",
-      "canonicalName": "Whitby Town",
-      "assetKind": "crest",
-      "message": "Whitby Town has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "witney town",
-      "clubId": "witney-town",
-      "canonicalName": "Witney Town",
-      "assetKind": "crest",
-      "message": "Witney Town has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "accrington stanley 1891",
-      "clubId": "accrington-stanley-1891",
-      "canonicalName": "Accrington Stanley (1891)",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Accrington Stanley (1891) has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "altrincham",
-      "clubId": "altrincham",
-      "canonicalName": "Altrincham",
-      "assetKind": "crest",
-      "candidateCount": 3,
-      "message": "Altrincham has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "atherstone town",
-      "clubId": "atherstone-town",
-      "canonicalName": "Atherstone Town",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Atherstone Town has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "bootle",
-      "clubId": "bootle",
-      "canonicalName": "Bootle",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Bootle has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "bromley",
-      "clubId": "bromley",
-      "canonicalName": "Bromley",
-      "assetKind": "crest",
-      "candidateCount": 3,
-      "message": "Bromley has crest candidates but no usable preferred asset"
-    },
-    {
       "type": "club-asset-multiple-review-candidates",
       "clubKey": "chester city",
       "clubId": "chester-city",
       "canonicalName": "Chester City",
       "assetKind": "crest",
-      "candidateCount": 4,
-      "message": "Chester City has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "clevedon town",
-      "clubId": "clevedon-town",
-      "canonicalName": "Clevedon Town",
-      "assetKind": "crest",
       "candidateCount": 2,
-      "message": "Clevedon Town has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "darlington 1883",
-      "clubId": "darlington-1883",
-      "canonicalName": "Darlington (1883)",
-      "assetKind": "crest",
-      "candidateCount": 3,
-      "message": "Darlington (1883) has crest candidates but no usable preferred asset"
+      "message": "Chester City has crest candidates but no usable preferred asset"
     },
     {
       "type": "club-asset-multiple-review-candidates",
@@ -3786,26 +3477,8 @@
       "clubId": "dunstable-town",
       "canonicalName": "Dunstable Town",
       "assetKind": "crest",
-      "candidateCount": 3,
+      "candidateCount": 2,
       "message": "Dunstable Town has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "eastleigh",
-      "clubId": "eastleigh",
-      "canonicalName": "Eastleigh",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Eastleigh has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "farsley celtic",
-      "clubId": "farsley-celtic",
-      "canonicalName": "Farsley Celtic",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Farsley Celtic has crest candidates but no usable preferred asset"
     },
     {
       "type": "club-asset-multiple-review-candidates",
@@ -3822,7 +3495,7 @@
       "clubId": "gateshead-1899",
       "canonicalName": "Gateshead (1899)",
       "assetKind": "crest",
-      "candidateCount": 4,
+      "candidateCount": 2,
       "message": "Gateshead (1899) has crest candidates but no usable preferred asset"
     },
     {
@@ -3831,7 +3504,7 @@
       "clubId": "glossop",
       "canonicalName": "Glossop",
       "assetKind": "crest",
-      "candidateCount": 4,
+      "candidateCount": 2,
       "message": "Glossop has crest candidates but no usable preferred asset"
     },
     {
@@ -3840,7 +3513,7 @@
       "clubId": "hendon",
       "canonicalName": "Hendon",
       "assetKind": "crest",
-      "candidateCount": 3,
+      "candidateCount": 2,
       "message": "Hendon has crest candidates but no usable preferred asset"
     },
     {
@@ -3849,53 +3522,8 @@
       "clubId": "hereford",
       "canonicalName": "Hereford",
       "assetKind": "crest",
-      "candidateCount": 3,
+      "candidateCount": 2,
       "message": "Hereford has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "hereford united",
-      "clubId": "hereford-united",
-      "canonicalName": "Hereford United",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Hereford United has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "leamington",
-      "clubId": "leamington",
-      "canonicalName": "Leamington",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Leamington has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "lewes",
-      "clubId": "lewes",
-      "canonicalName": "Lewes",
-      "assetKind": "crest",
-      "candidateCount": 3,
-      "message": "Lewes has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "leyton",
-      "clubId": "leyton",
-      "canonicalName": "Leyton",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Leyton has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "maidenhead united",
-      "clubId": "maidenhead-united",
-      "canonicalName": "Maidenhead United",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Maidenhead United has crest candidates but no usable preferred asset"
     },
     {
       "type": "club-asset-multiple-review-candidates",
@@ -3903,7 +3531,7 @@
       "clubId": "maidstone-united-1897",
       "canonicalName": "Maidstone United (1897)",
       "assetKind": "crest",
-      "candidateCount": 3,
+      "candidateCount": 2,
       "message": "Maidstone United (1897) has crest candidates but no usable preferred asset"
     },
     {
@@ -3921,44 +3549,8 @@
       "clubId": "middlesbrough",
       "canonicalName": "Middlesbrough",
       "assetKind": "crest",
-      "candidateCount": 3,
+      "candidateCount": 2,
       "message": "Middlesbrough has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "newport county 1912",
-      "clubId": "newport-county-1912",
-      "canonicalName": "Newport County (1912)",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Newport County (1912) has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "oxford city",
-      "clubId": "oxford-city",
-      "canonicalName": "Oxford City",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Oxford City has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "peterborough sports",
-      "clubId": "peterborough-sports",
-      "canonicalName": "Peterborough Sports",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Peterborough Sports has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "runcorn fc halton",
-      "clubId": "runcorn-fc-halton",
-      "canonicalName": "Runcorn FC Halton",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Runcorn FC Halton has crest candidates but no usable preferred asset"
     },
     {
       "type": "club-asset-multiple-review-candidates",
@@ -3970,213 +3562,164 @@
       "message": "Windsor & Eton has crest candidates but no usable preferred asset"
     },
     {
-      "type": "club-asset-multiple-review-candidates",
-      "clubKey": "wivenhoe town",
-      "clubId": "wivenhoe-town",
-      "canonicalName": "Wivenhoe Town",
-      "assetKind": "crest",
-      "candidateCount": 2,
-      "message": "Wivenhoe Town has crest candidates but no usable preferred asset"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
+      "type": "club-asset-needs-more-research",
       "clubKey": "accrington",
       "clubId": "accrington",
       "canonicalName": "Accrington",
       "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Crown_Ground_sign-geograph-1761360.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Accrington crest candidate does not look like a crest/logo filename"
+      "message": "Accrington needs more crest asset research"
     },
     {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "accrington stanley 1891",
-      "clubId": "accrington-stanley-1891",
-      "canonicalName": "Accrington Stanley (1891)",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Accrington Stanley (1891) crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
+      "type": "club-asset-needs-more-research",
       "clubKey": "addlestone and weybridge town",
       "clubId": "addlestone-and-weybridge-town",
       "canonicalName": "Addlestone & Weybridge Town",
       "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:St_Paul,_Addlestone_-_geograph.org.uk_-_1517212.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Addlestone & Weybridge Town crest candidate does not look like a crest/logo filename"
+      "message": "Addlestone & Weybridge Town needs more crest asset research"
     },
     {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "altrincham",
-      "clubId": "altrincham",
-      "canonicalName": "Altrincham",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Altrincham_Town_Square_-_2024.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Altrincham crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "altrincham",
-      "clubId": "altrincham",
-      "canonicalName": "Altrincham",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Exeter_City_match.JPG",
-      "source": "wikipedia-pageimage-free",
-      "message": "Altrincham crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
+      "type": "club-asset-needs-more-research",
       "clubKey": "andover",
       "clubId": "andover",
       "canonicalName": "Andover",
       "assetKind": "crest",
-      "assetId": "wikidata-image:Andover-2008-Squad.jpg",
-      "source": "wikidata-image",
-      "message": "Andover crest candidate does not look like a crest/logo filename"
+      "message": "Andover needs more crest asset research"
     },
     {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "atherstone town",
-      "clubId": "atherstone-town",
-      "canonicalName": "Atherstone Town",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Atherstone_Town_FC_2009.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Atherstone Town crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
+      "type": "club-asset-needs-more-research",
       "clubKey": "bishop auckland",
       "clubId": "bishop-auckland",
       "canonicalName": "Bishop Auckland",
       "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Bishop_Auckland_Town_Hall.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Bishop Auckland crest candidate does not look like a crest/logo filename"
+      "message": "Bishop Auckland needs more crest asset research"
     },
     {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "bootle",
-      "clubId": "bootle",
-      "canonicalName": "Bootle",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Bootle_Town_Hall_2020-1.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Bootle crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "bromley",
-      "clubId": "bromley",
-      "canonicalName": "Bromley",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Bromley_-_geograph.org.uk_-_4623007.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Bromley crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "bromley",
-      "clubId": "bromley",
-      "canonicalName": "Bromley",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Bromley_FC_League_Performance.svg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Bromley crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "chester city",
-      "clubId": "chester-city",
-      "canonicalName": "Chester City",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Chester_-_Shops_in_city_centre_-_2005-10-09.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Chester City crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "chester city",
-      "clubId": "chester-city",
-      "canonicalName": "Chester City",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Chester City crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "clevedon town",
-      "clubId": "clevedon-town",
-      "canonicalName": "Clevedon Town",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Clevedon_Town_2007.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Clevedon Town crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
+      "type": "club-asset-needs-more-research",
       "clubKey": "dagenham",
       "clubId": "dagenham",
       "canonicalName": "Dagenham",
       "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Beam_valley_park_and_turbine_1.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Dagenham crest candidate does not look like a crest/logo filename"
+      "message": "Dagenham needs more crest asset research"
     },
     {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "darlington 1883",
-      "clubId": "darlington-1883",
-      "canonicalName": "Darlington (1883)",
+      "type": "club-asset-needs-more-research",
+      "clubKey": "hounslow",
+      "clubId": "hounslow",
+      "canonicalName": "Hounslow",
       "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Darlington_clock_tower_and_market_hall_(geograph_6299652).jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Darlington (1883) crest candidate does not look like a crest/logo filename"
+      "message": "Hounslow needs more crest asset research"
     },
     {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "darlington 1883",
-      "clubId": "darlington-1883",
-      "canonicalName": "Darlington (1883)",
+      "type": "club-asset-needs-more-research",
+      "clubKey": "leicester united",
+      "clubId": "leicester-united",
+      "canonicalName": "Leicester United",
       "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Darlington (1883) crest candidate does not look like a crest/logo filename"
+      "message": "Leicester United needs more crest asset research"
     },
     {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "dunstable town",
-      "clubId": "dunstable-town",
-      "canonicalName": "Dunstable Town",
+      "type": "club-asset-needs-more-research",
+      "clubKey": "loughborough",
+      "clubId": "loughborough",
+      "canonicalName": "Loughborough",
       "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:High_Street_Dunstable_-_geograph.org.uk_-_6524692.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Dunstable Town crest candidate does not look like a crest/logo filename"
+      "message": "Loughborough needs more crest asset research"
     },
     {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "eastleigh",
-      "clubId": "eastleigh",
-      "canonicalName": "Eastleigh",
+      "type": "club-asset-needs-more-research",
+      "clubKey": "milton keynes city",
+      "clubId": "milton-keynes-city",
+      "canonicalName": "Milton Keynes City",
       "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Old_Town_Hall_Eastleigh.JPG",
-      "source": "wikipedia-pageimage-free",
-      "message": "Eastleigh crest candidate does not look like a crest/logo filename"
+      "message": "Milton Keynes City needs more crest asset research"
     },
     {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "farsley celtic",
-      "clubId": "farsley-celtic",
-      "canonicalName": "Farsley Celtic",
+      "type": "club-asset-needs-more-research",
+      "clubKey": "new brighton tower",
+      "clubId": "new-brighton-tower",
+      "canonicalName": "New Brighton Tower",
       "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Citadel-1.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Farsley Celtic crest candidate does not look like a crest/logo filename"
+      "message": "New Brighton Tower needs more crest asset research"
+    },
+    {
+      "type": "club-asset-needs-more-research",
+      "clubKey": "redbridge forest",
+      "clubId": "redbridge-forest",
+      "canonicalName": "Redbridge Forest",
+      "assetKind": "crest",
+      "message": "Redbridge Forest needs more crest asset research"
+    },
+    {
+      "type": "club-asset-needs-more-research",
+      "clubKey": "rothwell town",
+      "clubId": "rothwell-town",
+      "canonicalName": "Rothwell Town",
+      "assetKind": "crest",
+      "message": "Rothwell Town needs more crest asset research"
+    },
+    {
+      "type": "club-asset-needs-more-research",
+      "clubKey": "shepshed dynamo",
+      "clubId": "shepshed-dynamo",
+      "canonicalName": "Shepshed Dynamo",
+      "assetKind": "crest",
+      "message": "Shepshed Dynamo needs more crest asset research"
+    },
+    {
+      "type": "club-asset-needs-more-research",
+      "clubKey": "staines town",
+      "clubId": "staines-town",
+      "canonicalName": "Staines Town",
+      "assetKind": "crest",
+      "message": "Staines Town needs more crest asset research"
+    },
+    {
+      "type": "club-asset-needs-more-research",
+      "clubKey": "team bath",
+      "clubId": "team-bath",
+      "canonicalName": "Team Bath",
+      "assetKind": "crest",
+      "message": "Team Bath needs more crest asset research"
+    },
+    {
+      "type": "club-asset-needs-more-research",
+      "clubKey": "thames",
+      "clubId": "thames",
+      "canonicalName": "Thames",
+      "assetKind": "crest",
+      "message": "Thames needs more crest asset research"
+    },
+    {
+      "type": "club-asset-needs-more-research",
+      "clubKey": "trowbridge town",
+      "clubId": "trowbridge-town",
+      "canonicalName": "Trowbridge Town",
+      "assetKind": "crest",
+      "message": "Trowbridge Town needs more crest asset research"
+    },
+    {
+      "type": "club-asset-needs-more-research",
+      "clubKey": "walthamstow avenue",
+      "clubId": "walthamstow-avenue",
+      "canonicalName": "Walthamstow Avenue",
+      "assetKind": "crest",
+      "message": "Walthamstow Avenue needs more crest asset research"
+    },
+    {
+      "type": "club-asset-needs-more-research",
+      "clubKey": "whitby town",
+      "clubId": "whitby-town",
+      "canonicalName": "Whitby Town",
+      "assetKind": "crest",
+      "message": "Whitby Town needs more crest asset research"
+    },
+    {
+      "type": "club-asset-needs-more-research",
+      "clubKey": "witney town",
+      "clubId": "witney-town",
+      "canonicalName": "Witney Town",
+      "assetKind": "crest",
+      "message": "Witney Town needs more crest asset research"
     },
     {
       "type": "club-asset-non-crest-candidate",
@@ -4190,61 +3733,11 @@
     },
     {
       "type": "club-asset-non-crest-candidate",
-      "clubKey": "gateshead 1899",
-      "clubId": "gateshead-1899",
-      "canonicalName": "Gateshead (1899)",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Angel_of_the_North,_Gateshead,_United_Kingdom.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Gateshead (1899) crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "gateshead 1899",
-      "clubId": "gateshead-1899",
-      "canonicalName": "Gateshead (1899)",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Hôtel_ville_South_Shields_South_Tyneside_28.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Gateshead (1899) crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "glossop",
-      "clubId": "glossop",
-      "canonicalName": "Glossop",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Glossop_-_geograph.org.uk_-_7292918.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Glossop crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "glossop",
-      "clubId": "glossop",
-      "canonicalName": "Glossop",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Glossop crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
       "clubKey": "hendon",
       "clubId": "hendon",
       "canonicalName": "Hendon",
       "assetKind": "crest",
       "assetId": "wikipedia-pageimage-free:HampsteadTownFC1919.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Hendon crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "hendon",
-      "clubId": "hendon",
-      "canonicalName": "Hendon",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Hendon_Town_Hall_in_December_2011.JPG",
       "source": "wikipedia-pageimage-free",
       "message": "Hendon crest candidate does not look like a crest/logo filename"
     },
@@ -4260,36 +3753,6 @@
     },
     {
       "type": "club-asset-non-crest-candidate",
-      "clubKey": "hereford",
-      "clubId": "hereford",
-      "canonicalName": "Hereford",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Centre_of_Hereford_-_geograph.org.uk_-_4306743.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Hereford crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "hereford united",
-      "clubId": "hereford-united",
-      "canonicalName": "Hereford United",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Hereford_United_League_Performance.svg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Hereford United crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "hounslow",
-      "clubId": "hounslow",
-      "canonicalName": "Hounslow",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Hounslow_High_Street.1.JPG",
-      "source": "wikipedia-pageimage-free",
-      "message": "Hounslow crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
       "clubKey": "knowsley united",
       "clubId": "knowsley-united",
       "canonicalName": "Knowsley United",
@@ -4297,86 +3760,6 @@
       "assetId": "wikipedia-pageimage-free:Knowsley-united.png",
       "source": "wikipedia-pageimage-free",
       "message": "Knowsley United crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "leamington",
-      "clubId": "leamington",
-      "canonicalName": "Leamington",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:New_North_Bank.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Leamington crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "leeds city",
-      "clubId": "leeds-city",
-      "canonicalName": "Leeds City",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Leeds_old_arms.png",
-      "source": "wikipedia-pageimage-free",
-      "message": "Leeds City crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "lewes",
-      "clubId": "lewes",
-      "canonicalName": "Lewes",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:DrippingPan.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Lewes crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "lewes",
-      "clubId": "lewes",
-      "canonicalName": "Lewes",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Lewes-udsigt.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Lewes crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "leyton",
-      "clubId": "leyton",
-      "canonicalName": "Leyton",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:LeytonCentre.JPG",
-      "source": "wikipedia-pageimage-free",
-      "message": "Leyton crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "loughborough",
-      "clubId": "loughborough",
-      "canonicalName": "Loughborough",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Town_Hall_-_Market_Place_(geograph_2938168).jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Loughborough crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "maidenhead united",
-      "clubId": "maidenhead-united",
-      "canonicalName": "Maidenhead United",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Maidenhead_v_Barnet_022.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Maidenhead United crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "maidstone united 1897",
-      "clubId": "maidstone-united-1897",
-      "canonicalName": "Maidstone United (1897)",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Maidstone United (1897) crest candidate does not look like a crest/logo filename"
     },
     {
       "type": "club-asset-non-crest-candidate",
@@ -4400,56 +3783,6 @@
     },
     {
       "type": "club-asset-non-crest-candidate",
-      "clubKey": "middlesbrough",
-      "clubId": "middlesbrough",
-      "canonicalName": "Middlesbrough",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Middlesborough_Town_Hall_image_by_Robert_Eva.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Middlesbrough crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "new brighton tower",
-      "clubId": "new-brighton-tower",
-      "canonicalName": "New Brighton Tower",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:New_Brighton_Tower.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "New Brighton Tower crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "newport county 1912",
-      "clubId": "newport-county-1912",
-      "canonicalName": "Newport County (1912)",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Newport County (1912) crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "oxford city",
-      "clubId": "oxford-city",
-      "canonicalName": "Oxford City",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:The_Main_Stand_at_Court_Place_Farm_-_geograph.org.uk_-_1245335.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Oxford City crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "peterborough sports",
-      "clubId": "peterborough-sports",
-      "canonicalName": "Peterborough Sports",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Peterborough_Sports_vs_Guiseley_FC_-_FA_Cup_3rd_qualifying_round_2019.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Peterborough Sports crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
       "clubKey": "queens park rangers",
       "clubId": "queens-park-rangers",
       "canonicalName": "Queens Park Rangers",
@@ -4467,26 +3800,6 @@
       "assetId": "wikipedia-pageimage-any:Road-Sea_Southampton_F.C.jpg",
       "source": "wikipedia-pageimage-any",
       "message": "Road-Sea Southampton crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "runcorn fc halton",
-      "clubId": "runcorn-fc-halton",
-      "canonicalName": "Runcorn FC Halton",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Silver_Jubilee_Bridge,_Runcorn,_night,_2024.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Runcorn FC Halton crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "shepshed dynamo",
-      "clubId": "shepshed-dynamo",
-      "canonicalName": "Shepshed Dynamo",
-      "assetKind": "crest",
-      "assetId": "wikidata-image:Shepshed Ground 001 Small.jpg",
-      "source": "wikidata-image",
-      "message": "Shepshed Dynamo crest candidate does not look like a crest/logo filename"
     },
     {
       "type": "club-asset-non-crest-candidate",
@@ -4510,36 +3823,6 @@
     },
     {
       "type": "club-asset-non-crest-candidate",
-      "clubKey": "staines town",
-      "clubId": "staines-town",
-      "canonicalName": "Staines Town",
-      "assetKind": "crest",
-      "assetId": "wikidata-image:DovervStaines.jpg",
-      "source": "wikidata-image",
-      "message": "Staines Town crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "thames",
-      "clubId": "thames",
-      "canonicalName": "Thames",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:London_Thames_Sunset_panorama_-_Feb_2008.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Thames crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "trowbridge town",
-      "clubId": "trowbridge-town",
-      "canonicalName": "Trowbridge Town",
-      "assetKind": "crest",
-      "assetId": "wikidata-image:Trowbridge Town F.C..jpg",
-      "source": "wikidata-image",
-      "message": "Trowbridge Town crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
       "clubKey": "windsor and eton",
       "clubId": "windsor-and-eton",
       "canonicalName": "Windsor & Eton",
@@ -4547,16 +3830,6 @@
       "assetId": "wikipedia-pageimage-any:Windsorandetonfc.jpg",
       "source": "wikipedia-pageimage-any",
       "message": "Windsor & Eton crest candidate does not look like a crest/logo filename"
-    },
-    {
-      "type": "club-asset-non-crest-candidate",
-      "clubKey": "wivenhoe town",
-      "clubId": "wivenhoe-town",
-      "canonicalName": "Wivenhoe Town",
-      "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:BroadLaneWivenhoeTown21Jan2017.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Wivenhoe Town crest candidate does not look like a crest/logo filename"
     }
   ]
 }

--- a/data/club-assets-review.json
+++ b/data/club-assets-review.json
@@ -2,8 +2,8 @@
   "metadata": {
     "schemaVersion": 1,
     "generator": "club-assets-review",
-    "generatedAt": "2026-06-20T19:54:09.020Z",
-    "gitSha": "798511e",
+    "generatedAt": "2026-06-20T20:01:39.482Z",
+    "gitSha": "b94ecf2",
     "sourceFiles": [
       "/Users/dsteele/repos/footy-data-kit-club-assets/data/club-metadata.json"
     ],
@@ -13,11 +13,11 @@
     }
   },
   "clubCount": 375,
-  "issueCount": 467,
+  "issueCount": 458,
   "issueCounts": {
     "club-asset-identity-uncertain": 25,
     "club-asset-license-restricted": 338,
-    "club-asset-missing": 16,
+    "club-asset-missing": 7,
     "club-asset-multiple-review-candidates": 30,
     "club-asset-non-crest-candidate": 58
   },
@@ -3654,51 +3654,11 @@
     },
     {
       "type": "club-asset-missing",
-      "clubKey": "birmingham st georges",
-      "clubId": "birmingham-st-georges",
-      "canonicalName": "Birmingham St George's",
-      "assetKind": "crest",
-      "message": "Birmingham St George's has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "burton swifts",
-      "clubId": "burton-swifts",
-      "canonicalName": "Burton Swifts",
-      "assetKind": "crest",
-      "message": "Burton Swifts has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "burton united",
-      "clubId": "burton-united",
-      "canonicalName": "Burton United",
-      "assetKind": "crest",
-      "message": "Burton United has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "burton wanderers",
-      "clubId": "burton-wanderers",
-      "canonicalName": "Burton Wanderers",
-      "assetKind": "crest",
-      "message": "Burton Wanderers has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
       "clubKey": "leicester united",
       "clubId": "leicester-united",
       "canonicalName": "Leicester United",
       "assetKind": "crest",
       "message": "Leicester United has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "middlesbrough ironopolis",
-      "clubId": "middlesbrough-ironopolis",
-      "canonicalName": "Middlesbrough Ironopolis",
-      "assetKind": "crest",
-      "message": "Middlesbrough Ironopolis has no crest asset candidates"
     },
     {
       "type": "club-asset-missing",
@@ -3710,43 +3670,11 @@
     },
     {
       "type": "club-asset-missing",
-      "clubKey": "oswestry town",
-      "clubId": "oswestry-town",
-      "canonicalName": "Oswestry Town",
-      "assetKind": "crest",
-      "message": "Oswestry Town has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "redbridge forest",
-      "clubId": "redbridge-forest",
-      "canonicalName": "Redbridge Forest",
-      "assetKind": "crest",
-      "message": "Redbridge Forest has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "rotherham town",
-      "clubId": "rotherham-town",
-      "canonicalName": "Rotherham Town",
-      "assetKind": "crest",
-      "message": "Rotherham Town has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
       "clubKey": "rothwell town",
       "clubId": "rothwell-town",
       "canonicalName": "Rothwell Town",
       "assetKind": "crest",
       "message": "Rothwell Town has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "sunderland albion",
-      "clubId": "sunderland-albion",
-      "canonicalName": "Sunderland Albion",
-      "assetKind": "crest",
-      "message": "Sunderland Albion has no crest asset candidates"
     },
     {
       "type": "club-asset-missing",

--- a/data/club-assets-review.json
+++ b/data/club-assets-review.json
@@ -2,8 +2,8 @@
   "metadata": {
     "schemaVersion": 1,
     "generator": "club-assets-review",
-    "generatedAt": "2026-06-20T19:11:05.512Z",
-    "gitSha": "afe2785",
+    "generatedAt": "2026-06-20T19:31:27.733Z",
+    "gitSha": "e0edd04",
     "sourceFiles": [
       "/Users/dsteele/repos/footy-data-kit-club-assets/data/club-metadata.json"
     ],
@@ -13,15 +13,25 @@
     }
   },
   "clubCount": 375,
-  "issueCount": 420,
+  "issueCount": 466,
   "issueCounts": {
-    "club-asset-identity-uncertain": 19,
-    "club-asset-license-restricted": 309,
-    "club-asset-missing": 44,
-    "club-asset-multiple-review-candidates": 17,
-    "club-asset-non-crest-candidate": 31
+    "club-asset-identity-uncertain": 23,
+    "club-asset-license-restricted": 337,
+    "club-asset-missing": 22,
+    "club-asset-multiple-review-candidates": 30,
+    "club-asset-non-crest-candidate": 54
   },
   "issues": [
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "accrington",
+      "clubId": "accrington",
+      "canonicalName": "Accrington",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Crown_Ground_sign-geograph-1761360.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Accrington crest candidate identity is uncertain"
+    },
     {
       "type": "club-asset-identity-uncertain",
       "clubKey": "accrington stanley 1891",
@@ -51,6 +61,16 @@
       "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
       "source": "wikipedia-pageimage-free",
       "message": "Chester City crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "dagenham",
+      "clubId": "dagenham",
+      "canonicalName": "Dagenham",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Beam_valley_park_and_turbine_1.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Dagenham crest candidate identity is uncertain"
     },
     {
       "type": "club-asset-identity-uncertain",
@@ -94,13 +114,13 @@
     },
     {
       "type": "club-asset-identity-uncertain",
-      "clubKey": "gateshead 1899",
-      "clubId": "gateshead-1899",
-      "canonicalName": "Gateshead (1899)",
+      "clubKey": "glossop",
+      "clubId": "glossop",
+      "canonicalName": "Glossop",
       "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-      "source": "wikipedia-pageimage-free",
-      "message": "Gateshead (1899) crest candidate identity is uncertain"
+      "assetId": "wikipedia-pageimage-any:GNE_afc_badge.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Glossop crest candidate identity is uncertain"
     },
     {
       "type": "club-asset-identity-uncertain",
@@ -154,6 +174,16 @@
     },
     {
       "type": "club-asset-identity-uncertain",
+      "clubKey": "loughborough",
+      "clubId": "loughborough",
+      "canonicalName": "Loughborough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Town_Hall_-_Market_Place_(geograph_2938168).jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Loughborough crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
       "clubKey": "maidenhead united",
       "clubId": "maidenhead-united",
       "canonicalName": "Maidenhead United",
@@ -171,6 +201,16 @@
       "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
       "source": "wikipedia-pageimage-free",
       "message": "Maidstone United (1897) crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "middlesbrough",
+      "clubId": "middlesbrough",
+      "canonicalName": "Middlesbrough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Middlesborough_Town_Hall_image_by_Robert_Eva.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Middlesbrough crest candidate identity is uncertain"
     },
     {
       "type": "club-asset-identity-uncertain",
@@ -224,6 +264,16 @@
     },
     {
       "type": "club-asset-license-restricted",
+      "clubKey": "accrington stanley 1891",
+      "clubId": "accrington-stanley-1891",
+      "canonicalName": "Accrington Stanley (1891)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Accrington_Stanley_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Accrington Stanley (1891) crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
       "clubKey": "afc bournemouth",
       "clubId": "afc-bournemouth",
       "canonicalName": "AFC Bournemouth",
@@ -234,6 +284,16 @@
     },
     {
       "type": "club-asset-license-restricted",
+      "clubKey": "afc fylde",
+      "clubId": "afc-fylde",
+      "canonicalName": "AFC Fylde",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:AFC_Fylde_(2014).svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "AFC Fylde crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
       "clubKey": "afc telford united",
       "clubId": "afc-telford-united",
       "canonicalName": "AFC Telford United",
@@ -241,6 +301,16 @@
       "assetId": "wikipedia-pageimage-any:AFC_Telford_United_logo.svg",
       "source": "wikipedia-pageimage-any",
       "message": "AFC Telford United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "afc totton",
+      "clubId": "afc-totton",
+      "canonicalName": "AFC Totton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:AFC_Totton_2024_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "AFC Totton crest candidate is license restricted"
     },
     {
       "type": "club-asset-license-restricted",
@@ -594,6 +664,16 @@
     },
     {
       "type": "club-asset-license-restricted",
+      "clubKey": "bootle",
+      "clubId": "bootle",
+      "canonicalName": "Bootle",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bootle_FC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bootle crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
       "clubKey": "boston united",
       "clubId": "boston-united",
       "canonicalName": "Boston United",
@@ -864,6 +944,26 @@
     },
     {
       "type": "club-asset-license-restricted",
+      "clubKey": "cheltenham town",
+      "clubId": "cheltenham-town",
+      "canonicalName": "Cheltenham Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Cheltenham_Town_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Cheltenham Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "chertsey town",
+      "clubId": "chertsey-town",
+      "canonicalName": "Chertsey Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Chertsey_Town_FC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Chertsey Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
       "clubKey": "chesham united",
       "clubId": "chesham-united",
       "canonicalName": "Chesham United",
@@ -891,6 +991,26 @@
       "assetId": "wikipedia-pageimage-any:Chester-fc.svg",
       "source": "wikipedia-pageimage-any",
       "message": "Chester crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "chester city",
+      "clubId": "chester-city",
+      "canonicalName": "Chester City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Chester_City_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Chester City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "chester city",
+      "clubId": "chester-city",
+      "canonicalName": "Chester City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Chester-fc.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Chester City crest candidate is license restricted"
     },
     {
       "type": "club-asset-license-restricted",
@@ -1074,6 +1194,16 @@
     },
     {
       "type": "club-asset-license-restricted",
+      "clubKey": "darlington 1883",
+      "clubId": "darlington-1883",
+      "canonicalName": "Darlington (1883)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Darlington_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Darlington (1883) crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
       "clubKey": "dartford",
       "clubId": "dartford",
       "canonicalName": "Dartford",
@@ -1194,6 +1324,16 @@
     },
     {
       "type": "club-asset-license-restricted",
+      "clubKey": "dunstable town",
+      "clubId": "dunstable-town",
+      "canonicalName": "Dunstable Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Dunstable_FC.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Dunstable Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
       "clubKey": "durham city",
       "clubId": "durham-city",
       "canonicalName": "Durham City",
@@ -1221,6 +1361,16 @@
       "assetId": "wikipedia-pageimage-any:Eastbourne_Borough_FC_crest.svg",
       "source": "wikipedia-pageimage-any",
       "message": "Eastbourne Borough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "eastleigh",
+      "clubId": "eastleigh",
+      "canonicalName": "Eastleigh",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Eastleigh_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Eastleigh crest candidate is license restricted"
     },
     {
       "type": "club-asset-license-restricted",
@@ -1334,6 +1484,16 @@
     },
     {
       "type": "club-asset-license-restricted",
+      "clubKey": "fc halifax town",
+      "clubId": "fc-halifax-town",
+      "canonicalName": "FC Halifax Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:FC_Halifax_Town_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "FC Halifax Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
       "clubKey": "fc united of manchester",
       "clubId": "fc-united-of-manchester",
       "canonicalName": "FC United of Manchester",
@@ -1361,6 +1521,16 @@
       "assetId": "wikipedia-pageimage-any:Fleetwood_Town_F.C._logo.svg",
       "source": "wikipedia-pageimage-any",
       "message": "Fleetwood Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "folkestone",
+      "clubId": "folkestone",
+      "canonicalName": "Folkestone",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Folkestone_Invicta_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Folkestone crest candidate is license restricted"
     },
     {
       "type": "club-asset-license-restricted",
@@ -1414,6 +1584,26 @@
     },
     {
       "type": "club-asset-license-restricted",
+      "clubKey": "gateshead 1899",
+      "clubId": "gateshead-1899",
+      "canonicalName": "Gateshead (1899)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Gateshead_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Gateshead (1899) crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "gateshead 1899",
+      "clubId": "gateshead-1899",
+      "canonicalName": "Gateshead (1899)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:South_Shields_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Gateshead (1899) crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
       "clubKey": "gillingham",
       "clubId": "gillingham",
       "canonicalName": "Gillingham",
@@ -1421,6 +1611,26 @@
       "assetId": "wikipedia-pageimage-any:FC_Gillingham_Logo.svg",
       "source": "wikipedia-pageimage-any",
       "message": "Gillingham crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "glossop",
+      "clubId": "glossop",
+      "canonicalName": "Glossop",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:GNE_afc_badge.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Glossop crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "glossop",
+      "clubId": "glossop",
+      "canonicalName": "Glossop",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:North_West_Counties_Football_League_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Glossop crest candidate is license restricted"
     },
     {
       "type": "club-asset-license-restricted",
@@ -1561,6 +1771,26 @@
       "assetId": "wikipedia-pageimage-any:Hartlepool_United_FC_crest.svg",
       "source": "wikipedia-pageimage-any",
       "message": "Hartlepool United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hastings united",
+      "clubId": "hastings-united",
+      "canonicalName": "Hastings United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hastings_United_F.C._2020_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hastings United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hastings united 1948",
+      "clubId": "hastings-united-1948",
+      "canonicalName": "Hastings United (1948)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hastings_United_F.C._2020_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hastings United (1948) crest candidate is license restricted"
     },
     {
       "type": "club-asset-license-restricted",
@@ -1934,6 +2164,16 @@
     },
     {
       "type": "club-asset-license-restricted",
+      "clubKey": "leyton",
+      "clubId": "leyton",
+      "canonicalName": "Leyton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:LeytonFC.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Leyton crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
       "clubKey": "leyton orient",
       "clubId": "leyton-orient",
       "canonicalName": "Leyton Orient",
@@ -2021,6 +2261,26 @@
       "assetId": "wikipedia-pageimage-any:Maidstone_United_FC_crest.svg",
       "source": "wikipedia-pageimage-any",
       "message": "Maidstone United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "maidstone united 1897",
+      "clubId": "maidstone-united-1897",
+      "canonicalName": "Maidstone United (1897)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Maidstone_United_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Maidstone United (1897) crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "maidstone united 1897",
+      "clubId": "maidstone-united-1897",
+      "canonicalName": "Maidstone United (1897)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Maidstone-utd-logo.jpg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Maidstone United (1897) crest candidate is license restricted"
     },
     {
       "type": "club-asset-license-restricted",
@@ -2234,6 +2494,16 @@
     },
     {
       "type": "club-asset-license-restricted",
+      "clubKey": "newport county 1912",
+      "clubId": "newport-county-1912",
+      "canonicalName": "Newport County (1912)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Newport_County_AFC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Newport County (1912) crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
       "clubKey": "newport isle of wight",
       "clubId": "newport-isle-of-wight",
       "canonicalName": "Newport (Isle of Wight)",
@@ -2271,6 +2541,16 @@
       "assetId": "wikipedia-pageimage-any:Northwich_Victoria_F.C._logo.svg",
       "source": "wikipedia-pageimage-any",
       "message": "Northwich Victoria crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "northwood",
+      "clubId": "northwood",
+      "canonicalName": "Northwood",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Northwood.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Northwood crest candidate is license restricted"
     },
     {
       "type": "club-asset-license-restricted",
@@ -2504,6 +2784,16 @@
     },
     {
       "type": "club-asset-license-restricted",
+      "clubKey": "runcorn fc halton",
+      "clubId": "runcorn-fc-halton",
+      "canonicalName": "Runcorn FC Halton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:RuncornLinnetsCrest.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Runcorn FC Halton crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
       "clubKey": "rushall olympic",
       "clubId": "rushall-olympic",
       "canonicalName": "Rushall Olympic",
@@ -2591,6 +2881,16 @@
       "assetId": "wikipedia-pageimage-any:Sheffield_United_FC_logo.svg",
       "source": "wikipedia-pageimage-any",
       "message": "Sheffield United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "sheffield wednesday",
+      "clubId": "sheffield-wednesday",
+      "canonicalName": "Sheffield Wednesday",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Sheffield_Wednesday_FC_2026_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Sheffield Wednesday crest candidate is license restricted"
     },
     {
       "type": "club-asset-license-restricted",
@@ -2944,6 +3244,16 @@
     },
     {
       "type": "club-asset-license-restricted",
+      "clubKey": "tranmere rovers",
+      "clubId": "tranmere-rovers",
+      "canonicalName": "Tranmere Rovers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Tranmere_Rovers_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Tranmere Rovers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
       "clubKey": "truro city",
       "clubId": "truro-city",
       "canonicalName": "Truro City",
@@ -3148,6 +3458,16 @@
       "clubId": "windsor-and-eton",
       "canonicalName": "Windsor & Eton",
       "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Windsor_&_Eton_F.C._(2023)_Logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Windsor & Eton crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "windsor and eton",
+      "clubId": "windsor-and-eton",
+      "canonicalName": "Windsor & Eton",
+      "assetKind": "crest",
       "assetId": "wikipedia-pageimage-any:Windsorandetonfc.jpg",
       "source": "wikipedia-pageimage-any",
       "message": "Windsor & Eton crest candidate is license restricted"
@@ -3312,38 +3632,6 @@
     },
     {
       "type": "club-asset-missing",
-      "clubKey": "accrington",
-      "clubId": "accrington",
-      "canonicalName": "Accrington",
-      "assetKind": "crest",
-      "message": "Accrington has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "addlestone and weybridge town",
-      "clubId": "addlestone-and-weybridge-town",
-      "canonicalName": "Addlestone & Weybridge Town",
-      "assetKind": "crest",
-      "message": "Addlestone & Weybridge Town has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "afc fylde",
-      "clubId": "afc-fylde",
-      "canonicalName": "AFC Fylde",
-      "assetKind": "crest",
-      "message": "AFC Fylde has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "afc totton",
-      "clubId": "afc-totton",
-      "canonicalName": "AFC Totton",
-      "assetKind": "crest",
-      "message": "AFC Totton has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
       "clubKey": "andover",
       "clubId": "andover",
       "canonicalName": "Andover",
@@ -3357,22 +3645,6 @@
       "canonicalName": "Birmingham St George's",
       "assetKind": "crest",
       "message": "Birmingham St George's has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "bishop auckland",
-      "clubId": "bishop-auckland",
-      "canonicalName": "Bishop Auckland",
-      "assetKind": "crest",
-      "message": "Bishop Auckland has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "bootle",
-      "clubId": "bootle",
-      "canonicalName": "Bootle",
-      "assetKind": "crest",
-      "message": "Bootle has no crest asset candidates"
     },
     {
       "type": "club-asset-missing",
@@ -3400,30 +3672,6 @@
     },
     {
       "type": "club-asset-missing",
-      "clubKey": "chertsey town",
-      "clubId": "chertsey-town",
-      "canonicalName": "Chertsey Town",
-      "assetKind": "crest",
-      "message": "Chertsey Town has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "dagenham",
-      "clubId": "dagenham",
-      "canonicalName": "Dagenham",
-      "assetKind": "crest",
-      "message": "Dagenham has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "eastleigh",
-      "clubId": "eastleigh",
-      "canonicalName": "Eastleigh",
-      "assetKind": "crest",
-      "message": "Eastleigh has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
       "clubKey": "eastwood town",
       "clubId": "eastwood-town",
       "canonicalName": "Eastwood Town",
@@ -3432,67 +3680,11 @@
     },
     {
       "type": "club-asset-missing",
-      "clubKey": "fc halifax town",
-      "clubId": "fc-halifax-town",
-      "canonicalName": "FC Halifax Town",
-      "assetKind": "crest",
-      "message": "FC Halifax Town has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "folkestone",
-      "clubId": "folkestone",
-      "canonicalName": "Folkestone",
-      "assetKind": "crest",
-      "message": "Folkestone has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "hastings united",
-      "clubId": "hastings-united",
-      "canonicalName": "Hastings United",
-      "assetKind": "crest",
-      "message": "Hastings United has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "hastings united 1948",
-      "clubId": "hastings-united-1948",
-      "canonicalName": "Hastings United (1948)",
-      "assetKind": "crest",
-      "message": "Hastings United (1948) has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "hounslow",
-      "clubId": "hounslow",
-      "canonicalName": "Hounslow",
-      "assetKind": "crest",
-      "message": "Hounslow has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
       "clubKey": "leicester united",
       "clubId": "leicester-united",
       "canonicalName": "Leicester United",
       "assetKind": "crest",
       "message": "Leicester United has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "leyton",
-      "clubId": "leyton",
-      "canonicalName": "Leyton",
-      "assetKind": "crest",
-      "message": "Leyton has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "loughborough",
-      "clubId": "loughborough",
-      "canonicalName": "Loughborough",
-      "assetKind": "crest",
-      "message": "Loughborough has no crest asset candidates"
     },
     {
       "type": "club-asset-missing",
@@ -3509,22 +3701,6 @@
       "canonicalName": "Milton Keynes City",
       "assetKind": "crest",
       "message": "Milton Keynes City has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "new brighton tower",
-      "clubId": "new-brighton-tower",
-      "canonicalName": "New Brighton Tower",
-      "assetKind": "crest",
-      "message": "New Brighton Tower has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "northwood",
-      "clubId": "northwood",
-      "canonicalName": "Northwood",
-      "assetKind": "crest",
-      "message": "Northwood has no crest asset candidates"
     },
     {
       "type": "club-asset-missing",
@@ -3560,22 +3736,6 @@
     },
     {
       "type": "club-asset-missing",
-      "clubKey": "runcorn fc halton",
-      "clubId": "runcorn-fc-halton",
-      "canonicalName": "Runcorn FC Halton",
-      "assetKind": "crest",
-      "message": "Runcorn FC Halton has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "sheffield wednesday",
-      "clubId": "sheffield-wednesday",
-      "canonicalName": "Sheffield Wednesday",
-      "assetKind": "crest",
-      "message": "Sheffield Wednesday has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
       "clubKey": "shepshed dynamo",
       "clubId": "shepshed-dynamo",
       "canonicalName": "Shepshed Dynamo",
@@ -3605,22 +3765,6 @@
       "canonicalName": "Team Bath",
       "assetKind": "crest",
       "message": "Team Bath has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "thames",
-      "clubId": "thames",
-      "canonicalName": "Thames",
-      "assetKind": "crest",
-      "message": "Thames has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "tranmere rovers",
-      "clubId": "tranmere-rovers",
-      "canonicalName": "Tranmere Rovers",
-      "assetKind": "crest",
-      "message": "Tranmere Rovers has no crest asset candidates"
     },
     {
       "type": "club-asset-missing",
@@ -3656,11 +3800,20 @@
     },
     {
       "type": "club-asset-multiple-review-candidates",
+      "clubKey": "accrington stanley 1891",
+      "clubId": "accrington-stanley-1891",
+      "canonicalName": "Accrington Stanley (1891)",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Accrington Stanley (1891) has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
       "clubKey": "altrincham",
       "clubId": "altrincham",
       "canonicalName": "Altrincham",
       "assetKind": "crest",
-      "candidateCount": 2,
+      "candidateCount": 3,
       "message": "Altrincham has crest candidates but no usable preferred asset"
     },
     {
@@ -3674,12 +3827,30 @@
     },
     {
       "type": "club-asset-multiple-review-candidates",
+      "clubKey": "bootle",
+      "clubId": "bootle",
+      "canonicalName": "Bootle",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Bootle has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
       "clubKey": "bromley",
       "clubId": "bromley",
       "canonicalName": "Bromley",
       "assetKind": "crest",
-      "candidateCount": 2,
+      "candidateCount": 3,
       "message": "Bromley has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "chester city",
+      "clubId": "chester-city",
+      "canonicalName": "Chester City",
+      "assetKind": "crest",
+      "candidateCount": 4,
+      "message": "Chester City has crest candidates but no usable preferred asset"
     },
     {
       "type": "club-asset-multiple-review-candidates",
@@ -3689,6 +3860,33 @@
       "assetKind": "crest",
       "candidateCount": 2,
       "message": "Clevedon Town has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "darlington 1883",
+      "clubId": "darlington-1883",
+      "canonicalName": "Darlington (1883)",
+      "assetKind": "crest",
+      "candidateCount": 3,
+      "message": "Darlington (1883) has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "dunstable town",
+      "clubId": "dunstable-town",
+      "canonicalName": "Dunstable Town",
+      "assetKind": "crest",
+      "candidateCount": 3,
+      "message": "Dunstable Town has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "eastleigh",
+      "clubId": "eastleigh",
+      "canonicalName": "Eastleigh",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Eastleigh has crest candidates but no usable preferred asset"
     },
     {
       "type": "club-asset-multiple-review-candidates",
@@ -3710,11 +3908,29 @@
     },
     {
       "type": "club-asset-multiple-review-candidates",
+      "clubKey": "gateshead 1899",
+      "clubId": "gateshead-1899",
+      "canonicalName": "Gateshead (1899)",
+      "assetKind": "crest",
+      "candidateCount": 4,
+      "message": "Gateshead (1899) has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "glossop",
+      "clubId": "glossop",
+      "canonicalName": "Glossop",
+      "assetKind": "crest",
+      "candidateCount": 4,
+      "message": "Glossop has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
       "clubKey": "hendon",
       "clubId": "hendon",
       "canonicalName": "Hendon",
       "assetKind": "crest",
-      "candidateCount": 2,
+      "candidateCount": 3,
       "message": "Hendon has crest candidates but no usable preferred asset"
     },
     {
@@ -3723,7 +3939,7 @@
       "clubId": "hereford",
       "canonicalName": "Hereford",
       "assetKind": "crest",
-      "candidateCount": 2,
+      "candidateCount": 3,
       "message": "Hereford has crest candidates but no usable preferred asset"
     },
     {
@@ -3750,8 +3966,17 @@
       "clubId": "lewes",
       "canonicalName": "Lewes",
       "assetKind": "crest",
-      "candidateCount": 2,
+      "candidateCount": 3,
       "message": "Lewes has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "leyton",
+      "clubId": "leyton",
+      "canonicalName": "Leyton",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Leyton has crest candidates but no usable preferred asset"
     },
     {
       "type": "club-asset-multiple-review-candidates",
@@ -3761,6 +3986,15 @@
       "assetKind": "crest",
       "candidateCount": 2,
       "message": "Maidenhead United has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "maidstone united 1897",
+      "clubId": "maidstone-united-1897",
+      "canonicalName": "Maidstone United (1897)",
+      "assetKind": "crest",
+      "candidateCount": 3,
+      "message": "Maidstone United (1897) has crest candidates but no usable preferred asset"
     },
     {
       "type": "club-asset-multiple-review-candidates",
@@ -3777,8 +4011,17 @@
       "clubId": "middlesbrough",
       "canonicalName": "Middlesbrough",
       "assetKind": "crest",
-      "candidateCount": 2,
+      "candidateCount": 3,
       "message": "Middlesbrough has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "newport county 1912",
+      "clubId": "newport-county-1912",
+      "canonicalName": "Newport County (1912)",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Newport County (1912) has crest candidates but no usable preferred asset"
     },
     {
       "type": "club-asset-multiple-review-candidates",
@@ -3800,12 +4043,40 @@
     },
     {
       "type": "club-asset-multiple-review-candidates",
+      "clubKey": "runcorn fc halton",
+      "clubId": "runcorn-fc-halton",
+      "canonicalName": "Runcorn FC Halton",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Runcorn FC Halton has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "windsor and eton",
+      "clubId": "windsor-and-eton",
+      "canonicalName": "Windsor & Eton",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Windsor & Eton has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
       "clubKey": "wivenhoe town",
       "clubId": "wivenhoe-town",
       "canonicalName": "Wivenhoe Town",
       "assetKind": "crest",
       "candidateCount": 2,
       "message": "Wivenhoe Town has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "accrington",
+      "clubId": "accrington",
+      "canonicalName": "Accrington",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Crown_Ground_sign-geograph-1761360.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Accrington crest candidate does not look like a crest/logo filename"
     },
     {
       "type": "club-asset-non-crest-candidate",
@@ -3816,6 +4087,26 @@
       "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
       "source": "wikipedia-pageimage-free",
       "message": "Accrington Stanley (1891) crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "addlestone and weybridge town",
+      "clubId": "addlestone-and-weybridge-town",
+      "canonicalName": "Addlestone & Weybridge Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:St_Paul,_Addlestone_-_geograph.org.uk_-_1517212.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Addlestone & Weybridge Town crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "altrincham",
+      "clubId": "altrincham",
+      "canonicalName": "Altrincham",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Altrincham_Town_Square_-_2024.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Altrincham crest candidate does not look like a crest/logo filename"
     },
     {
       "type": "club-asset-non-crest-candidate",
@@ -3839,6 +4130,36 @@
     },
     {
       "type": "club-asset-non-crest-candidate",
+      "clubKey": "bishop auckland",
+      "clubId": "bishop-auckland",
+      "canonicalName": "Bishop Auckland",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Bishop_Auckland_Town_Hall.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Bishop Auckland crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "bootle",
+      "clubId": "bootle",
+      "canonicalName": "Bootle",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Bootle_Town_Hall_2020-1.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Bootle crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "bromley",
+      "clubId": "bromley",
+      "canonicalName": "Bromley",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Bromley_-_geograph.org.uk_-_4623007.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Bromley crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
       "clubKey": "bromley",
       "clubId": "bromley",
       "canonicalName": "Bromley",
@@ -3846,6 +4167,16 @@
       "assetId": "wikipedia-pageimage-free:Bromley_FC_League_Performance.svg",
       "source": "wikipedia-pageimage-free",
       "message": "Bromley crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "chester city",
+      "clubId": "chester-city",
+      "canonicalName": "Chester City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Chester_-_Shops_in_city_centre_-_2005-10-09.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Chester City crest candidate does not look like a crest/logo filename"
     },
     {
       "type": "club-asset-non-crest-candidate",
@@ -3869,6 +4200,26 @@
     },
     {
       "type": "club-asset-non-crest-candidate",
+      "clubKey": "dagenham",
+      "clubId": "dagenham",
+      "canonicalName": "Dagenham",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Beam_valley_park_and_turbine_1.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Dagenham crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "darlington 1883",
+      "clubId": "darlington-1883",
+      "canonicalName": "Darlington (1883)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Darlington_clock_tower_and_market_hall_(geograph_6299652).jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Darlington (1883) crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
       "clubKey": "darlington 1883",
       "clubId": "darlington-1883",
       "canonicalName": "Darlington (1883)",
@@ -3876,6 +4227,26 @@
       "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
       "source": "wikipedia-pageimage-free",
       "message": "Darlington (1883) crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "dunstable town",
+      "clubId": "dunstable-town",
+      "canonicalName": "Dunstable Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:High_Street_Dunstable_-_geograph.org.uk_-_6524692.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Dunstable Town crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "eastleigh",
+      "clubId": "eastleigh",
+      "canonicalName": "Eastleigh",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Old_Town_Hall_Eastleigh.JPG",
+      "source": "wikipedia-pageimage-free",
+      "message": "Eastleigh crest candidate does not look like a crest/logo filename"
     },
     {
       "type": "club-asset-non-crest-candidate",
@@ -3903,9 +4274,29 @@
       "clubId": "gateshead-1899",
       "canonicalName": "Gateshead (1899)",
       "assetKind": "crest",
-      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "assetId": "wikipedia-pageimage-free:Angel_of_the_North,_Gateshead,_United_Kingdom.jpg",
       "source": "wikipedia-pageimage-free",
       "message": "Gateshead (1899) crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "gateshead 1899",
+      "clubId": "gateshead-1899",
+      "canonicalName": "Gateshead (1899)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Hôtel_ville_South_Shields_South_Tyneside_28.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Gateshead (1899) crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "glossop",
+      "clubId": "glossop",
+      "canonicalName": "Glossop",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Glossop_-_geograph.org.uk_-_7292918.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Glossop crest candidate does not look like a crest/logo filename"
     },
     {
       "type": "club-asset-non-crest-candidate",
@@ -3929,12 +4320,32 @@
     },
     {
       "type": "club-asset-non-crest-candidate",
+      "clubKey": "hendon",
+      "clubId": "hendon",
+      "canonicalName": "Hendon",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Hendon_Town_Hall_in_December_2011.JPG",
+      "source": "wikipedia-pageimage-free",
+      "message": "Hendon crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
       "clubKey": "hereford",
       "clubId": "hereford",
       "canonicalName": "Hereford",
       "assetKind": "crest",
       "assetId": "wikidata-logo:Forever United, Edgar Street, Hereford - geograph.org.uk - 5596516.jpg",
       "source": "wikidata-logo",
+      "message": "Hereford crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "hereford",
+      "clubId": "hereford",
+      "canonicalName": "Hereford",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Centre_of_Hereford_-_geograph.org.uk_-_4306743.jpg",
+      "source": "wikipedia-pageimage-free",
       "message": "Hereford crest candidate does not look like a crest/logo filename"
     },
     {
@@ -3946,6 +4357,16 @@
       "assetId": "wikipedia-pageimage-free:Hereford_United_League_Performance.svg",
       "source": "wikipedia-pageimage-free",
       "message": "Hereford United crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "hounslow",
+      "clubId": "hounslow",
+      "canonicalName": "Hounslow",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Hounslow_High_Street.1.JPG",
+      "source": "wikipedia-pageimage-free",
+      "message": "Hounslow crest candidate does not look like a crest/logo filename"
     },
     {
       "type": "club-asset-non-crest-candidate",
@@ -3989,6 +4410,36 @@
     },
     {
       "type": "club-asset-non-crest-candidate",
+      "clubKey": "lewes",
+      "clubId": "lewes",
+      "canonicalName": "Lewes",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Lewes-udsigt.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Lewes crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "leyton",
+      "clubId": "leyton",
+      "canonicalName": "Leyton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:LeytonCentre.JPG",
+      "source": "wikipedia-pageimage-free",
+      "message": "Leyton crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "loughborough",
+      "clubId": "loughborough",
+      "canonicalName": "Loughborough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Town_Hall_-_Market_Place_(geograph_2938168).jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Loughborough crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
       "clubKey": "maidenhead united",
       "clubId": "maidenhead-united",
       "canonicalName": "Maidenhead United",
@@ -4026,6 +4477,26 @@
       "assetId": "wikidata-logo:Middlesbrough Walk (27470064759).jpg",
       "source": "wikidata-logo",
       "message": "Middlesbrough crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "middlesbrough",
+      "clubId": "middlesbrough",
+      "canonicalName": "Middlesbrough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Middlesborough_Town_Hall_image_by_Robert_Eva.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Middlesbrough crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "new brighton tower",
+      "clubId": "new-brighton-tower",
+      "canonicalName": "New Brighton Tower",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:New_Brighton_Tower.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "New Brighton Tower crest candidate does not look like a crest/logo filename"
     },
     {
       "type": "club-asset-non-crest-candidate",
@@ -4079,6 +4550,16 @@
     },
     {
       "type": "club-asset-non-crest-candidate",
+      "clubKey": "runcorn fc halton",
+      "clubId": "runcorn-fc-halton",
+      "canonicalName": "Runcorn FC Halton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Silver_Jubilee_Bridge,_Runcorn,_night,_2024.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Runcorn FC Halton crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
       "clubKey": "solihull borough",
       "clubId": "solihull-borough",
       "canonicalName": "Solihull Borough",
@@ -4096,6 +4577,16 @@
       "assetId": "wikipedia-pageimage-any:Staffordfc.png",
       "source": "wikipedia-pageimage-any",
       "message": "Stafford Rangers crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "thames",
+      "clubId": "thames",
+      "canonicalName": "Thames",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:London_Thames_Sunset_panorama_-_Feb_2008.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Thames crest candidate does not look like a crest/logo filename"
     },
     {
       "type": "club-asset-non-crest-candidate",

--- a/data/club-assets-review.json
+++ b/data/club-assets-review.json
@@ -1,0 +1,4121 @@
+{
+  "metadata": {
+    "schemaVersion": 1,
+    "generator": "club-assets-review",
+    "generatedAt": "2026-06-20T19:11:05.512Z",
+    "gitSha": "afe2785",
+    "sourceFiles": [
+      "/Users/dsteele/repos/footy-data-kit-club-assets/data/club-metadata.json"
+    ],
+    "buildOptions": {
+      "input": "./data/club-metadata.json",
+      "output": "./data/club-metadata.json"
+    }
+  },
+  "clubCount": 375,
+  "issueCount": 420,
+  "issueCounts": {
+    "club-asset-identity-uncertain": 19,
+    "club-asset-license-restricted": 309,
+    "club-asset-missing": 44,
+    "club-asset-multiple-review-candidates": 17,
+    "club-asset-non-crest-candidate": 31
+  },
+  "issues": [
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "accrington stanley 1891",
+      "clubId": "accrington-stanley-1891",
+      "canonicalName": "Accrington Stanley (1891)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Accrington Stanley (1891) crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "altrincham",
+      "clubId": "altrincham",
+      "canonicalName": "Altrincham",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Exeter_City_match.JPG",
+      "source": "wikipedia-pageimage-free",
+      "message": "Altrincham crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "chester city",
+      "clubId": "chester-city",
+      "canonicalName": "Chester City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Chester City crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "darlington 1883",
+      "clubId": "darlington-1883",
+      "canonicalName": "Darlington (1883)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Darlington (1883) crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "dunstable town",
+      "clubId": "dunstable-town",
+      "canonicalName": "Dunstable Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Dtfc-badge.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Dunstable Town crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "epsom and ewell",
+      "clubId": "epsom-and-ewell",
+      "canonicalName": "Epsom & Ewell",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:EpsomEwellBadge.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Epsom & Ewell crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "farsley celtic",
+      "clubId": "farsley-celtic",
+      "canonicalName": "Farsley Celtic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Citadel-1.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Farsley Celtic crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "gateshead 1899",
+      "clubId": "gateshead-1899",
+      "canonicalName": "Gateshead (1899)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Gateshead (1899) crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "glossop",
+      "clubId": "glossop",
+      "canonicalName": "Glossop",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Glossop crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "hendon",
+      "clubId": "hendon",
+      "canonicalName": "Hendon",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:HampsteadTownFC1919.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Hendon crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "leamington",
+      "clubId": "leamington",
+      "canonicalName": "Leamington",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:New_North_Bank.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Leamington crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "leeds city",
+      "clubId": "leeds-city",
+      "canonicalName": "Leeds City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Leeds_old_arms.png",
+      "source": "wikipedia-pageimage-free",
+      "message": "Leeds City crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "lewes",
+      "clubId": "lewes",
+      "canonicalName": "Lewes",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:DrippingPan.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Lewes crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "maidenhead united",
+      "clubId": "maidenhead-united",
+      "canonicalName": "Maidenhead United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Maidenhead_v_Barnet_022.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Maidenhead United crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "maidstone united 1897",
+      "clubId": "maidstone-united-1897",
+      "canonicalName": "Maidstone United (1897)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Maidstone United (1897) crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "newport county 1912",
+      "clubId": "newport-county-1912",
+      "canonicalName": "Newport County (1912)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Newport County (1912) crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "oxford city",
+      "clubId": "oxford-city",
+      "canonicalName": "Oxford City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:The_Main_Stand_at_Court_Place_Farm_-_geograph.org.uk_-_1245335.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Oxford City crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "queens park rangers",
+      "clubId": "queens-park-rangers",
+      "canonicalName": "Queens Park Rangers",
+      "assetKind": "crest",
+      "assetId": "wikidata-logo:QPr.jpg",
+      "source": "wikidata-logo",
+      "message": "Queens Park Rangers crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "stafford rangers",
+      "clubId": "stafford-rangers",
+      "canonicalName": "Stafford Rangers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Staffordfc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Stafford Rangers crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "accrington stanley",
+      "clubId": "accrington-stanley",
+      "canonicalName": "Accrington Stanley",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Accrington_Stanley_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Accrington Stanley crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "afc bournemouth",
+      "clubId": "afc-bournemouth",
+      "canonicalName": "AFC Bournemouth",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:AFC_Bournemouth_(2013).svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "AFC Bournemouth crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "afc telford united",
+      "clubId": "afc-telford-united",
+      "canonicalName": "AFC Telford United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:AFC_Telford_United_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "AFC Telford United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "afc wimbledon",
+      "clubId": "afc-wimbledon",
+      "canonicalName": "AFC Wimbledon",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:AFC_Wimbledon_(2020)_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "AFC Wimbledon crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "aldershot",
+      "clubId": "aldershot",
+      "canonicalName": "Aldershot",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Aldershot_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Aldershot crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "aldershot town",
+      "clubId": "aldershot-town",
+      "canonicalName": "Aldershot Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Aldershot_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Aldershot Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "alfreton town",
+      "clubId": "alfreton-town",
+      "canonicalName": "Alfreton Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Alfreton_Town_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Alfreton Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "altrincham",
+      "clubId": "altrincham",
+      "canonicalName": "Altrincham",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Altrincham_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Altrincham crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "alvechurch",
+      "clubId": "alvechurch",
+      "canonicalName": "Alvechurch",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Alvechurch_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Alvechurch crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "arsenal",
+      "clubId": "arsenal",
+      "canonicalName": "Arsenal",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Arsenal_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Arsenal crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "ashford united",
+      "clubId": "ashford-united",
+      "canonicalName": "Ashford United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:AshfordUnited.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Ashford United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "ashington",
+      "clubId": "ashington",
+      "canonicalName": "Ashington",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Ashington_A.F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Ashington crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "ashton united",
+      "clubId": "ashton-united",
+      "canonicalName": "Ashton United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Ashton_United_FC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Ashton United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "aston villa",
+      "clubId": "aston-villa",
+      "canonicalName": "Aston Villa",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Aston_Villa_FC_new_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Aston Villa crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "atherstone town",
+      "clubId": "atherstone-town",
+      "canonicalName": "Atherstone Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:AtherstoneTownFC.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Atherstone Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "aveley",
+      "clubId": "aveley",
+      "canonicalName": "Aveley",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Aveley_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Aveley crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "aylesbury united",
+      "clubId": "aylesbury-united",
+      "canonicalName": "Aylesbury United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Aylesbury_United_FC.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Aylesbury United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "baldock town",
+      "clubId": "baldock-town",
+      "canonicalName": "Baldock Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Baldock_Town_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Baldock Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bamber bridge",
+      "clubId": "bamber-bridge",
+      "canonicalName": "Bamber Bridge",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bamberbridgefc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bamber Bridge crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "banbury united",
+      "clubId": "banbury-united",
+      "canonicalName": "Banbury United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Banbury_United_Logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Banbury United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bangor city",
+      "clubId": "bangor-city",
+      "canonicalName": "Bangor City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bangor_City_FC_Logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bangor City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "barking",
+      "clubId": "barking",
+      "canonicalName": "Barking",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Barking_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Barking crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "barnet",
+      "clubId": "barnet",
+      "canonicalName": "Barnet",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Barnet_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Barnet crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "barnsley",
+      "clubId": "barnsley",
+      "canonicalName": "Barnsley",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Barnsley_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Barnsley crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "barrow",
+      "clubId": "barrow",
+      "canonicalName": "Barrow",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Barrow_AFC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Barrow crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "barry town united",
+      "clubId": "barry-town-united",
+      "canonicalName": "Barry Town United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Barry_Town_United_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Barry Town United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bashley",
+      "clubId": "bashley",
+      "canonicalName": "Bashley",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bashleyfc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bashley crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "basingstoke town",
+      "clubId": "basingstoke-town",
+      "canonicalName": "Basingstoke Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Basingstoke_town_fc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Basingstoke Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bedford town",
+      "clubId": "bedford-town",
+      "canonicalName": "Bedford Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bedford_Town_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bedford Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bedworth united",
+      "clubId": "bedworth-united",
+      "canonicalName": "Bedworth United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bedworth_United_FC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bedworth United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "billericay town",
+      "clubId": "billericay-town",
+      "canonicalName": "Billericay Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Billericay_Town_Football_Club_Badge.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Billericay Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "birmingham city",
+      "clubId": "birmingham-city",
+      "canonicalName": "Birmingham City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Birmingham_City_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Birmingham City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bishops stortford",
+      "clubId": "bishops-stortford",
+      "canonicalName": "Bishop's Stortford",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bishop's_Stortford_FC.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bishop's Stortford crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "blackburn rovers",
+      "clubId": "blackburn-rovers",
+      "canonicalName": "Blackburn Rovers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Blackburn_Rovers.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Blackburn Rovers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "blackpool",
+      "clubId": "blackpool",
+      "canonicalName": "Blackpool",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Blackpool_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Blackpool crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "blyth spartans",
+      "clubId": "blyth-spartans",
+      "canonicalName": "Blyth Spartans",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Blyth_Spartans_AFC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Blyth Spartans crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bognor regis town",
+      "clubId": "bognor-regis-town",
+      "canonicalName": "Bognor Regis Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bognorregistownfc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bognor Regis Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bolton wanderers",
+      "clubId": "bolton-wanderers",
+      "canonicalName": "Bolton Wanderers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bolton_Wanderers_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bolton Wanderers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "boston united",
+      "clubId": "boston-united",
+      "canonicalName": "Boston United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Boston_United_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Boston United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "brackley town",
+      "clubId": "brackley-town",
+      "canonicalName": "Brackley Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:BrackleyTownFCBadge.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Brackley Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bradford city",
+      "clubId": "bradford-city",
+      "canonicalName": "Bradford City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bradford_City_AFC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bradford City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bradford park avenue",
+      "clubId": "bradford-park-avenue",
+      "canonicalName": "Bradford (Park Avenue)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bradford_(Park_Avenue)_A.F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bradford (Park Avenue) crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "braintree town",
+      "clubId": "braintree-town",
+      "canonicalName": "Braintree Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Braintree_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Braintree Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "brentford",
+      "clubId": "brentford",
+      "canonicalName": "Brentford",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Brentford_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Brentford crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bridgend town",
+      "clubId": "bridgend-town",
+      "canonicalName": "Bridgend Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bridgendtown.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bridgend Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "brighton and hove albion",
+      "clubId": "brighton-and-hove-albion",
+      "canonicalName": "Brighton & Hove Albion",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Brighton_and_Hove_Albion_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Brighton & Hove Albion crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bristol city",
+      "clubId": "bristol-city",
+      "canonicalName": "Bristol City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bristol_City_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bristol City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bristol rovers",
+      "clubId": "bristol-rovers",
+      "canonicalName": "Bristol Rovers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bristol_Rovers_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bristol Rovers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bromley",
+      "clubId": "bromley",
+      "canonicalName": "Bromley",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bromley_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bromley crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bromsgrove rovers",
+      "clubId": "bromsgrove-rovers",
+      "canonicalName": "Bromsgrove Rovers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bromsgrove_Rovers_Badge.jpg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bromsgrove Rovers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "burnley",
+      "clubId": "burnley",
+      "canonicalName": "Burnley",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Burnley_FC_Logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Burnley crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "burscough",
+      "clubId": "burscough",
+      "canonicalName": "Burscough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Burscoughafc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Burscough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "burton albion",
+      "clubId": "burton-albion",
+      "canonicalName": "Burton Albion",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Burton_Albion_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Burton Albion crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "bury",
+      "clubId": "bury",
+      "canonicalName": "Bury",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Bury_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Bury crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "buxton",
+      "clubId": "buxton",
+      "canonicalName": "Buxton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Buxton_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Buxton crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "caernarfon town",
+      "clubId": "caernarfon-town",
+      "canonicalName": "Caernarfon Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Caernarfon_Town_F.C.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Caernarfon Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "cambridge city",
+      "clubId": "cambridge-city",
+      "canonicalName": "Cambridge City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Cambridgecityfc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Cambridge City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "canterbury city",
+      "clubId": "canterbury-city",
+      "canonicalName": "Canterbury City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Canterbury_City_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Canterbury City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "canvey island",
+      "clubId": "canvey-island",
+      "canonicalName": "Canvey Island",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Canvey_Island_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Canvey Island crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "cardiff city",
+      "clubId": "cardiff-city",
+      "canonicalName": "Cardiff City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Cardiff_City_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Cardiff City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "carlisle united",
+      "clubId": "carlisle-united",
+      "canonicalName": "Carlisle United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Carlisle_United_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Carlisle United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "carshalton athletic",
+      "clubId": "carshalton-athletic",
+      "canonicalName": "Carshalton Athletic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Carshalton_Athletic_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Carshalton Athletic crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "charlton athletic",
+      "clubId": "charlton-athletic",
+      "canonicalName": "Charlton Athletic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Charlton_Athletic_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Charlton Athletic crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "chelmsford city",
+      "clubId": "chelmsford-city",
+      "canonicalName": "Chelmsford City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Chelmsford_City_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Chelmsford City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "chelsea",
+      "clubId": "chelsea",
+      "canonicalName": "Chelsea",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Chelsea_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Chelsea crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "chesham united",
+      "clubId": "chesham-united",
+      "canonicalName": "Chesham United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Chesham_United_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Chesham United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "cheshunt",
+      "clubId": "cheshunt",
+      "canonicalName": "Cheshunt",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Cheshunt_FC.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Cheshunt crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "chester",
+      "clubId": "chester",
+      "canonicalName": "Chester",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Chester-fc.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Chester crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "chesterfield",
+      "clubId": "chesterfield",
+      "canonicalName": "Chesterfield",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Chesterfield_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Chesterfield crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "chesterfield town",
+      "clubId": "chesterfield-town",
+      "canonicalName": "Chesterfield Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Chesterfield_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Chesterfield Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "chippenham town",
+      "clubId": "chippenham-town",
+      "canonicalName": "Chippenham Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Chippenham_Town_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Chippenham Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "chorley",
+      "clubId": "chorley",
+      "canonicalName": "Chorley",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Chorley_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Chorley crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "clevedon town",
+      "clubId": "clevedon-town",
+      "canonicalName": "Clevedon Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Clevedontownafc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Clevedon Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "colchester united",
+      "clubId": "colchester-united",
+      "canonicalName": "Colchester United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Colchester_United_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Colchester United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "colne dynamoes",
+      "clubId": "colne-dynamoes",
+      "canonicalName": "Colne Dynamoes",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Colne_FC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Colne Dynamoes crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "colwyn bay",
+      "clubId": "colwyn-bay",
+      "canonicalName": "Colwyn Bay",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Colwyn_Bay_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Colwyn Bay crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "concord rangers",
+      "clubId": "concord-rangers",
+      "canonicalName": "Concord Rangers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Concord_Rangers_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Concord Rangers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "corby town",
+      "clubId": "corby-town",
+      "canonicalName": "Corby Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:CorbyTownFC.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Corby Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "coventry city",
+      "clubId": "coventry-city",
+      "canonicalName": "Coventry City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Coventry_City_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Coventry City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "crawley town",
+      "clubId": "crawley-town",
+      "canonicalName": "Crawley Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Crawley_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Crawley Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "crewe alexandra",
+      "clubId": "crewe-alexandra",
+      "canonicalName": "Crewe Alexandra",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Crewe_Alexandra.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Crewe Alexandra crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "croydon",
+      "clubId": "croydon",
+      "canonicalName": "Croydon",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Croydon_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Croydon crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "crystal palace",
+      "clubId": "crystal-palace",
+      "canonicalName": "Crystal Palace",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Crystal_Palace_FC_logo_(2022).svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Crystal Palace crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "curzon ashton",
+      "clubId": "curzon-ashton",
+      "canonicalName": "Curzon Ashton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Curzon_Ashton_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Curzon Ashton crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "dagenham and redbridge",
+      "clubId": "dagenham-and-redbridge",
+      "canonicalName": "Dagenham & Redbridge",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Dagenham_and_Redbridge_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Dagenham & Redbridge crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "darlington",
+      "clubId": "darlington",
+      "canonicalName": "Darlington",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Darlington_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Darlington crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "dartford",
+      "clubId": "dartford",
+      "canonicalName": "Dartford",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Dartford_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Dartford crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "darwen",
+      "clubId": "darwen",
+      "canonicalName": "Darwen",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Darwen_FC_crest.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Darwen crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "derby county",
+      "clubId": "derby-county",
+      "canonicalName": "Derby County",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Derby_County_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Derby County crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "doncaster rovers",
+      "clubId": "doncaster-rovers",
+      "canonicalName": "Doncaster Rovers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Doncaster_Rovers_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Doncaster Rovers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "dorchester town",
+      "clubId": "dorchester-town",
+      "canonicalName": "Dorchester Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Dorchester_Town.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Dorchester Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "dorking",
+      "clubId": "dorking",
+      "canonicalName": "Dorking",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Dorkingfc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Dorking crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "dorking wanderers",
+      "clubId": "dorking-wanderers",
+      "canonicalName": "Dorking Wanderers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Dorking_Wanderers_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Dorking Wanderers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "dover",
+      "clubId": "dover",
+      "canonicalName": "Dover",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Dover_Athletic_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Dover crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "dover athletic",
+      "clubId": "dover-athletic",
+      "canonicalName": "Dover Athletic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Dover_Athletic_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Dover Athletic crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "droylsden",
+      "clubId": "droylsden",
+      "canonicalName": "Droylsden",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Droylsden.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Droylsden crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "dudley town",
+      "clubId": "dudley-town",
+      "canonicalName": "Dudley Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Dudley_Town_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Dudley Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "dunstable town",
+      "clubId": "dunstable-town",
+      "canonicalName": "Dunstable Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Dtfc-badge.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Dunstable Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "durham city",
+      "clubId": "durham-city",
+      "canonicalName": "Durham City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:DurhamCityBadge.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Durham City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "east thurrock united",
+      "clubId": "east-thurrock-united",
+      "canonicalName": "East Thurrock United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:East_Thurrock_United_Logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "East Thurrock United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "eastbourne borough",
+      "clubId": "eastbourne-borough",
+      "canonicalName": "Eastbourne Borough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Eastbourne_Borough_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Eastbourne Borough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "ebbsfleet united",
+      "clubId": "ebbsfleet-united",
+      "canonicalName": "Ebbsfleet United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Ebbsfleet_United_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Ebbsfleet United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "emley",
+      "clubId": "emley",
+      "canonicalName": "Emley",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Emley_AFC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Emley crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "enfield",
+      "clubId": "enfield",
+      "canonicalName": "Enfield",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Enfield_1893_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Enfield crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "enfield town",
+      "clubId": "enfield-town",
+      "canonicalName": "Enfield Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Enfield_Town_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Enfield Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "epsom and ewell",
+      "clubId": "epsom-and-ewell",
+      "canonicalName": "Epsom & Ewell",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:EpsomEwellBadge.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Epsom & Ewell crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "everton",
+      "clubId": "everton",
+      "canonicalName": "Everton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Everton_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Everton crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "exeter city",
+      "clubId": "exeter-city",
+      "canonicalName": "Exeter City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Exeter_City_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Exeter City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "fareham town",
+      "clubId": "fareham-town",
+      "canonicalName": "Fareham Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Farehamtownfc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Fareham Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "farnborough",
+      "clubId": "farnborough",
+      "canonicalName": "Farnborough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Farnborough_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Farnborough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "farnborough town",
+      "clubId": "farnborough-town",
+      "canonicalName": "Farnborough Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Farnborough_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Farnborough Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "farsley celtic",
+      "clubId": "farsley-celtic",
+      "canonicalName": "Farsley Celtic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Farsley_AFC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Farsley Celtic crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "fc united of manchester",
+      "clubId": "fc-united-of-manchester",
+      "canonicalName": "FC United of Manchester",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:FC_United_of_Manchester_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "FC United of Manchester crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "fisher athletic",
+      "clubId": "fisher-athletic",
+      "canonicalName": "Fisher Athletic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Fisherathleticfc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Fisher Athletic crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "fleetwood town",
+      "clubId": "fleetwood-town",
+      "canonicalName": "Fleetwood Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Fleetwood_Town_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Fleetwood Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "folkestone invicta",
+      "clubId": "folkestone-invicta",
+      "canonicalName": "Folkestone Invicta",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Folkestone_Invicta_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Folkestone Invicta crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "forest green rovers",
+      "clubId": "forest-green-rovers",
+      "canonicalName": "Forest Green Rovers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Forest_Green_Rovers_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Forest Green Rovers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "frickley athletic",
+      "clubId": "frickley-athletic",
+      "canonicalName": "Frickley Athletic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Frickley_Athletic_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Frickley Athletic crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "gainsborough trinity",
+      "clubId": "gainsborough-trinity",
+      "canonicalName": "Gainsborough Trinity",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Gainsborough_Trinity_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Gainsborough Trinity crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "gateshead",
+      "clubId": "gateshead",
+      "canonicalName": "Gateshead",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Gateshead_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Gateshead crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "gillingham",
+      "clubId": "gillingham",
+      "canonicalName": "Gillingham",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:FC_Gillingham_Logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Gillingham crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "goole town",
+      "clubId": "goole-town",
+      "canonicalName": "Goole Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Goole_A.F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Goole Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "gosport borough",
+      "clubId": "gosport-borough",
+      "canonicalName": "Gosport Borough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Gosport_Borough_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Gosport Borough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "grantham town",
+      "clubId": "grantham-town",
+      "canonicalName": "Grantham Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Grantham_Town_F.C.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Grantham Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "grays athletic",
+      "clubId": "grays-athletic",
+      "canonicalName": "Grays Athletic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Grays_Athletic_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Grays Athletic crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "gresley rovers",
+      "clubId": "gresley-rovers",
+      "canonicalName": "Gresley Rovers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Gresley_Rovers_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Gresley Rovers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "grimsby town",
+      "clubId": "grimsby-town",
+      "canonicalName": "Grimsby Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Grimsby_Town_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Grimsby Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "guiseley",
+      "clubId": "guiseley",
+      "canonicalName": "Guiseley",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Guiseley_AFC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Guiseley crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "halesowen town",
+      "clubId": "halesowen-town",
+      "canonicalName": "Halesowen Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Halesowen_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Halesowen Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "halifax town",
+      "clubId": "halifax-town",
+      "canonicalName": "Halifax Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:HalifaxTownAFC.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Halifax Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hampton and richmond borough",
+      "clubId": "hampton-and-richmond-borough",
+      "canonicalName": "Hampton & Richmond Borough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hampton_&_Richmond_Borough_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hampton & Richmond Borough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "harlow town",
+      "clubId": "harlow-town",
+      "canonicalName": "Harlow Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Harlow_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Harlow Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "harrogate town",
+      "clubId": "harrogate-town",
+      "canonicalName": "Harrogate Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Harrogate_Town_AFC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Harrogate Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "harrow borough",
+      "clubId": "harrow-borough",
+      "canonicalName": "Harrow Borough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Harrowborough.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Harrow Borough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hartlepool united",
+      "clubId": "hartlepool-united",
+      "canonicalName": "Hartlepool United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hartlepool_United_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hartlepool United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "havant and waterlooville",
+      "clubId": "havant-and-waterlooville",
+      "canonicalName": "Havant & Waterlooville",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Havant_&_Waterlooville_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Havant & Waterlooville crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hayes",
+      "clubId": "hayes",
+      "canonicalName": "Hayes",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hayes_&_Yeading_United_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hayes crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hayes and yeading united",
+      "clubId": "hayes-and-yeading-united",
+      "canonicalName": "Hayes & Yeading United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hayes_&_Yeading_United_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hayes & Yeading United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hednesford town",
+      "clubId": "hednesford-town",
+      "canonicalName": "Hednesford Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hednesford_Town_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hednesford Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hemel hempstead town",
+      "clubId": "hemel-hempstead-town",
+      "canonicalName": "Hemel Hempstead Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hemel_Hempstead_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hemel Hempstead Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hendon",
+      "clubId": "hendon",
+      "canonicalName": "Hendon",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:HendonFcCrest.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hendon crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hereford",
+      "clubId": "hereford",
+      "canonicalName": "Hereford",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hereford_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hereford crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hereford united",
+      "clubId": "hereford-united",
+      "canonicalName": "Hereford United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hereford_United_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hereford United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "heybridge swifts",
+      "clubId": "heybridge-swifts",
+      "canonicalName": "Heybridge Swifts",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Heybridge_Swifts_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Heybridge Swifts crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hillingdon borough",
+      "clubId": "hillingdon-borough",
+      "canonicalName": "Hillingdon Borough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hillingdon_Borough_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hillingdon Borough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hinckley united",
+      "clubId": "hinckley-united",
+      "canonicalName": "Hinckley United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hinckley_A.F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hinckley United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "histon",
+      "clubId": "histon",
+      "canonicalName": "Histon",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:HistonFClogo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Histon crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hitchin town",
+      "clubId": "hitchin-town",
+      "canonicalName": "Hitchin Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:HitchinTownFC.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hitchin Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hornchurch",
+      "clubId": "hornchurch",
+      "canonicalName": "Hornchurch",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hornchurch_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hornchurch crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "horsham",
+      "clubId": "horsham",
+      "canonicalName": "Horsham",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Horsham_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Horsham crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hucknall town",
+      "clubId": "hucknall-town",
+      "canonicalName": "Hucknall Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hucknall_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hucknall Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "huddersfield town",
+      "clubId": "huddersfield-town",
+      "canonicalName": "Huddersfield Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Huddersfield_Town_AFC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Huddersfield Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hull city",
+      "clubId": "hull-city",
+      "canonicalName": "Hull City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hull_City_A.F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hull City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hungerford town",
+      "clubId": "hungerford-town",
+      "canonicalName": "Hungerford Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hungerford_Town_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hungerford Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "hyde united",
+      "clubId": "hyde-united",
+      "canonicalName": "Hyde United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hyde_United_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Hyde United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "ilkeston town",
+      "clubId": "ilkeston-town",
+      "canonicalName": "Ilkeston Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Ilkeston_FC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Ilkeston Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "ipswich town",
+      "clubId": "ipswich-town",
+      "canonicalName": "Ipswich Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Ipswich_Town.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Ipswich Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "kendal town",
+      "clubId": "kendal-town",
+      "canonicalName": "Kendal Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Kendal_Town_FC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Kendal Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "kettering town",
+      "clubId": "kettering-town",
+      "canonicalName": "Kettering Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Kettering_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Kettering Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "kidderminster harriers",
+      "clubId": "kidderminster-harriers",
+      "canonicalName": "Kidderminster Harriers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Kidderminster_Harriers_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Kidderminster Harriers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "kings lynn",
+      "clubId": "kings-lynn",
+      "canonicalName": "King's Lynn",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:King's_Lynn_F.C._(emblem).png",
+      "source": "wikipedia-pageimage-any",
+      "message": "King's Lynn crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "kings lynn town",
+      "clubId": "kings-lynn-town",
+      "canonicalName": "King's Lynn Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:King's_Lynn_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "King's Lynn Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "kingstonian",
+      "clubId": "kingstonian",
+      "canonicalName": "Kingstonian",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Kingstonian_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Kingstonian crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "knowsley united",
+      "clubId": "knowsley-united",
+      "canonicalName": "Knowsley United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Knowsley-united.png",
+      "source": "wikipedia-pageimage-free",
+      "message": "Knowsley United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "lancaster city",
+      "clubId": "lancaster-city",
+      "canonicalName": "Lancaster City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Lancaster_City_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Lancaster City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "leamington",
+      "clubId": "leamington",
+      "canonicalName": "Leamington",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Leamington_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Leamington crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "leatherhead",
+      "clubId": "leatherhead",
+      "canonicalName": "Leatherhead",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Leatherhead_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Leatherhead crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "leeds united",
+      "clubId": "leeds-united",
+      "canonicalName": "Leeds United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Leeds_United_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Leeds United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "leek town",
+      "clubId": "leek-town",
+      "canonicalName": "Leek Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Leek_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Leek Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "leicester city",
+      "clubId": "leicester-city",
+      "canonicalName": "Leicester City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Leicester_City_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Leicester City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "leigh genesis",
+      "clubId": "leigh-genesis",
+      "canonicalName": "Leigh Genesis",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:LeighRMICrest.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Leigh Genesis crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "lewes",
+      "clubId": "lewes",
+      "canonicalName": "Lewes",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Lewes_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Lewes crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "leyton orient",
+      "clubId": "leyton-orient",
+      "canonicalName": "Leyton Orient",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Leyton_Orient_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Leyton Orient crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "lincoln city",
+      "clubId": "lincoln-city",
+      "canonicalName": "Lincoln City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Lincoln_City_FC_2024_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Lincoln City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "liverpool",
+      "clubId": "liverpool",
+      "canonicalName": "Liverpool",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Liverpool_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Liverpool crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "lowestoft town",
+      "clubId": "lowestoft-town",
+      "canonicalName": "Lowestoft Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Lowestoft_Town_Badge.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Lowestoft Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "luton town",
+      "clubId": "luton-town",
+      "canonicalName": "Luton Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Luton_Town_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Luton Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "macclesfield",
+      "clubId": "macclesfield",
+      "canonicalName": "Macclesfield",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Macclesfield_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Macclesfield crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "macclesfield town",
+      "clubId": "macclesfield-town",
+      "canonicalName": "Macclesfield Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Macclesfield_Town_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Macclesfield Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "maidenhead united",
+      "clubId": "maidenhead-united",
+      "canonicalName": "Maidenhead United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Maidenhead_United_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Maidenhead United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "maidstone united",
+      "clubId": "maidstone-united",
+      "canonicalName": "Maidstone United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Maidstone_United_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Maidstone United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "manchester city",
+      "clubId": "manchester-city",
+      "canonicalName": "Manchester City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Manchester_City_FC_badge.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Manchester City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "manchester united",
+      "clubId": "manchester-united",
+      "canonicalName": "Manchester United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Manchester_United_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Manchester United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "mansfield town",
+      "clubId": "mansfield-town",
+      "canonicalName": "Mansfield Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Mansfield_Town_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Mansfield Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "margate",
+      "clubId": "margate",
+      "canonicalName": "Margate",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Margate_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Margate crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "marine",
+      "clubId": "marine",
+      "canonicalName": "Marine",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Marine_AFC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Marine crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "marlow",
+      "clubId": "marlow",
+      "canonicalName": "Marlow",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Marlow_FC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Marlow crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "matlock town",
+      "clubId": "matlock-town",
+      "canonicalName": "Matlock Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Matlock_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Matlock Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "merthyr town",
+      "clubId": "merthyr-town",
+      "canonicalName": "Merthyr Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Merthyr_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Merthyr Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "merthyr tydfil",
+      "clubId": "merthyr-tydfil",
+      "canonicalName": "Merthyr Tydfil",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Merthyr_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Merthyr Tydfil crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "middlesbrough",
+      "clubId": "middlesbrough",
+      "canonicalName": "Middlesbrough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Middlesbrough_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Middlesbrough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "millwall",
+      "clubId": "millwall",
+      "canonicalName": "Millwall",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Millwall_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Millwall crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "minehead",
+      "clubId": "minehead",
+      "canonicalName": "Minehead",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Minehead_A.F.C.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Minehead crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "molesey",
+      "clubId": "molesey",
+      "canonicalName": "Molesey",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Molesey_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Molesey crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "moor green",
+      "clubId": "moor-green",
+      "canonicalName": "Moor Green",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:MoorGreenFCCrest.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Moor Green crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "morecambe",
+      "clubId": "morecambe",
+      "canonicalName": "Morecambe",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Morecambe_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Morecambe crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "mossley",
+      "clubId": "mossley",
+      "canonicalName": "Mossley",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Mossley_AFC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Mossley crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "needham market",
+      "clubId": "needham-market",
+      "canonicalName": "Needham Market",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Needham_Market_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Needham Market crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "nelson",
+      "clubId": "nelson",
+      "canonicalName": "Nelson",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Nelson_FC_Logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Nelson crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "new brighton",
+      "clubId": "new-brighton",
+      "canonicalName": "New Brighton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:New_Brighton_AFC_crest.jpg",
+      "source": "wikipedia-pageimage-any",
+      "message": "New Brighton crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "newcastle united",
+      "clubId": "newcastle-united",
+      "canonicalName": "Newcastle United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Newcastle_United_Logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Newcastle United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "newport county",
+      "clubId": "newport-county",
+      "canonicalName": "Newport County",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Newport_County_AFC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Newport County crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "newport isle of wight",
+      "clubId": "newport-isle-of-wight",
+      "canonicalName": "Newport (Isle of Wight)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Newportfclogo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Newport (Isle of Wight) crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "north ferriby united",
+      "clubId": "north-ferriby-united",
+      "canonicalName": "North Ferriby United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:North_Ferriby_United_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "North Ferriby United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "northampton town",
+      "clubId": "northampton-town",
+      "canonicalName": "Northampton Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Northampton_Town_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Northampton Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "northwich victoria",
+      "clubId": "northwich-victoria",
+      "canonicalName": "Northwich Victoria",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Northwich_Victoria_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Northwich Victoria crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "norwich city",
+      "clubId": "norwich-city",
+      "canonicalName": "Norwich City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Norwich_City_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Norwich City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "nottingham forest",
+      "clubId": "nottingham-forest",
+      "canonicalName": "Nottingham Forest",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Nottingham_Forest_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Nottingham Forest crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "notts county",
+      "clubId": "notts-county",
+      "canonicalName": "Notts County",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Notts_County_Logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Notts County crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "nuneaton borough",
+      "clubId": "nuneaton-borough",
+      "canonicalName": "Nuneaton Borough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Nuneaton_Town_FC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Nuneaton Borough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "nuneaton town",
+      "clubId": "nuneaton-town",
+      "canonicalName": "Nuneaton Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Nuneaton_Town_FC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Nuneaton Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "oldham athletic",
+      "clubId": "oldham-athletic",
+      "canonicalName": "Oldham Athletic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Oldham_Athletic_AFC_(emblem).svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Oldham Athletic crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "oxford city",
+      "clubId": "oxford-city",
+      "canonicalName": "Oxford City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Oxford_City_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Oxford City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "oxford united",
+      "clubId": "oxford-united",
+      "canonicalName": "Oxford United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Oxford_United_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Oxford United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "peterborough sports",
+      "clubId": "peterborough-sports",
+      "canonicalName": "Peterborough Sports",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Peterborough_Sports_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Peterborough Sports crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "plymouth argyle",
+      "clubId": "plymouth-argyle",
+      "canonicalName": "Plymouth Argyle",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Plymouth_Argyle_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Plymouth Argyle crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "poole town",
+      "clubId": "poole-town",
+      "canonicalName": "Poole Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Poole_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Poole Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "port vale",
+      "clubId": "port-vale",
+      "canonicalName": "Port Vale",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Port_Vale_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Port Vale crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "preston north end",
+      "clubId": "preston-north-end",
+      "canonicalName": "Preston North End",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Preston_North_End_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Preston North End crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "radcliffe",
+      "clubId": "radcliffe",
+      "canonicalName": "Radcliffe",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Radcliffe_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Radcliffe crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "reading",
+      "clubId": "reading",
+      "canonicalName": "Reading",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Reading_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Reading crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "redbridge",
+      "clubId": "redbridge",
+      "canonicalName": "Redbridge",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Redbridge_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Redbridge crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "redditch united",
+      "clubId": "redditch-united",
+      "canonicalName": "Redditch United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:RedditchUnitedFC.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Redditch United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "rhyl",
+      "clubId": "rhyl",
+      "canonicalName": "Rhyl",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Rhyl_FC_Logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Rhyl crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "road-sea southampton",
+      "clubId": "road-sea-southampton",
+      "canonicalName": "Road-Sea Southampton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Road-Sea_Southampton_F.C.jpg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Road-Sea Southampton crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "rochdale",
+      "clubId": "rochdale",
+      "canonicalName": "Rochdale",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Rochdale_AFC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Rochdale crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "rotherham county",
+      "clubId": "rotherham-county",
+      "canonicalName": "Rotherham County",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Rotherham_County_FC_crest.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Rotherham County crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "rotherham united",
+      "clubId": "rotherham-united",
+      "canonicalName": "Rotherham United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Rotherham_United_F.C._svg.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Rotherham United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "rugby town",
+      "clubId": "rugby-town",
+      "canonicalName": "Rugby Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Rugby_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Rugby Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "rushall olympic",
+      "clubId": "rushall-olympic",
+      "canonicalName": "Rushall Olympic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Rushallolympicfc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Rushall Olympic crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "rushden and diamonds",
+      "clubId": "rushden-and-diamonds",
+      "canonicalName": "Rushden & Diamonds",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Rushden_&_Diamonds.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Rushden & Diamonds crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "salford city",
+      "clubId": "salford-city",
+      "canonicalName": "Salford City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Salford_City_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Salford City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "salisbury",
+      "clubId": "salisbury",
+      "canonicalName": "Salisbury",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Salisbury_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Salisbury crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "salisbury city",
+      "clubId": "salisbury-city",
+      "canonicalName": "Salisbury City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Salisbury_City_FC.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Salisbury City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "scarborough",
+      "clubId": "scarborough",
+      "canonicalName": "Scarborough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Scarborough_Athletic_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Scarborough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "scarborough athletic",
+      "clubId": "scarborough-athletic",
+      "canonicalName": "Scarborough Athletic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Scarborough_Athletic_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Scarborough Athletic crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "scunthorpe united",
+      "clubId": "scunthorpe-united",
+      "canonicalName": "Scunthorpe United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Scunthorpe_United_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Scunthorpe United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "sheffield united",
+      "clubId": "sheffield-united",
+      "canonicalName": "Sheffield United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Sheffield_United_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Sheffield United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "shrewsbury town",
+      "clubId": "shrewsbury-town",
+      "canonicalName": "Shrewsbury Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Shrewsbury_Town_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Shrewsbury Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "sittingbourne",
+      "clubId": "sittingbourne",
+      "canonicalName": "Sittingbourne",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Sittingbourne_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Sittingbourne crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "slough town",
+      "clubId": "slough-town",
+      "canonicalName": "Slough Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Slough_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Slough Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "solihull borough",
+      "clubId": "solihull-borough",
+      "canonicalName": "Solihull Borough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Solihullboroughafc.jpg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Solihull Borough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "solihull moors",
+      "clubId": "solihull-moors",
+      "canonicalName": "Solihull Moors",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Solihull_Moors_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Solihull Moors crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "south liverpool",
+      "clubId": "south-liverpool",
+      "canonicalName": "South Liverpool",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:South_Liverpool_FC_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "South Liverpool crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "south shields",
+      "clubId": "south-shields",
+      "canonicalName": "South Shields",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:South_Shields_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "South Shields crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "southampton",
+      "clubId": "southampton",
+      "canonicalName": "Southampton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:FC_Southampton.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Southampton crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "southend united",
+      "clubId": "southend-united",
+      "canonicalName": "Southend United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Southend_United.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Southend United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "southport",
+      "clubId": "southport",
+      "canonicalName": "Southport",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Southport_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Southport crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "spennymoor town",
+      "clubId": "spennymoor-town",
+      "canonicalName": "Spennymoor Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Spennymoor_Town_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Spennymoor Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "spennymoor united",
+      "clubId": "spennymoor-united",
+      "canonicalName": "Spennymoor United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Spennymoor_Town_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Spennymoor United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "st albans city",
+      "clubId": "st-albans-city",
+      "canonicalName": "St Albans City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:St_Albans_City_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "St Albans City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "st leonards",
+      "clubId": "st-leonards",
+      "canonicalName": "St. Leonards",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:StLeonardsCrest.gif",
+      "source": "wikipedia-pageimage-any",
+      "message": "St. Leonards crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "stafford rangers",
+      "clubId": "stafford-rangers",
+      "canonicalName": "Stafford Rangers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Staffordfc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Stafford Rangers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "stalybridge celtic",
+      "clubId": "stalybridge-celtic",
+      "canonicalName": "Stalybridge Celtic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:StalybridgeCeltic.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Stalybridge Celtic crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "stevenage",
+      "clubId": "stevenage",
+      "canonicalName": "Stevenage",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Stevenage_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Stevenage crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "stockport county",
+      "clubId": "stockport-county",
+      "canonicalName": "Stockport County",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Stockport_County_FC_logo_2020.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Stockport County crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "stourbridge",
+      "clubId": "stourbridge",
+      "canonicalName": "Stourbridge",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Stourbridge_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Stourbridge crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "sudbury town",
+      "clubId": "sudbury-town",
+      "canonicalName": "Sudbury Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:AFC_Sudbury_Logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Sudbury Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "sunderland",
+      "clubId": "sunderland",
+      "canonicalName": "Sunderland",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Logo_Sunderland.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Sunderland crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "sutton coldfield town",
+      "clubId": "sutton-coldfield-town",
+      "canonicalName": "Sutton Coldfield Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Sutton_Coldfield_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Sutton Coldfield Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "sutton united",
+      "clubId": "sutton-united",
+      "canonicalName": "Sutton United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Sutton_United_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Sutton United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "swansea city",
+      "clubId": "swansea-city",
+      "canonicalName": "Swansea City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Swansea_City_AFC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Swansea City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "swindon town",
+      "clubId": "swindon-town",
+      "canonicalName": "Swindon Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Swindon_Town_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Swindon Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "tamworth",
+      "clubId": "tamworth",
+      "canonicalName": "Tamworth",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Tamworth_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Tamworth crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "taunton town",
+      "clubId": "taunton-town",
+      "canonicalName": "Taunton Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Taunton_Town_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Taunton Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "telford united",
+      "clubId": "telford-united",
+      "canonicalName": "Telford United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:AFC_Telford_United_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Telford United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "thurrock",
+      "clubId": "thurrock",
+      "canonicalName": "Thurrock",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Thurrock_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Thurrock crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "tilbury",
+      "clubId": "tilbury",
+      "canonicalName": "Tilbury",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Tilbury_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Tilbury crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "tiverton town",
+      "clubId": "tiverton-town",
+      "canonicalName": "Tiverton Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:TivertonTown.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Tiverton Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "tonbridge angels",
+      "clubId": "tonbridge-angels",
+      "canonicalName": "Tonbridge Angels",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Tonbridge_Angels_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Tonbridge Angels crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "tooting and mitcham united",
+      "clubId": "tooting-and-mitcham-united",
+      "canonicalName": "Tooting & Mitcham United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Tooting&Mitcham.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Tooting & Mitcham United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "torquay united",
+      "clubId": "torquay-united",
+      "canonicalName": "Torquay United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Torquay_United_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Torquay United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "tottenham hotspur",
+      "clubId": "tottenham-hotspur",
+      "canonicalName": "Tottenham Hotspur",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Tottenham_Hotspur.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Tottenham Hotspur crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "truro city",
+      "clubId": "truro-city",
+      "canonicalName": "Truro City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Truro_City_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Truro City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "vauxhall motors",
+      "clubId": "vauxhall-motors",
+      "canonicalName": "Vauxhall Motors",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Vauxhall_Motors_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Vauxhall Motors crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "walsall",
+      "clubId": "walsall",
+      "canonicalName": "Walsall",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Walsall_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Walsall crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "walton and hersham",
+      "clubId": "walton-and-hersham",
+      "canonicalName": "Walton & Hersham",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Walton_&_Hersham_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Walton & Hersham crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "warrington town",
+      "clubId": "warrington-town",
+      "canonicalName": "Warrington Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Warrington_Town_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Warrington Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "waterlooville",
+      "clubId": "waterlooville",
+      "canonicalName": "Waterlooville",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Havant_&_Waterlooville_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Waterlooville crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "watford",
+      "clubId": "watford",
+      "canonicalName": "Watford",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Watford.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Watford crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "wealdstone",
+      "clubId": "wealdstone",
+      "canonicalName": "Wealdstone",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Wealdstone_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Wealdstone crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "welling united",
+      "clubId": "welling-united",
+      "canonicalName": "Welling United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:WellingUnitedBadge.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Welling United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "wellingborough town",
+      "clubId": "wellingborough-town",
+      "canonicalName": "Wellingborough Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Wellingborough_Town_logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Wellingborough Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "west bromwich albion",
+      "clubId": "west-bromwich-albion",
+      "canonicalName": "West Bromwich Albion",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:West_Bromwich_Albion.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "West Bromwich Albion crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "west ham united",
+      "clubId": "west-ham-united",
+      "canonicalName": "West Ham United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:West_Ham_United_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "West Ham United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "weston-super-mare",
+      "clubId": "weston-super-mare",
+      "canonicalName": "Weston-super-Mare",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Weston-super-Mare_AFC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Weston-super-Mare crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "weymouth",
+      "clubId": "weymouth",
+      "canonicalName": "Weymouth",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Weymouth_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Weymouth crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "whitehawk",
+      "clubId": "whitehawk",
+      "canonicalName": "Whitehawk",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Whitehawk_F.C._logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Whitehawk crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "whitley bay",
+      "clubId": "whitley-bay",
+      "canonicalName": "Whitley Bay",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Whitley_Bay_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Whitley Bay crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "wigan athletic",
+      "clubId": "wigan-athletic",
+      "canonicalName": "Wigan Athletic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Wigan_Athletic.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Wigan Athletic crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "wigan borough",
+      "clubId": "wigan-borough",
+      "canonicalName": "Wigan Borough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Wigan_Borough_FC_crest.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Wigan Borough crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "willenhall town",
+      "clubId": "willenhall-town",
+      "canonicalName": "Willenhall Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:WillenhallTownLogo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Willenhall Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "wimbledon",
+      "clubId": "wimbledon",
+      "canonicalName": "Wimbledon",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:AFC_Wimbledon_(2020)_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Wimbledon crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "windsor and eton",
+      "clubId": "windsor-and-eton",
+      "canonicalName": "Windsor & Eton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Windsorandetonfc.jpg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Windsor & Eton crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "winsford united",
+      "clubId": "winsford-united",
+      "canonicalName": "Winsford United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Winsford_United_Crest.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Winsford United crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "witton albion",
+      "clubId": "witton-albion",
+      "canonicalName": "Witton Albion",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Wittonalbionfc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Witton Albion crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "wivenhoe town",
+      "clubId": "wivenhoe-town",
+      "canonicalName": "Wivenhoe Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Wivenhoe_Town_F.C._logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Wivenhoe Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "woking",
+      "clubId": "woking",
+      "canonicalName": "Woking",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Woking_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Woking crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "wokingham town",
+      "clubId": "wokingham-town",
+      "canonicalName": "Wokingham Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Wokingham_Emmbrook_Logo.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Wokingham Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "wolverhampton wanderers",
+      "clubId": "wolverhampton-wanderers",
+      "canonicalName": "Wolverhampton Wanderers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Wolverhampton_Wanderers_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Wolverhampton Wanderers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "worcester city",
+      "clubId": "worcester-city",
+      "canonicalName": "Worcester City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Worcester_City_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Worcester City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "workington",
+      "clubId": "workington",
+      "canonicalName": "Workington",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Workington_AFC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Workington crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "worksop town",
+      "clubId": "worksop-town",
+      "canonicalName": "Worksop Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Worksop_Town_FC_updated_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Worksop Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "worthing",
+      "clubId": "worthing",
+      "canonicalName": "Worthing",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Worthing_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Worthing crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "wrexham",
+      "clubId": "wrexham",
+      "canonicalName": "Wrexham",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Wrexham_A.F.C._Logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Wrexham crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "wycombe wanderers",
+      "clubId": "wycombe-wanderers",
+      "canonicalName": "Wycombe Wanderers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Wycombe_Wanderers_FC_logo.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Wycombe Wanderers crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "yeading",
+      "clubId": "yeading",
+      "canonicalName": "Yeading",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Hayes_&_Yeading_United_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Yeading crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "yeovil town",
+      "clubId": "yeovil-town",
+      "canonicalName": "Yeovil Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Yeovil_Town_FC_crest.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Yeovil Town crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "york city",
+      "clubId": "york-city",
+      "canonicalName": "York City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:York_City_FC.svg",
+      "source": "wikipedia-pageimage-any",
+      "message": "York City crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "aberdare athletic",
+      "clubId": "aberdare-athletic",
+      "canonicalName": "Aberdare Athletic",
+      "assetKind": "crest",
+      "message": "Aberdare Athletic has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "accrington",
+      "clubId": "accrington",
+      "canonicalName": "Accrington",
+      "assetKind": "crest",
+      "message": "Accrington has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "addlestone and weybridge town",
+      "clubId": "addlestone-and-weybridge-town",
+      "canonicalName": "Addlestone & Weybridge Town",
+      "assetKind": "crest",
+      "message": "Addlestone & Weybridge Town has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "afc fylde",
+      "clubId": "afc-fylde",
+      "canonicalName": "AFC Fylde",
+      "assetKind": "crest",
+      "message": "AFC Fylde has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "afc totton",
+      "clubId": "afc-totton",
+      "canonicalName": "AFC Totton",
+      "assetKind": "crest",
+      "message": "AFC Totton has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "andover",
+      "clubId": "andover",
+      "canonicalName": "Andover",
+      "assetKind": "crest",
+      "message": "Andover has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "birmingham st georges",
+      "clubId": "birmingham-st-georges",
+      "canonicalName": "Birmingham St George's",
+      "assetKind": "crest",
+      "message": "Birmingham St George's has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "bishop auckland",
+      "clubId": "bishop-auckland",
+      "canonicalName": "Bishop Auckland",
+      "assetKind": "crest",
+      "message": "Bishop Auckland has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "bootle",
+      "clubId": "bootle",
+      "canonicalName": "Bootle",
+      "assetKind": "crest",
+      "message": "Bootle has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "burton swifts",
+      "clubId": "burton-swifts",
+      "canonicalName": "Burton Swifts",
+      "assetKind": "crest",
+      "message": "Burton Swifts has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "burton united",
+      "clubId": "burton-united",
+      "canonicalName": "Burton United",
+      "assetKind": "crest",
+      "message": "Burton United has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "burton wanderers",
+      "clubId": "burton-wanderers",
+      "canonicalName": "Burton Wanderers",
+      "assetKind": "crest",
+      "message": "Burton Wanderers has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "chertsey town",
+      "clubId": "chertsey-town",
+      "canonicalName": "Chertsey Town",
+      "assetKind": "crest",
+      "message": "Chertsey Town has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "dagenham",
+      "clubId": "dagenham",
+      "canonicalName": "Dagenham",
+      "assetKind": "crest",
+      "message": "Dagenham has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "eastleigh",
+      "clubId": "eastleigh",
+      "canonicalName": "Eastleigh",
+      "assetKind": "crest",
+      "message": "Eastleigh has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "eastwood town",
+      "clubId": "eastwood-town",
+      "canonicalName": "Eastwood Town",
+      "assetKind": "crest",
+      "message": "Eastwood Town has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "fc halifax town",
+      "clubId": "fc-halifax-town",
+      "canonicalName": "FC Halifax Town",
+      "assetKind": "crest",
+      "message": "FC Halifax Town has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "folkestone",
+      "clubId": "folkestone",
+      "canonicalName": "Folkestone",
+      "assetKind": "crest",
+      "message": "Folkestone has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "hastings united",
+      "clubId": "hastings-united",
+      "canonicalName": "Hastings United",
+      "assetKind": "crest",
+      "message": "Hastings United has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "hastings united 1948",
+      "clubId": "hastings-united-1948",
+      "canonicalName": "Hastings United (1948)",
+      "assetKind": "crest",
+      "message": "Hastings United (1948) has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "hounslow",
+      "clubId": "hounslow",
+      "canonicalName": "Hounslow",
+      "assetKind": "crest",
+      "message": "Hounslow has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "leicester united",
+      "clubId": "leicester-united",
+      "canonicalName": "Leicester United",
+      "assetKind": "crest",
+      "message": "Leicester United has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "leyton",
+      "clubId": "leyton",
+      "canonicalName": "Leyton",
+      "assetKind": "crest",
+      "message": "Leyton has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "loughborough",
+      "clubId": "loughborough",
+      "canonicalName": "Loughborough",
+      "assetKind": "crest",
+      "message": "Loughborough has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "middlesbrough ironopolis",
+      "clubId": "middlesbrough-ironopolis",
+      "canonicalName": "Middlesbrough Ironopolis",
+      "assetKind": "crest",
+      "message": "Middlesbrough Ironopolis has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "milton keynes city",
+      "clubId": "milton-keynes-city",
+      "canonicalName": "Milton Keynes City",
+      "assetKind": "crest",
+      "message": "Milton Keynes City has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "new brighton tower",
+      "clubId": "new-brighton-tower",
+      "canonicalName": "New Brighton Tower",
+      "assetKind": "crest",
+      "message": "New Brighton Tower has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "northwood",
+      "clubId": "northwood",
+      "canonicalName": "Northwood",
+      "assetKind": "crest",
+      "message": "Northwood has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "oswestry town",
+      "clubId": "oswestry-town",
+      "canonicalName": "Oswestry Town",
+      "assetKind": "crest",
+      "message": "Oswestry Town has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "redbridge forest",
+      "clubId": "redbridge-forest",
+      "canonicalName": "Redbridge Forest",
+      "assetKind": "crest",
+      "message": "Redbridge Forest has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "rotherham town",
+      "clubId": "rotherham-town",
+      "canonicalName": "Rotherham Town",
+      "assetKind": "crest",
+      "message": "Rotherham Town has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "rothwell town",
+      "clubId": "rothwell-town",
+      "canonicalName": "Rothwell Town",
+      "assetKind": "crest",
+      "message": "Rothwell Town has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "runcorn fc halton",
+      "clubId": "runcorn-fc-halton",
+      "canonicalName": "Runcorn FC Halton",
+      "assetKind": "crest",
+      "message": "Runcorn FC Halton has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "sheffield wednesday",
+      "clubId": "sheffield-wednesday",
+      "canonicalName": "Sheffield Wednesday",
+      "assetKind": "crest",
+      "message": "Sheffield Wednesday has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "shepshed dynamo",
+      "clubId": "shepshed-dynamo",
+      "canonicalName": "Shepshed Dynamo",
+      "assetKind": "crest",
+      "message": "Shepshed Dynamo has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "staines town",
+      "clubId": "staines-town",
+      "canonicalName": "Staines Town",
+      "assetKind": "crest",
+      "message": "Staines Town has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "sunderland albion",
+      "clubId": "sunderland-albion",
+      "canonicalName": "Sunderland Albion",
+      "assetKind": "crest",
+      "message": "Sunderland Albion has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "team bath",
+      "clubId": "team-bath",
+      "canonicalName": "Team Bath",
+      "assetKind": "crest",
+      "message": "Team Bath has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "thames",
+      "clubId": "thames",
+      "canonicalName": "Thames",
+      "assetKind": "crest",
+      "message": "Thames has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "tranmere rovers",
+      "clubId": "tranmere-rovers",
+      "canonicalName": "Tranmere Rovers",
+      "assetKind": "crest",
+      "message": "Tranmere Rovers has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "trowbridge town",
+      "clubId": "trowbridge-town",
+      "canonicalName": "Trowbridge Town",
+      "assetKind": "crest",
+      "message": "Trowbridge Town has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "walthamstow avenue",
+      "clubId": "walthamstow-avenue",
+      "canonicalName": "Walthamstow Avenue",
+      "assetKind": "crest",
+      "message": "Walthamstow Avenue has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "whitby town",
+      "clubId": "whitby-town",
+      "canonicalName": "Whitby Town",
+      "assetKind": "crest",
+      "message": "Whitby Town has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-missing",
+      "clubKey": "witney town",
+      "clubId": "witney-town",
+      "canonicalName": "Witney Town",
+      "assetKind": "crest",
+      "message": "Witney Town has no crest asset candidates"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "altrincham",
+      "clubId": "altrincham",
+      "canonicalName": "Altrincham",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Altrincham has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "atherstone town",
+      "clubId": "atherstone-town",
+      "canonicalName": "Atherstone Town",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Atherstone Town has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "bromley",
+      "clubId": "bromley",
+      "canonicalName": "Bromley",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Bromley has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "clevedon town",
+      "clubId": "clevedon-town",
+      "canonicalName": "Clevedon Town",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Clevedon Town has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "farsley celtic",
+      "clubId": "farsley-celtic",
+      "canonicalName": "Farsley Celtic",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Farsley Celtic has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "gainsborough trinity",
+      "clubId": "gainsborough-trinity",
+      "canonicalName": "Gainsborough Trinity",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Gainsborough Trinity has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "hendon",
+      "clubId": "hendon",
+      "canonicalName": "Hendon",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Hendon has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "hereford",
+      "clubId": "hereford",
+      "canonicalName": "Hereford",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Hereford has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "hereford united",
+      "clubId": "hereford-united",
+      "canonicalName": "Hereford United",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Hereford United has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "leamington",
+      "clubId": "leamington",
+      "canonicalName": "Leamington",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Leamington has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "lewes",
+      "clubId": "lewes",
+      "canonicalName": "Lewes",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Lewes has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "maidenhead united",
+      "clubId": "maidenhead-united",
+      "canonicalName": "Maidenhead United",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Maidenhead United has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "marlow",
+      "clubId": "marlow",
+      "canonicalName": "Marlow",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Marlow has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "middlesbrough",
+      "clubId": "middlesbrough",
+      "canonicalName": "Middlesbrough",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Middlesbrough has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "oxford city",
+      "clubId": "oxford-city",
+      "canonicalName": "Oxford City",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Oxford City has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "peterborough sports",
+      "clubId": "peterborough-sports",
+      "canonicalName": "Peterborough Sports",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Peterborough Sports has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-multiple-review-candidates",
+      "clubKey": "wivenhoe town",
+      "clubId": "wivenhoe-town",
+      "canonicalName": "Wivenhoe Town",
+      "assetKind": "crest",
+      "candidateCount": 2,
+      "message": "Wivenhoe Town has crest candidates but no usable preferred asset"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "accrington stanley 1891",
+      "clubId": "accrington-stanley-1891",
+      "canonicalName": "Accrington Stanley (1891)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Accrington Stanley (1891) crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "altrincham",
+      "clubId": "altrincham",
+      "canonicalName": "Altrincham",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Exeter_City_match.JPG",
+      "source": "wikipedia-pageimage-free",
+      "message": "Altrincham crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "atherstone town",
+      "clubId": "atherstone-town",
+      "canonicalName": "Atherstone Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Atherstone_Town_FC_2009.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Atherstone Town crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "bromley",
+      "clubId": "bromley",
+      "canonicalName": "Bromley",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Bromley_FC_League_Performance.svg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Bromley crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "chester city",
+      "clubId": "chester-city",
+      "canonicalName": "Chester City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Chester City crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "clevedon town",
+      "clubId": "clevedon-town",
+      "canonicalName": "Clevedon Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Clevedon_Town_2007.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Clevedon Town crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "darlington 1883",
+      "clubId": "darlington-1883",
+      "canonicalName": "Darlington (1883)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Darlington (1883) crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "farsley celtic",
+      "clubId": "farsley-celtic",
+      "canonicalName": "Farsley Celtic",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Citadel-1.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Farsley Celtic crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "gainsborough trinity",
+      "clubId": "gainsborough-trinity",
+      "canonicalName": "Gainsborough Trinity",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Gainsborough_Trinity_1966–67.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Gainsborough Trinity crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "gateshead 1899",
+      "clubId": "gateshead-1899",
+      "canonicalName": "Gateshead (1899)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Gateshead (1899) crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "glossop",
+      "clubId": "glossop",
+      "canonicalName": "Glossop",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Glossop crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "hendon",
+      "clubId": "hendon",
+      "canonicalName": "Hendon",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:HampsteadTownFC1919.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Hendon crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "hereford",
+      "clubId": "hereford",
+      "canonicalName": "Hereford",
+      "assetKind": "crest",
+      "assetId": "wikidata-logo:Forever United, Edgar Street, Hereford - geograph.org.uk - 5596516.jpg",
+      "source": "wikidata-logo",
+      "message": "Hereford crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "hereford united",
+      "clubId": "hereford-united",
+      "canonicalName": "Hereford United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Hereford_United_League_Performance.svg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Hereford United crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "knowsley united",
+      "clubId": "knowsley-united",
+      "canonicalName": "Knowsley United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Knowsley-united.png",
+      "source": "wikipedia-pageimage-free",
+      "message": "Knowsley United crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "leamington",
+      "clubId": "leamington",
+      "canonicalName": "Leamington",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:New_North_Bank.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Leamington crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "leeds city",
+      "clubId": "leeds-city",
+      "canonicalName": "Leeds City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Leeds_old_arms.png",
+      "source": "wikipedia-pageimage-free",
+      "message": "Leeds City crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "lewes",
+      "clubId": "lewes",
+      "canonicalName": "Lewes",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:DrippingPan.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Lewes crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "maidenhead united",
+      "clubId": "maidenhead-united",
+      "canonicalName": "Maidenhead United",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Maidenhead_v_Barnet_022.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Maidenhead United crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "maidstone united 1897",
+      "clubId": "maidstone-united-1897",
+      "canonicalName": "Maidstone United (1897)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Maidstone United (1897) crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "marlow",
+      "clubId": "marlow",
+      "canonicalName": "Marlow",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Marlow1894.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Marlow crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "middlesbrough",
+      "clubId": "middlesbrough",
+      "canonicalName": "Middlesbrough",
+      "assetKind": "crest",
+      "assetId": "wikidata-logo:Middlesbrough Walk (27470064759).jpg",
+      "source": "wikidata-logo",
+      "message": "Middlesbrough crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "newport county 1912",
+      "clubId": "newport-county-1912",
+      "canonicalName": "Newport County (1912)",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Newport County (1912) crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "oxford city",
+      "clubId": "oxford-city",
+      "canonicalName": "Oxford City",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:The_Main_Stand_at_Court_Place_Farm_-_geograph.org.uk_-_1245335.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Oxford City crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "peterborough sports",
+      "clubId": "peterborough-sports",
+      "canonicalName": "Peterborough Sports",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:Peterborough_Sports_vs_Guiseley_FC_-_FA_Cup_3rd_qualifying_round_2019.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Peterborough Sports crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "queens park rangers",
+      "clubId": "queens-park-rangers",
+      "canonicalName": "Queens Park Rangers",
+      "assetKind": "crest",
+      "assetId": "wikidata-logo:QPr.jpg",
+      "source": "wikidata-logo",
+      "message": "Queens Park Rangers crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "road-sea southampton",
+      "clubId": "road-sea-southampton",
+      "canonicalName": "Road-Sea Southampton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Road-Sea_Southampton_F.C.jpg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Road-Sea Southampton crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "solihull borough",
+      "clubId": "solihull-borough",
+      "canonicalName": "Solihull Borough",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Solihullboroughafc.jpg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Solihull Borough crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "stafford rangers",
+      "clubId": "stafford-rangers",
+      "canonicalName": "Stafford Rangers",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Staffordfc.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Stafford Rangers crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "windsor and eton",
+      "clubId": "windsor-and-eton",
+      "canonicalName": "Windsor & Eton",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Windsorandetonfc.jpg",
+      "source": "wikipedia-pageimage-any",
+      "message": "Windsor & Eton crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "wivenhoe town",
+      "clubId": "wivenhoe-town",
+      "canonicalName": "Wivenhoe Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-free:BroadLaneWivenhoeTown21Jan2017.jpg",
+      "source": "wikipedia-pageimage-free",
+      "message": "Wivenhoe Town crest candidate does not look like a crest/logo filename"
+    }
+  ]
+}

--- a/data/club-assets-review.json
+++ b/data/club-assets-review.json
@@ -2,8 +2,8 @@
   "metadata": {
     "schemaVersion": 1,
     "generator": "club-assets-review",
-    "generatedAt": "2026-06-20T19:31:27.733Z",
-    "gitSha": "e0edd04",
+    "generatedAt": "2026-06-20T19:54:09.020Z",
+    "gitSha": "798511e",
     "sourceFiles": [
       "/Users/dsteele/repos/footy-data-kit-club-assets/data/club-metadata.json"
     ],
@@ -13,13 +13,13 @@
     }
   },
   "clubCount": 375,
-  "issueCount": 466,
+  "issueCount": 467,
   "issueCounts": {
-    "club-asset-identity-uncertain": 23,
-    "club-asset-license-restricted": 337,
-    "club-asset-missing": 22,
+    "club-asset-identity-uncertain": 25,
+    "club-asset-license-restricted": 338,
+    "club-asset-missing": 16,
     "club-asset-multiple-review-candidates": 30,
-    "club-asset-non-crest-candidate": 54
+    "club-asset-non-crest-candidate": 58
   },
   "issues": [
     {
@@ -244,6 +244,16 @@
     },
     {
       "type": "club-asset-identity-uncertain",
+      "clubKey": "shepshed dynamo",
+      "clubId": "shepshed-dynamo",
+      "canonicalName": "Shepshed Dynamo",
+      "assetKind": "crest",
+      "assetId": "wikidata-image:Shepshed Ground 001 Small.jpg",
+      "source": "wikidata-image",
+      "message": "Shepshed Dynamo crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
       "clubKey": "stafford rangers",
       "clubId": "stafford-rangers",
       "canonicalName": "Stafford Rangers",
@@ -251,6 +261,16 @@
       "assetId": "wikipedia-pageimage-any:Staffordfc.png",
       "source": "wikipedia-pageimage-any",
       "message": "Stafford Rangers crest candidate identity is uncertain"
+    },
+    {
+      "type": "club-asset-identity-uncertain",
+      "clubKey": "staines town",
+      "clubId": "staines-town",
+      "canonicalName": "Staines Town",
+      "assetKind": "crest",
+      "assetId": "wikidata-image:DovervStaines.jpg",
+      "source": "wikidata-image",
+      "message": "Staines Town crest candidate identity is uncertain"
     },
     {
       "type": "club-asset-license-restricted",
@@ -1371,6 +1391,16 @@
       "assetId": "wikipedia-pageimage-any:Eastleigh_FC_crest.svg",
       "source": "wikipedia-pageimage-any",
       "message": "Eastleigh crest candidate is license restricted"
+    },
+    {
+      "type": "club-asset-license-restricted",
+      "clubKey": "eastwood town",
+      "clubId": "eastwood-town",
+      "canonicalName": "Eastwood Town",
+      "assetKind": "crest",
+      "assetId": "wikipedia-pageimage-any:Eastwood_Town_FC.png",
+      "source": "wikipedia-pageimage-any",
+      "message": "Eastwood Town crest candidate is license restricted"
     },
     {
       "type": "club-asset-license-restricted",
@@ -3624,22 +3654,6 @@
     },
     {
       "type": "club-asset-missing",
-      "clubKey": "aberdare athletic",
-      "clubId": "aberdare-athletic",
-      "canonicalName": "Aberdare Athletic",
-      "assetKind": "crest",
-      "message": "Aberdare Athletic has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "andover",
-      "clubId": "andover",
-      "canonicalName": "Andover",
-      "assetKind": "crest",
-      "message": "Andover has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
       "clubKey": "birmingham st georges",
       "clubId": "birmingham-st-georges",
       "canonicalName": "Birmingham St George's",
@@ -3669,14 +3683,6 @@
       "canonicalName": "Burton Wanderers",
       "assetKind": "crest",
       "message": "Burton Wanderers has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "eastwood town",
-      "clubId": "eastwood-town",
-      "canonicalName": "Eastwood Town",
-      "assetKind": "crest",
-      "message": "Eastwood Town has no crest asset candidates"
     },
     {
       "type": "club-asset-missing",
@@ -3736,22 +3742,6 @@
     },
     {
       "type": "club-asset-missing",
-      "clubKey": "shepshed dynamo",
-      "clubId": "shepshed-dynamo",
-      "canonicalName": "Shepshed Dynamo",
-      "assetKind": "crest",
-      "message": "Shepshed Dynamo has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "staines town",
-      "clubId": "staines-town",
-      "canonicalName": "Staines Town",
-      "assetKind": "crest",
-      "message": "Staines Town has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
       "clubKey": "sunderland albion",
       "clubId": "sunderland-albion",
       "canonicalName": "Sunderland Albion",
@@ -3765,14 +3755,6 @@
       "canonicalName": "Team Bath",
       "assetKind": "crest",
       "message": "Team Bath has no crest asset candidates"
-    },
-    {
-      "type": "club-asset-missing",
-      "clubKey": "trowbridge town",
-      "clubId": "trowbridge-town",
-      "canonicalName": "Trowbridge Town",
-      "assetKind": "crest",
-      "message": "Trowbridge Town has no crest asset candidates"
     },
     {
       "type": "club-asset-missing",
@@ -4117,6 +4099,16 @@
       "assetId": "wikipedia-pageimage-free:Exeter_City_match.JPG",
       "source": "wikipedia-pageimage-free",
       "message": "Altrincham crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "andover",
+      "clubId": "andover",
+      "canonicalName": "Andover",
+      "assetKind": "crest",
+      "assetId": "wikidata-image:Andover-2008-Squad.jpg",
+      "source": "wikidata-image",
+      "message": "Andover crest candidate does not look like a crest/logo filename"
     },
     {
       "type": "club-asset-non-crest-candidate",
@@ -4560,6 +4552,16 @@
     },
     {
       "type": "club-asset-non-crest-candidate",
+      "clubKey": "shepshed dynamo",
+      "clubId": "shepshed-dynamo",
+      "canonicalName": "Shepshed Dynamo",
+      "assetKind": "crest",
+      "assetId": "wikidata-image:Shepshed Ground 001 Small.jpg",
+      "source": "wikidata-image",
+      "message": "Shepshed Dynamo crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
       "clubKey": "solihull borough",
       "clubId": "solihull-borough",
       "canonicalName": "Solihull Borough",
@@ -4580,6 +4582,16 @@
     },
     {
       "type": "club-asset-non-crest-candidate",
+      "clubKey": "staines town",
+      "clubId": "staines-town",
+      "canonicalName": "Staines Town",
+      "assetKind": "crest",
+      "assetId": "wikidata-image:DovervStaines.jpg",
+      "source": "wikidata-image",
+      "message": "Staines Town crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
       "clubKey": "thames",
       "clubId": "thames",
       "canonicalName": "Thames",
@@ -4587,6 +4599,16 @@
       "assetId": "wikipedia-pageimage-free:London_Thames_Sunset_panorama_-_Feb_2008.jpg",
       "source": "wikipedia-pageimage-free",
       "message": "Thames crest candidate does not look like a crest/logo filename"
+    },
+    {
+      "type": "club-asset-non-crest-candidate",
+      "clubKey": "trowbridge town",
+      "clubId": "trowbridge-town",
+      "canonicalName": "Trowbridge Town",
+      "assetKind": "crest",
+      "assetId": "wikidata-image:Trowbridge Town F.C..jpg",
+      "source": "wikidata-image",
+      "message": "Trowbridge Town crest candidate does not look like a crest/logo filename"
     },
     {
       "type": "club-asset-non-crest-candidate",

--- a/data/club-metadata.json
+++ b/data/club-metadata.json
@@ -2,8 +2,8 @@
   "metadata": {
     "schemaVersion": 1,
     "generator": "club-assets",
-    "generatedAt": "2026-06-20T19:54:09.010Z",
-    "gitSha": "798511e",
+    "generatedAt": "2026-06-20T20:01:39.471Z",
+    "gitSha": "b94ecf2",
     "sourceFiles": [
       "/Users/dsteele/repos/footy-data-kit/data-output/all-seasons.json",
       "/Users/dsteele/repos/footy-data-kit-club-assets/data/club-metadata.json"
@@ -10288,7 +10288,48 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "preferred": "generated-placeholder:Generated:birmingham-st-georges-placeholder-crest.svg",
+          "status": "placeholder",
+          "candidates": [
+            {
+              "assetId": "generated-placeholder:Generated:birmingham-st-georges-placeholder-crest.svg",
+              "kind": "crest",
+              "status": "placeholder",
+              "source": "generated-placeholder",
+              "placeholder": true,
+              "sourceUrl": "https://en.wikipedia.org/wiki/Birmingham_St_George's_F.C.",
+              "imageUrl": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20256%20256%22%20role%3D%22img%22%3E%3Ctitle%3EBirmingham%20St%20George%26apos%3Bs%20generated%20placeholder%20crest%3C%2Ftitle%3E%3Cpath%20d%3D%22M128%2014%20220%2048v68c0%2058-36%20103-92%20126-56-23-92-68-92-126V48l92-34Z%22%20fill%3D%22%23FFFFFF%22%20stroke%3D%22%23000000%22%20stroke-width%3D%2210%22%2F%3E%3Cpath%20d%3D%22M128%2026%20210%2056v58c0%2049-30%2088-82%20110V26Z%22%20fill%3D%22%23000000%22%20opacity%3D%220.92%22%2F%3E%3Cpath%20d%3D%22M50%2084h156v30H50z%22%20fill%3D%22%23000000%22%20opacity%3D%220.9%22%2F%3E%3Ctext%20x%3D%22128%22%20y%3D%22154%22%20text-anchor%3D%22middle%22%20font-family%3D%22Arial%2C%20Helvetica%2C%20sans-serif%22%20font-size%3D%2258%22%20font-weight%3D%22700%22%20fill%3D%22%23111111%22%20stroke%3D%22%23FFFFFF%22%20stroke-width%3D%223%22%20paint-order%3D%22stroke%22%3EBG%3C%2Ftext%3E%3C%2Fsvg%3E",
+              "fileTitle": "Generated:birmingham-st-georges-placeholder-crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 256,
+              "colors": [
+                {
+                  "role": "primary",
+                  "hex": "#FFFFFF"
+                },
+                {
+                  "role": "secondary",
+                  "hex": "#000000"
+                }
+              ],
+              "license": {
+                "shortName": "CC0-1.0",
+                "usageTerms": "Creative Commons Zero v1.0 Universal",
+                "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "copyrighted": false,
+                "attribution": "footy-data-kit generated placeholder"
+              },
+              "verification": {
+                "identityMatch": "generated-placeholder",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false
+              },
+              "notes": "Generated placeholder shield from source-backed club colours; not an official or historical club crest.",
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -19031,7 +19072,52 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "preferred": "generated-placeholder:Generated:burton-swifts-placeholder-crest.svg",
+          "status": "placeholder",
+          "candidates": [
+            {
+              "assetId": "generated-placeholder:Generated:burton-swifts-placeholder-crest.svg",
+              "kind": "crest",
+              "status": "placeholder",
+              "source": "generated-placeholder",
+              "placeholder": true,
+              "sourceUrl": "https://en.wikipedia.org/wiki/Burton_Swifts_F.C.",
+              "imageUrl": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20256%20256%22%20role%3D%22img%22%3E%3Ctitle%3EBurton%20Swifts%20generated%20placeholder%20crest%3C%2Ftitle%3E%3Cpath%20d%3D%22M128%2014%20220%2048v68c0%2058-36%20103-92%20126-56-23-92-68-92-126V48l92-34Z%22%20fill%3D%22%23FF0000%22%20stroke%3D%22%23000099%22%20stroke-width%3D%2210%22%2F%3E%3Cpath%20d%3D%22M128%2026%20210%2056v58c0%2049-30%2088-82%20110V26Z%22%20fill%3D%22%23FFFFFF%22%20opacity%3D%220.92%22%2F%3E%3Cpath%20d%3D%22M50%2084h156v30H50z%22%20fill%3D%22%23000099%22%20opacity%3D%220.9%22%2F%3E%3Ctext%20x%3D%22128%22%20y%3D%22154%22%20text-anchor%3D%22middle%22%20font-family%3D%22Arial%2C%20Helvetica%2C%20sans-serif%22%20font-size%3D%2258%22%20font-weight%3D%22700%22%20fill%3D%22%23FFFFFF%22%20stroke%3D%22%23111111%22%20stroke-width%3D%223%22%20paint-order%3D%22stroke%22%3EBS%3C%2Ftext%3E%3C%2Fsvg%3E",
+              "fileTitle": "Generated:burton-swifts-placeholder-crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 256,
+              "colors": [
+                {
+                  "role": "primary",
+                  "hex": "#FF0000"
+                },
+                {
+                  "role": "secondary",
+                  "hex": "#FFFFFF"
+                },
+                {
+                  "role": "accent",
+                  "hex": "#000099"
+                }
+              ],
+              "license": {
+                "shortName": "CC0-1.0",
+                "usageTerms": "Creative Commons Zero v1.0 Universal",
+                "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "copyrighted": false,
+                "attribution": "footy-data-kit generated placeholder"
+              },
+              "verification": {
+                "identityMatch": "generated-placeholder",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false
+              },
+              "notes": "Generated placeholder shield from source-backed club colours; not an official or historical club crest.",
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -19229,7 +19315,52 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "preferred": "generated-placeholder:Generated:burton-united-placeholder-crest.svg",
+          "status": "placeholder",
+          "candidates": [
+            {
+              "assetId": "generated-placeholder:Generated:burton-united-placeholder-crest.svg",
+              "kind": "crest",
+              "status": "placeholder",
+              "source": "generated-placeholder",
+              "placeholder": true,
+              "sourceUrl": "https://en.wikipedia.org/wiki/Burton_United_F.C.",
+              "imageUrl": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20256%20256%22%20role%3D%22img%22%3E%3Ctitle%3EBurton%20United%20generated%20placeholder%20crest%3C%2Ftitle%3E%3Cpath%20d%3D%22M128%2014%20220%2048v68c0%2058-36%20103-92%20126-56-23-92-68-92-126V48l92-34Z%22%20fill%3D%22%23663300%22%20stroke%3D%22%23FFFFFF%22%20stroke-width%3D%2210%22%2F%3E%3Cpath%20d%3D%22M128%2026%20210%2056v58c0%2049-30%2088-82%20110V26Z%22%20fill%3D%22%2387CEEB%22%20opacity%3D%220.92%22%2F%3E%3Cpath%20d%3D%22M50%2084h156v30H50z%22%20fill%3D%22%23FFFFFF%22%20opacity%3D%220.9%22%2F%3E%3Ctext%20x%3D%22128%22%20y%3D%22154%22%20text-anchor%3D%22middle%22%20font-family%3D%22Arial%2C%20Helvetica%2C%20sans-serif%22%20font-size%3D%2258%22%20font-weight%3D%22700%22%20fill%3D%22%23FFFFFF%22%20stroke%3D%22%23111111%22%20stroke-width%3D%223%22%20paint-order%3D%22stroke%22%3EBU%3C%2Ftext%3E%3C%2Fsvg%3E",
+              "fileTitle": "Generated:burton-united-placeholder-crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 256,
+              "colors": [
+                {
+                  "role": "primary",
+                  "hex": "#663300"
+                },
+                {
+                  "role": "secondary",
+                  "hex": "#87CEEB"
+                },
+                {
+                  "role": "accent",
+                  "hex": "#FFFFFF"
+                }
+              ],
+              "license": {
+                "shortName": "CC0-1.0",
+                "usageTerms": "Creative Commons Zero v1.0 Universal",
+                "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "copyrighted": false,
+                "attribution": "footy-data-kit generated placeholder"
+              },
+              "verification": {
+                "identityMatch": "generated-placeholder",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false
+              },
+              "notes": "Generated placeholder shield from source-backed club colours; not an official or historical club crest.",
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -19354,7 +19485,52 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "preferred": "generated-placeholder:Generated:burton-wanderers-placeholder-crest.svg",
+          "status": "placeholder",
+          "candidates": [
+            {
+              "assetId": "generated-placeholder:Generated:burton-wanderers-placeholder-crest.svg",
+              "kind": "crest",
+              "status": "placeholder",
+              "source": "generated-placeholder",
+              "placeholder": true,
+              "sourceUrl": "https://en.wikipedia.org/wiki/Burton_Wanderers_F.C.",
+              "imageUrl": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20256%20256%22%20role%3D%22img%22%3E%3Ctitle%3EBurton%20Wanderers%20generated%20placeholder%20crest%3C%2Ftitle%3E%3Cpath%20d%3D%22M128%2014%20220%2048v68c0%2058-36%20103-92%20126-56-23-92-68-92-126V48l92-34Z%22%20fill%3D%22%23FFFFFF%22%20stroke%3D%22%23333333%22%20stroke-width%3D%2210%22%2F%3E%3Cpath%20d%3D%22M128%2026%20210%2056v58c0%2049-30%2088-82%20110V26Z%22%20fill%3D%22%230057B8%22%20opacity%3D%220.92%22%2F%3E%3Cpath%20d%3D%22M50%2084h156v30H50z%22%20fill%3D%22%23333333%22%20opacity%3D%220.9%22%2F%3E%3Ctext%20x%3D%22128%22%20y%3D%22154%22%20text-anchor%3D%22middle%22%20font-family%3D%22Arial%2C%20Helvetica%2C%20sans-serif%22%20font-size%3D%2258%22%20font-weight%3D%22700%22%20fill%3D%22%23111111%22%20stroke%3D%22%23FFFFFF%22%20stroke-width%3D%223%22%20paint-order%3D%22stroke%22%3EBW%3C%2Ftext%3E%3C%2Fsvg%3E",
+              "fileTitle": "Generated:burton-wanderers-placeholder-crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 256,
+              "colors": [
+                {
+                  "role": "primary",
+                  "hex": "#FFFFFF"
+                },
+                {
+                  "role": "secondary",
+                  "hex": "#0057B8"
+                },
+                {
+                  "role": "accent",
+                  "hex": "#333333"
+                }
+              ],
+              "license": {
+                "shortName": "CC0-1.0",
+                "usageTerms": "Creative Commons Zero v1.0 Universal",
+                "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "copyrighted": false,
+                "attribution": "footy-data-kit generated placeholder"
+              },
+              "verification": {
+                "identityMatch": "generated-placeholder",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false
+              },
+              "notes": "Generated placeholder shield from source-backed club colours; not an official or historical club crest.",
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -63101,7 +63277,52 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "preferred": "generated-placeholder:Generated:middlesbrough-ironopolis-placeholder-crest.svg",
+          "status": "placeholder",
+          "candidates": [
+            {
+              "assetId": "generated-placeholder:Generated:middlesbrough-ironopolis-placeholder-crest.svg",
+              "kind": "crest",
+              "status": "placeholder",
+              "source": "generated-placeholder",
+              "placeholder": true,
+              "sourceUrl": "https://en.wikipedia.org/wiki/Middlesbrough_Ironopolis",
+              "imageUrl": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20256%20256%22%20role%3D%22img%22%3E%3Ctitle%3EMiddlesbrough%20Ironopolis%20generated%20placeholder%20crest%3C%2Ftitle%3E%3Cpath%20d%3D%22M128%2014%20220%2048v68c0%2058-36%20103-92%20126-56-23-92-68-92-126V48l92-34Z%22%20fill%3D%22%23CC0033%22%20stroke%3D%22%23FFFFFF%22%20stroke-width%3D%2210%22%2F%3E%3Cpath%20d%3D%22M128%2026%20210%2056v58c0%2049-30%2088-82%20110V26Z%22%20fill%3D%22%23000000%22%20opacity%3D%220.92%22%2F%3E%3Cpath%20d%3D%22M50%2084h156v30H50z%22%20fill%3D%22%23FFFFFF%22%20opacity%3D%220.9%22%2F%3E%3Ctext%20x%3D%22128%22%20y%3D%22154%22%20text-anchor%3D%22middle%22%20font-family%3D%22Arial%2C%20Helvetica%2C%20sans-serif%22%20font-size%3D%2258%22%20font-weight%3D%22700%22%20fill%3D%22%23FFFFFF%22%20stroke%3D%22%23111111%22%20stroke-width%3D%223%22%20paint-order%3D%22stroke%22%3EMI%3C%2Ftext%3E%3C%2Fsvg%3E",
+              "fileTitle": "Generated:middlesbrough-ironopolis-placeholder-crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 256,
+              "colors": [
+                {
+                  "role": "primary",
+                  "hex": "#CC0033"
+                },
+                {
+                  "role": "secondary",
+                  "hex": "#000000"
+                },
+                {
+                  "role": "accent",
+                  "hex": "#FFFFFF"
+                }
+              ],
+              "license": {
+                "shortName": "CC0-1.0",
+                "usageTerms": "Creative Commons Zero v1.0 Universal",
+                "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "copyrighted": false,
+                "attribution": "footy-data-kit generated placeholder"
+              },
+              "verification": {
+                "identityMatch": "generated-placeholder",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false
+              },
+              "notes": "Generated placeholder shield from source-backed club colours; not an official or historical club crest.",
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -70655,7 +70876,48 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "preferred": "generated-placeholder:Generated:oswestry-town-placeholder-crest.svg",
+          "status": "placeholder",
+          "candidates": [
+            {
+              "assetId": "generated-placeholder:Generated:oswestry-town-placeholder-crest.svg",
+              "kind": "crest",
+              "status": "placeholder",
+              "source": "generated-placeholder",
+              "placeholder": true,
+              "sourceUrl": "https://en.wikipedia.org/wiki/Oswestry_Town_F.C.",
+              "imageUrl": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20256%20256%22%20role%3D%22img%22%3E%3Ctitle%3EOswestry%20Town%20generated%20placeholder%20crest%3C%2Ftitle%3E%3Cpath%20d%3D%22M128%2014%20220%2048v68c0%2058-36%20103-92%20126-56-23-92-68-92-126V48l92-34Z%22%20fill%3D%22%230000FF%22%20stroke%3D%22%23FFFFFF%22%20stroke-width%3D%2210%22%2F%3E%3Cpath%20d%3D%22M128%2026%20210%2056v58c0%2049-30%2088-82%20110V26Z%22%20fill%3D%22%23FFFFFF%22%20opacity%3D%220.92%22%2F%3E%3Cpath%20d%3D%22M50%2084h156v30H50z%22%20fill%3D%22%23FFFFFF%22%20opacity%3D%220.9%22%2F%3E%3Ctext%20x%3D%22128%22%20y%3D%22154%22%20text-anchor%3D%22middle%22%20font-family%3D%22Arial%2C%20Helvetica%2C%20sans-serif%22%20font-size%3D%2258%22%20font-weight%3D%22700%22%20fill%3D%22%23FFFFFF%22%20stroke%3D%22%23111111%22%20stroke-width%3D%223%22%20paint-order%3D%22stroke%22%3EOT%3C%2Ftext%3E%3C%2Fsvg%3E",
+              "fileTitle": "Generated:oswestry-town-placeholder-crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 256,
+              "colors": [
+                {
+                  "role": "primary",
+                  "hex": "#0000FF"
+                },
+                {
+                  "role": "secondary",
+                  "hex": "#FFFFFF"
+                }
+              ],
+              "license": {
+                "shortName": "CC0-1.0",
+                "usageTerms": "Creative Commons Zero v1.0 Universal",
+                "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "copyrighted": false,
+                "attribution": "footy-data-kit generated placeholder"
+              },
+              "verification": {
+                "identityMatch": "generated-placeholder",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false
+              },
+              "notes": "Generated placeholder shield from source-backed club colours; not an official or historical club crest.",
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -75470,7 +75732,52 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "preferred": "generated-placeholder:Generated:redbridge-forest-placeholder-crest.svg",
+          "status": "placeholder",
+          "candidates": [
+            {
+              "assetId": "generated-placeholder:Generated:redbridge-forest-placeholder-crest.svg",
+              "kind": "crest",
+              "status": "placeholder",
+              "source": "generated-placeholder",
+              "placeholder": true,
+              "sourceUrl": "https://en.wikipedia.org/wiki/Redbridge_Forest_F.C.",
+              "imageUrl": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20256%20256%22%20role%3D%22img%22%3E%3Ctitle%3ERedbridge%20Forest%20generated%20placeholder%20crest%3C%2Ftitle%3E%3Cpath%20d%3D%22M128%2014%20220%2048v68c0%2058-36%20103-92%20126-56-23-92-68-92-126V48l92-34Z%22%20fill%3D%22%23FF0000%22%20stroke%3D%22%23FFFFFF%22%20stroke-width%3D%2210%22%2F%3E%3Cpath%20d%3D%22M128%2026%20210%2056v58c0%2049-30%2088-82%20110V26Z%22%20fill%3D%22%230000FF%22%20opacity%3D%220.92%22%2F%3E%3Cpath%20d%3D%22M50%2084h156v30H50z%22%20fill%3D%22%23FFFFFF%22%20opacity%3D%220.9%22%2F%3E%3Ctext%20x%3D%22128%22%20y%3D%22154%22%20text-anchor%3D%22middle%22%20font-family%3D%22Arial%2C%20Helvetica%2C%20sans-serif%22%20font-size%3D%2258%22%20font-weight%3D%22700%22%20fill%3D%22%23FFFFFF%22%20stroke%3D%22%23111111%22%20stroke-width%3D%223%22%20paint-order%3D%22stroke%22%3ERF%3C%2Ftext%3E%3C%2Fsvg%3E",
+              "fileTitle": "Generated:redbridge-forest-placeholder-crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 256,
+              "colors": [
+                {
+                  "role": "primary",
+                  "hex": "#FF0000"
+                },
+                {
+                  "role": "secondary",
+                  "hex": "#0000FF"
+                },
+                {
+                  "role": "accent",
+                  "hex": "#FFFFFF"
+                }
+              ],
+              "license": {
+                "shortName": "CC0-1.0",
+                "usageTerms": "Creative Commons Zero v1.0 Universal",
+                "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "copyrighted": false,
+                "attribution": "footy-data-kit generated placeholder"
+              },
+              "verification": {
+                "identityMatch": "generated-placeholder",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false
+              },
+              "notes": "Generated placeholder shield from source-backed club colours; not an official or historical club crest.",
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -76769,7 +77076,48 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "preferred": "generated-placeholder:Generated:rotherham-town-placeholder-crest.svg",
+          "status": "placeholder",
+          "candidates": [
+            {
+              "assetId": "generated-placeholder:Generated:rotherham-town-placeholder-crest.svg",
+              "kind": "crest",
+              "status": "placeholder",
+              "source": "generated-placeholder",
+              "placeholder": true,
+              "sourceUrl": "https://en.wikipedia.org/wiki/Rotherham_Town_F.C._(1878)",
+              "imageUrl": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20256%20256%22%20role%3D%22img%22%3E%3Ctitle%3ERotherham%20Town%20generated%20placeholder%20crest%3C%2Ftitle%3E%3Cpath%20d%3D%22M128%2014%20220%2048v68c0%2058-36%20103-92%20126-56-23-92-68-92-126V48l92-34Z%22%20fill%3D%22%23FF0000%22%20stroke%3D%22%231C1271%22%20stroke-width%3D%2210%22%2F%3E%3Cpath%20d%3D%22M128%2026%20210%2056v58c0%2049-30%2088-82%20110V26Z%22%20fill%3D%22%231C1271%22%20opacity%3D%220.92%22%2F%3E%3Cpath%20d%3D%22M50%2084h156v30H50z%22%20fill%3D%22%231C1271%22%20opacity%3D%220.9%22%2F%3E%3Ctext%20x%3D%22128%22%20y%3D%22154%22%20text-anchor%3D%22middle%22%20font-family%3D%22Arial%2C%20Helvetica%2C%20sans-serif%22%20font-size%3D%2258%22%20font-weight%3D%22700%22%20fill%3D%22%23FFFFFF%22%20stroke%3D%22%23111111%22%20stroke-width%3D%223%22%20paint-order%3D%22stroke%22%3ERT%3C%2Ftext%3E%3C%2Fsvg%3E",
+              "fileTitle": "Generated:rotherham-town-placeholder-crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 256,
+              "colors": [
+                {
+                  "role": "primary",
+                  "hex": "#FF0000"
+                },
+                {
+                  "role": "secondary",
+                  "hex": "#1C1271"
+                }
+              ],
+              "license": {
+                "shortName": "CC0-1.0",
+                "usageTerms": "Creative Commons Zero v1.0 Universal",
+                "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "copyrighted": false,
+                "attribution": "footy-data-kit generated placeholder"
+              },
+              "verification": {
+                "identityMatch": "generated-placeholder",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false
+              },
+              "notes": "Generated placeholder shield from source-backed club colours; not an official or historical club crest.",
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -87791,7 +88139,48 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "preferred": "generated-placeholder:Generated:sunderland-albion-placeholder-crest.svg",
+          "status": "placeholder",
+          "candidates": [
+            {
+              "assetId": "generated-placeholder:Generated:sunderland-albion-placeholder-crest.svg",
+              "kind": "crest",
+              "status": "placeholder",
+              "source": "generated-placeholder",
+              "placeholder": true,
+              "sourceUrl": "https://en.wikipedia.org/wiki/Sunderland_Albion_F.C.",
+              "imageUrl": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20256%20256%22%20role%3D%22img%22%3E%3Ctitle%3ESunderland%20Albion%20generated%20placeholder%20crest%3C%2Ftitle%3E%3Cpath%20d%3D%22M128%2014%20220%2048v68c0%2058-36%20103-92%20126-56-23-92-68-92-126V48l92-34Z%22%20fill%3D%22%23000066%22%20stroke%3D%22%23FFFFFF%22%20stroke-width%3D%2210%22%2F%3E%3Cpath%20d%3D%22M128%2026%20210%2056v58c0%2049-30%2088-82%20110V26Z%22%20fill%3D%22%23FFFFFF%22%20opacity%3D%220.92%22%2F%3E%3Cpath%20d%3D%22M50%2084h156v30H50z%22%20fill%3D%22%23FFFFFF%22%20opacity%3D%220.9%22%2F%3E%3Ctext%20x%3D%22128%22%20y%3D%22154%22%20text-anchor%3D%22middle%22%20font-family%3D%22Arial%2C%20Helvetica%2C%20sans-serif%22%20font-size%3D%2258%22%20font-weight%3D%22700%22%20fill%3D%22%23FFFFFF%22%20stroke%3D%22%23111111%22%20stroke-width%3D%223%22%20paint-order%3D%22stroke%22%3ESA%3C%2Ftext%3E%3C%2Fsvg%3E",
+              "fileTitle": "Generated:sunderland-albion-placeholder-crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 256,
+              "colors": [
+                {
+                  "role": "primary",
+                  "hex": "#000066"
+                },
+                {
+                  "role": "secondary",
+                  "hex": "#FFFFFF"
+                }
+              ],
+              "license": {
+                "shortName": "CC0-1.0",
+                "usageTerms": "Creative Commons Zero v1.0 Universal",
+                "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
+                "copyrighted": false,
+                "attribution": "footy-data-kit generated placeholder"
+              },
+              "verification": {
+                "identityMatch": "generated-placeholder",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false
+              },
+              "notes": "Generated placeholder shield from source-backed club colours; not an official or historical club crest.",
+              "priority": 1
+            }
+          ]
         }
       }
     },

--- a/data/club-metadata.json
+++ b/data/club-metadata.json
@@ -2,8 +2,8 @@
   "metadata": {
     "schemaVersion": 1,
     "generator": "club-assets",
-    "generatedAt": "2026-06-20T20:01:39.471Z",
-    "gitSha": "b94ecf2",
+    "generatedAt": "2026-06-20T21:13:53.179Z",
+    "gitSha": "4f08010",
     "sourceFiles": [
       "/Users/dsteele/repos/footy-data-kit/data-output/all-seasons.json",
       "/Users/dsteele/repos/footy-data-kit-club-assets/data/club-metadata.json"
@@ -293,43 +293,7 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
-          "candidates": [
-            {
-              "assetId": "wikipedia-pageimage-free:Crown_Ground_sign-geograph-1761360.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Accrington",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/9/9a/Crown_Ground_sign-geograph-1761360.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Crown_Ground_sign-geograph-1761360.jpg",
-              "fileTitle": "File:Crown Ground sign-geograph-1761360.jpg",
-              "mimeType": "image/jpeg",
-              "width": 1632,
-              "height": 1224,
-              "license": {
-                "shortName": "CC BY-SA 2.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
-                "copyrighted": true,
-                "attribution": "robert wade",
-                "credit": "From geograph.org.uk",
-                "artist": "robert wade"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:30:53.942Z"
-              },
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -898,39 +862,6 @@
                 "checkedAt": "2026-06-20T19:24:44.226Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
-              "fileTitle": "File:Ryan Valentine scores.jpg",
-              "mimeType": "image/jpeg",
-              "width": 3456,
-              "height": 2304,
-              "license": {
-                "shortName": "CC BY 2.5",
-                "usageTerms": "Creative Commons Attribution 2.5",
-                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Markbarnes"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:24:44.226Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -1096,42 +1027,7 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
-          "candidates": [
-            {
-              "assetId": "wikipedia-pageimage-free:St_Paul,_Addlestone_-_geograph.org.uk_-_1517212.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Addlestone",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/f/fc/St_Paul%2C_Addlestone_-_geograph.org.uk_-_1517212.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:St_Paul,_Addlestone_-_geograph.org.uk_-_1517212.jpg",
-              "fileTitle": "File:St Paul, Addlestone - geograph.org.uk - 1517212.jpg",
-              "mimeType": "image/jpeg",
-              "width": 640,
-              "height": 414,
-              "license": {
-                "shortName": "CC BY-SA 2.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
-                "copyrighted": true,
-                "attribution": "Michael FORD",
-                "credit": "From geograph.org.uk",
-                "artist": "Michael FORD"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:30:55.586Z"
-              },
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -3453,69 +3349,6 @@
                 "checkedAt": "2026-06-20T19:24:53.566Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Altrincham_Town_Square_-_2024.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Altrincham",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/1/10/Altrincham_Town_Square_-_2024.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Altrincham_Town_Square_-_2024.jpg",
-              "fileTitle": "File:Altrincham Town Square - 2024.jpg",
-              "mimeType": "image/jpeg",
-              "width": 4032,
-              "height": 3024,
-              "license": {
-                "shortName": "CC0",
-                "usageTerms": "Creative Commons Zero, Public Domain Dedication",
-                "licenseUrl": "http://creativecommons.org/publicdomain/zero/1.0/deed.en",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Doomdorm64"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:24:53.566Z"
-              },
-              "priority": 2
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Exeter_City_match.JPG",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Altrincham_F.C.",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3e/Exeter_City_match.JPG",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Exeter_City_match.JPG",
-              "fileTitle": "File:Exeter City match.JPG",
-              "mimeType": "image/jpeg",
-              "width": 2592,
-              "height": 1944,
-              "license": {
-                "shortName": "CC BY-SA 3.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
-                "licenseUrl": "http://creativecommons.org/licenses/by-sa/3.0/",
-                "copyrighted": true
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:24:53.566Z"
-              },
-              "priority": 3
             }
           ]
         }
@@ -3828,41 +3661,7 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
-          "candidates": [
-            {
-              "assetId": "wikidata-image:Andover-2008-Squad.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikidata-image",
-              "sourceUrl": "https://www.wikidata.org/wiki/Q4754611",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Andover-2008-Squad.jpg",
-              "fileTitle": "File:Andover-2008-Squad.jpg",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/88/Andover-2008-Squad.jpg",
-              "mimeType": "image/jpeg",
-              "width": 500,
-              "height": 208,
-              "license": {
-                "shortName": "CC BY 3.0",
-                "usageTerms": "Creative Commons Attribution 3.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by/3.0",
-                "copyrighted": true,
-                "credit": "Len Abrahams (webmaster of www.andover-fc.co.uk)",
-                "artist": "Len Abrahams (webmaster of www.andover-fc.co.uk)"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:50:16.147Z"
-              },
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -5677,39 +5476,6 @@
                 "checkedAt": "2026-06-20T19:24:56.690Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Atherstone_Town_FC_2009.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Atherstone_Town_F.C.",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b9/Atherstone_Town_FC_2009.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Atherstone_Town_FC_2009.jpg",
-              "fileTitle": "File:Atherstone Town FC 2009.jpg",
-              "mimeType": "image/jpeg",
-              "width": 640,
-              "height": 480,
-              "license": {
-                "shortName": "CC BY-SA 2.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
-                "copyrighted": true,
-                "attribution": "Geoff Pick",
-                "credit": "From geograph.org.uk",
-                "artist": "Geoff Pick"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:24:56.690Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -10455,41 +10221,7 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
-          "candidates": [
-            {
-              "assetId": "wikipedia-pageimage-free:Bishop_Auckland_Town_Hall.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Bishop_Auckland",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/29/Bishop_Auckland_Town_Hall.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Bishop_Auckland_Town_Hall.jpg",
-              "fileTitle": "File:Bishop Auckland Town Hall.jpg",
-              "mimeType": "image/jpeg",
-              "width": 1600,
-              "height": 1200,
-              "license": {
-                "shortName": "CC BY-SA 3.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
-                "licenseUrl": "http://creativecommons.org/licenses/by-sa/3.0/",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Pit-yacker"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:30:58.291Z"
-              },
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -13157,39 +12889,6 @@
                 "checkedAt": "2026-06-20T19:25:02.484Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Bootle_Town_Hall_2020-1.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Bootle",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/d/dd/Bootle_Town_Hall_2020-1.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Bootle_Town_Hall_2020-1.jpg",
-              "fileTitle": "File:Bootle Town Hall 2020-1.jpg",
-              "mimeType": "image/jpeg",
-              "width": 3188,
-              "height": 4830,
-              "license": {
-                "shortName": "CC BY-SA 4.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
-                "copyrighted": true,
-                "attribution": "By Phil Nash from Wikimedia Commons CC BY-SA 4.0 & GFDL Views",
-                "credit": "Own work",
-                "artist": "Rodhullandemu"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:25:02.484Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -17597,71 +17296,6 @@
                 "checkedAt": "2026-06-20T19:25:04.399Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Bromley_-_geograph.org.uk_-_4623007.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Bromley",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/c7/Bromley_-_geograph.org.uk_-_4623007.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Bromley_-_geograph.org.uk_-_4623007.jpg",
-              "fileTitle": "File:Bromley - geograph.org.uk - 4623007.jpg",
-              "mimeType": "image/jpeg",
-              "width": 4000,
-              "height": 2666,
-              "license": {
-                "shortName": "CC BY-SA 2.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
-                "copyrighted": true,
-                "attribution": "Bromley by Peter Trimming",
-                "credit": "Geograph Britain and Ireland",
-                "artist": "Peter Trimming"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:25:04.399Z"
-              },
-              "priority": 2
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Bromley_FC_League_Performance.svg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Bromley_F.C.",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8e/Bromley_FC_League_Performance.svg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Bromley_FC_League_Performance.svg",
-              "fileTitle": "File:Bromley FC League Performance.svg",
-              "mimeType": "image/svg+xml",
-              "width": 1190,
-              "height": 688,
-              "license": {
-                "shortName": "CC BY-SA 4.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "EclecticArkie"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:25:04.399Z"
-              },
-              "priority": 3
             }
           ]
         }
@@ -24916,71 +24550,6 @@
                 "checkedAt": "2026-06-20T19:25:22.881Z"
               },
               "priority": 2
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Chester_-_Shops_in_city_centre_-_2005-10-09.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Chester",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b9/Chester_-_Shops_in_city_centre_-_2005-10-09.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Chester_-_Shops_in_city_centre_-_2005-10-09.jpg",
-              "fileTitle": "File:Chester - Shops in city centre - 2005-10-09.jpg",
-              "mimeType": "image/jpeg",
-              "width": 2016,
-              "height": 1512,
-              "license": {
-                "shortName": "CC BY-SA 3.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
-                "licenseUrl": "http://creativecommons.org/licenses/by-sa/3.0/",
-                "copyrighted": true,
-                "credit": "No machine-readable source provided. Own work assumed (based on copyright claims).",
-                "artist": "No machine-readable author provided. Tagishsimon assumed (based on copyright claims)."
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:25:22.881Z"
-              },
-              "priority": 3
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
-              "fileTitle": "File:Ryan Valentine scores.jpg",
-              "mimeType": "image/jpeg",
-              "width": 3456,
-              "height": 2304,
-              "license": {
-                "shortName": "CC BY 2.5",
-                "usageTerms": "Creative Commons Attribution 2.5",
-                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Markbarnes"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:25:22.881Z"
-              },
-              "priority": 4
             }
           ]
         }
@@ -26133,38 +25702,6 @@
                 "checkedAt": "2026-06-20T19:25:25.494Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Clevedon_Town_2007.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Clevedon_Town_F.C.",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/1/15/Clevedon_Town_2007.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Clevedon_Town_2007.jpg",
-              "fileTitle": "File:Clevedon Town 2007.jpg",
-              "mimeType": "image/jpeg",
-              "width": 1019,
-              "height": 681,
-              "license": {
-                "shortName": "CC BY-SA 3.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "NotFromUtrecht"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:25:25.494Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -29451,41 +28988,7 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
-          "candidates": [
-            {
-              "assetId": "wikipedia-pageimage-free:Beam_valley_park_and_turbine_1.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Dagenham",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/c3/Beam_valley_park_and_turbine_1.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Beam_valley_park_and_turbine_1.jpg",
-              "fileTitle": "File:Beam valley park and turbine 1.jpg",
-              "mimeType": "image/jpeg",
-              "width": 1024,
-              "height": 768,
-              "license": {
-                "shortName": "Public domain",
-                "usageTerms": "Public domain",
-                "copyrighted": false,
-                "credit": "Transferred from en.wikipedia to Commons by Teratornis using CommonsHelper .",
-                "artist": "MRSC at English Wikipedia"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:31:01.700Z"
-              },
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -30397,72 +29900,6 @@
                 "checkedAt": "2026-06-20T19:25:28.812Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Darlington_clock_tower_and_market_hall_(geograph_6299652).jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Darlington",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/c1/Darlington_clock_tower_and_market_hall_%28geograph_6299652%29.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Darlington_clock_tower_and_market_hall_(geograph_6299652).jpg",
-              "fileTitle": "File:Darlington clock tower and market hall (geograph 6299652).jpg",
-              "mimeType": "image/jpeg",
-              "width": 640,
-              "height": 480,
-              "license": {
-                "shortName": "CC BY-SA 2.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
-                "copyrighted": true,
-                "attribution": "Graham Hogg",
-                "credit": "From geograph.org.uk",
-                "artist": "Graham Hogg"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:25:28.812Z"
-              },
-              "priority": 2
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
-              "fileTitle": "File:Ryan Valentine scores.jpg",
-              "mimeType": "image/jpeg",
-              "width": 3456,
-              "height": 2304,
-              "license": {
-                "shortName": "CC BY 2.5",
-                "usageTerms": "Creative Commons Attribution 2.5",
-                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Markbarnes"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:25:28.812Z"
-              },
-              "priority": 3
             }
           ]
         }
@@ -33793,39 +33230,6 @@
                 "checkedAt": "2026-06-20T19:25:31.633Z"
               },
               "priority": 2
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:High_Street_Dunstable_-_geograph.org.uk_-_6524692.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Dunstable",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/f/fa/High_Street_Dunstable_-_geograph.org.uk_-_6524692.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:High_Street_Dunstable_-_geograph.org.uk_-_6524692.jpg",
-              "fileTitle": "File:High Street Dunstable - geograph.org.uk - 6524692.jpg",
-              "mimeType": "image/jpeg",
-              "width": 1884,
-              "height": 1224,
-              "license": {
-                "shortName": "CC BY-SA 2.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
-                "copyrighted": true,
-                "attribution": "High Street Dunstable by David Howard",
-                "credit": "Geograph Britain and Ireland",
-                "artist": "David Howard"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:25:31.633Z"
-              },
-              "priority": 3
             }
           ]
         }
@@ -34494,38 +33898,6 @@
                 "checkedAt": "2026-06-20T19:25:34.240Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Old_Town_Hall_Eastleigh.JPG",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Eastleigh",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/27/Old_Town_Hall_Eastleigh.JPG",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Old_Town_Hall_Eastleigh.JPG",
-              "fileTitle": "File:Old Town Hall Eastleigh.JPG",
-              "mimeType": "image/jpeg",
-              "width": 2822,
-              "height": 2090,
-              "license": {
-                "shortName": "CC BY-SA 3.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Marek69"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:25:34.240Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -35756,39 +35128,8 @@
       },
       "assets": {
         "crest": {
-          "preferred": "wikipedia-pageimage-any:Epsom_and_Ewell_UK_locator_map.svg",
-          "status": "usable",
+          "status": "restricted",
           "candidates": [
-            {
-              "assetId": "wikipedia-pageimage-any:Epsom_and_Ewell_UK_locator_map.svg",
-              "kind": "crest",
-              "status": "usable",
-              "source": "wikipedia-pageimage-any",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Epsom_and_Ewell",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/63/Epsom_and_Ewell_UK_locator_map.svg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Epsom_and_Ewell_UK_locator_map.svg",
-              "fileTitle": "File:Epsom and Ewell UK locator map.svg",
-              "mimeType": "image/svg+xml",
-              "width": 1425,
-              "height": 1081,
-              "license": {
-                "shortName": "CC BY-SA 3.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0",
-                "copyrighted": true,
-                "attribution": "Contains Ordnance Survey data © Crown copyright and database right",
-                "credit": "Ordnance Survey OpenData Coastline and administrative boundary data from Boundary-Line product. Lake data from Meridian 2 product. Inset derived from England location map.svg by Spischot .",
-                "artist": "Nilfanion , created using Ordnance Survey data"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": false,
-                "checkedAt": "2026-06-20T19:25:58.717Z"
-              },
-              "priority": 1
-            },
             {
               "assetId": "wikipedia-pageimage-any:EpsomEwellBadge.png",
               "kind": "crest",
@@ -35819,7 +35160,7 @@
                 ],
                 "checkedAt": "2026-06-20T19:25:58.717Z"
               },
-              "priority": 2
+              "priority": 1
             }
           ]
         }
@@ -37641,39 +36982,6 @@
                 "checkedAt": "2026-06-20T19:26:03.489Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Citadel-1.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Farsley_Celtic_F.C.",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/c2/Citadel-1.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Citadel-1.jpg",
-              "fileTitle": "File:Citadel-1.jpg",
-              "mimeType": "image/jpeg",
-              "width": 2048,
-              "height": 1536,
-              "license": {
-                "shortName": "CC BY-SA 4.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Farsleycelticmedia"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:26:03.489Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -38750,38 +38058,8 @@
       },
       "assets": {
         "crest": {
-          "preferred": "wikipedia-pageimage-any:Folkestone_Harbour_with_Viaduct_and_Swing_Bridge.png",
-          "status": "usable",
+          "status": "restricted",
           "candidates": [
-            {
-              "assetId": "wikipedia-pageimage-any:Folkestone_Harbour_with_Viaduct_and_Swing_Bridge.png",
-              "kind": "crest",
-              "status": "usable",
-              "source": "wikipedia-pageimage-any",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Folkestone",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/4/4c/Folkestone_Harbour_with_Viaduct_and_Swing_Bridge.png",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Folkestone_Harbour_with_Viaduct_and_Swing_Bridge.png",
-              "fileTitle": "File:Folkestone Harbour with Viaduct and Swing Bridge.png",
-              "mimeType": "image/png",
-              "width": 6000,
-              "height": 4000,
-              "license": {
-                "shortName": "CC BY-SA 4.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Claire Noble"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": false,
-                "checkedAt": "2026-06-20T19:26:07.298Z"
-              },
-              "priority": 1
-            },
             {
               "assetId": "wikipedia-pageimage-any:Folkestone_Invicta_FC_crest.svg",
               "kind": "crest",
@@ -38811,7 +38089,7 @@
                 ],
                 "checkedAt": "2026-06-20T19:26:07.298Z"
               },
-              "priority": 2
+              "priority": 1
             }
           ]
         }
@@ -40846,70 +40124,6 @@
                 "checkedAt": "2026-06-20T19:26:11.554Z"
               },
               "priority": 2
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Angel_of_the_North,_Gateshead,_United_Kingdom.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Gateshead",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/d/d2/Angel_of_the_North%2C_Gateshead%2C_United_Kingdom.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Angel_of_the_North,_Gateshead,_United_Kingdom.jpg",
-              "fileTitle": "File:Angel of the North, Gateshead, United Kingdom.jpg",
-              "mimeType": "image/jpeg",
-              "width": 3968,
-              "height": 2232,
-              "license": {
-                "shortName": "CC BY-SA 2.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
-                "copyrighted": true,
-                "credit": "https://www.flickr.com/photos/leonghongrui/11654459084/",
-                "artist": "Alvin Leong"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:26:11.554Z"
-              },
-              "priority": 3
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Hôtel_ville_South_Shields_South_Tyneside_28.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/South_Shields",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/5/55/H%C3%B4tel_ville_South_Shields_South_Tyneside_28.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:H%C3%B4tel_ville_South_Shields_South_Tyneside_28.jpg",
-              "fileTitle": "File:Hôtel ville South Shields South Tyneside 28.jpg",
-              "mimeType": "image/jpeg",
-              "width": 10581,
-              "height": 6866,
-              "license": {
-                "shortName": "CC BY-SA 4.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Chabe01"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:26:11.554Z"
-              },
-              "priority": 4
             }
           ]
         }
@@ -41603,72 +40817,6 @@
                 "checkedAt": "2026-06-20T19:26:14.645Z"
               },
               "priority": 2
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Glossop_-_geograph.org.uk_-_7292918.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Glossop",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/68/Glossop_-_geograph.org.uk_-_7292918.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Glossop_-_geograph.org.uk_-_7292918.jpg",
-              "fileTitle": "File:Glossop - geograph.org.uk - 7292918.jpg",
-              "mimeType": "image/jpeg",
-              "width": 4032,
-              "height": 2268,
-              "license": {
-                "shortName": "CC BY-SA 2.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
-                "copyrighted": true,
-                "attribution": "Glossop by Peter McDermott",
-                "credit": "Geograph Britain and Ireland",
-                "artist": "Peter McDermott"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:26:14.645Z"
-              },
-              "priority": 3
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
-              "fileTitle": "File:Ryan Valentine scores.jpg",
-              "mimeType": "image/jpeg",
-              "width": 3456,
-              "height": 2304,
-              "license": {
-                "shortName": "CC BY 2.5",
-                "usageTerms": "Creative Commons Attribution 2.5",
-                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Markbarnes"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:26:14.645Z"
-              },
-              "priority": 4
             }
           ]
         }
@@ -47320,38 +46468,6 @@
                 "checkedAt": "2026-06-20T19:26:32.611Z"
               },
               "priority": 2
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Hendon_Town_Hall_in_December_2011.JPG",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Hendon",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/2e/Hendon_Town_Hall_in_December_2011.JPG",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Hendon_Town_Hall_in_December_2011.JPG",
-              "fileTitle": "File:Hendon Town Hall in December 2011.JPG",
-              "mimeType": "image/jpeg",
-              "width": 4000,
-              "height": 3000,
-              "license": {
-                "shortName": "CC BY 3.0",
-                "usageTerms": "Creative Commons Attribution 3.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by/3.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Editor5807"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:26:32.611Z"
-              },
-              "priority": 3
             }
           ]
         }
@@ -47550,39 +46666,6 @@
                 ]
               },
               "priority": 2
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Centre_of_Hereford_-_geograph.org.uk_-_4306743.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Hereford",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/be/Centre_of_Hereford_-_geograph.org.uk_-_4306743.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Centre_of_Hereford_-_geograph.org.uk_-_4306743.jpg",
-              "fileTitle": "File:Centre of Hereford - geograph.org.uk - 4306743.jpg",
-              "mimeType": "image/jpeg",
-              "width": 800,
-              "height": 507,
-              "license": {
-                "shortName": "CC BY-SA 2.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
-                "copyrighted": true,
-                "attribution": "Centre of Hereford by Clint Mann",
-                "credit": "Geograph Britain and Ireland",
-                "artist": "Clint Mann"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:31:03.304Z"
-              },
-              "priority": 3
             }
           ]
         }
@@ -47883,38 +46966,6 @@
                 "checkedAt": "2026-06-20T19:26:59.679Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Hereford_United_League_Performance.svg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Hereford_United_F.C.",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Hereford_United_League_Performance.svg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Hereford_United_League_Performance.svg",
-              "fileTitle": "File:Hereford United League Performance.svg",
-              "mimeType": "image/svg+xml",
-              "width": 1105,
-              "height": 575,
-              "license": {
-                "shortName": "CC BY-SA 4.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "EclecticArkie"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:26:59.679Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -49301,41 +48352,7 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
-          "candidates": [
-            {
-              "assetId": "wikipedia-pageimage-free:Hounslow_High_Street.1.JPG",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Hounslow",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/d/d1/Hounslow_High_Street.1.JPG",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Hounslow_High_Street.1.JPG",
-              "fileTitle": "File:Hounslow High Street.1.JPG",
-              "mimeType": "image/jpeg",
-              "width": 2304,
-              "height": 1728,
-              "license": {
-                "shortName": "CC BY-SA 3.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "KTo288"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:31:04.917Z"
-              },
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -53529,39 +52546,6 @@
                 "checkedAt": "2026-06-20T19:27:06.034Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:New_North_Bank.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Leamington_F.C.",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/05/New_North_Bank.jpg",
-              "pageUrl": "https://en.wikipedia.org/wiki/File:New_North_Bank.jpg",
-              "fileTitle": "File:New North Bank.jpg",
-              "mimeType": "image/jpeg",
-              "width": 3008,
-              "height": 2000,
-              "license": {
-                "shortName": "Cc-by-sa-3.0",
-                "usageTerms": "Attribution-ShareAlike 3.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0/",
-                "copyrighted": true,
-                "credit": "Ian Oliver",
-                "artist": "Ian Oliver"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:27:06.034Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -53853,12 +52837,13 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
+          "preferred": "wikipedia-pageimage-free:Leeds_old_arms.png",
+          "status": "usable",
           "candidates": [
             {
               "assetId": "wikipedia-pageimage-free:Leeds_old_arms.png",
               "kind": "crest",
-              "status": "needs-review",
+              "status": "usable",
               "source": "wikipedia-pageimage-free",
               "sourceUrl": "https://en.wikipedia.org/wiki/Leeds_City_F.C.",
               "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9b/Leeds_old_arms.png",
@@ -53873,17 +52858,14 @@
                 "copyrighted": false
               },
               "verification": {
-                "identityMatch": "weak",
+                "identityMatch": "curated",
                 "licenseCheck": "pass",
                 "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
+                "needsManualReview": false,
                 "checkedAt": "2026-06-20T19:31:06.558Z"
               },
-              "priority": 1
+              "priority": 1,
+              "notes": "Curated as an acceptable Leeds City historical crest/arms candidate."
             }
           ]
         }
@@ -55236,7 +54218,7 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-more-research"
         }
       }
     },
@@ -55650,71 +54632,6 @@
                 "checkedAt": "2026-06-20T19:27:12.463Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:DrippingPan.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Lewes_F.C.",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/4/4b/DrippingPan.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:DrippingPan.jpg",
-              "fileTitle": "File:DrippingPan.jpg",
-              "mimeType": "image/jpeg",
-              "width": 640,
-              "height": 479,
-              "license": {
-                "shortName": "CC BY-SA 2.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
-                "copyrighted": true,
-                "attribution": "Simon Carey",
-                "credit": "From geograph.org.uk",
-                "artist": "Simon Carey"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:27:12.463Z"
-              },
-              "priority": 2
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Lewes-udsigt.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Lewes",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/73/Lewes-udsigt.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Lewes-udsigt.jpg",
-              "fileTitle": "File:Lewes-udsigt.jpg",
-              "mimeType": "image/jpeg",
-              "width": 1600,
-              "height": 1200,
-              "license": {
-                "shortName": "Public domain",
-                "usageTerms": "Public domain",
-                "copyrighted": false,
-                "credit": "Own work",
-                "artist": "Missjensen at da.wikipedia"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:27:12.463Z"
-              },
-              "priority": 3
             }
           ]
         }
@@ -55908,38 +54825,6 @@
                 "checkedAt": "2026-06-20T19:27:14.346Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:LeytonCentre.JPG",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Leyton",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b6/LeytonCentre.JPG",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:LeytonCentre.JPG",
-              "fileTitle": "File:LeytonCentre.JPG",
-              "mimeType": "image/jpeg",
-              "width": 3872,
-              "height": 2592,
-              "license": {
-                "shortName": "CC BY-SA 3.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Leyton59"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:27:14.346Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -57855,43 +56740,7 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
-          "candidates": [
-            {
-              "assetId": "wikipedia-pageimage-free:Town_Hall_-_Market_Place_(geograph_2938168).jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Loughborough",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b7/Town_Hall_-_Market_Place_%28geograph_2938168%29.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Town_Hall_-_Market_Place_(geograph_2938168).jpg",
-              "fileTitle": "File:Town Hall - Market Place (geograph 2938168).jpg",
-              "mimeType": "image/jpeg",
-              "width": 640,
-              "height": 533,
-              "license": {
-                "shortName": "CC BY-SA 2.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
-                "copyrighted": true,
-                "attribution": "Betty Longbottom",
-                "credit": "From geograph.org.uk",
-                "artist": "Betty Longbottom"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:31:08.179Z"
-              },
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -59159,39 +58008,6 @@
                 "checkedAt": "2026-06-20T19:27:18.534Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Maidenhead_v_Barnet_022.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Maidenhead_United_F.C.",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/5/51/Maidenhead_v_Barnet_022.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Maidenhead_v_Barnet_022.jpg",
-              "fileTitle": "File:Maidenhead v Barnet 022.jpg",
-              "mimeType": "image/jpeg",
-              "width": 4354,
-              "height": 3003,
-              "license": {
-                "shortName": "CC0",
-                "usageTerms": "Creative Commons Zero, Public Domain Dedication",
-                "licenseUrl": "http://creativecommons.org/publicdomain/zero/1.0/deed.en",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Maidenhead United FC"
-              },
-              "verification": {
-                "identityMatch": "weak",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:27:18.534Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -59601,39 +58417,6 @@
                 "checkedAt": "2026-06-20T19:27:20.144Z"
               },
               "priority": 2
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
-              "fileTitle": "File:Ryan Valentine scores.jpg",
-              "mimeType": "image/jpeg",
-              "width": 3456,
-              "height": 2304,
-              "license": {
-                "shortName": "CC BY 2.5",
-                "usageTerms": "Creative Commons Attribution 2.5",
-                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Markbarnes"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:27:20.144Z"
-              },
-              "priority": 3
             }
           ]
         }
@@ -63140,39 +61923,6 @@
                 ]
               },
               "priority": 2
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Middlesborough_Town_Hall_image_by_Robert_Eva.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Middlesbrough",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/a/a3/Middlesborough_Town_Hall_image_by_Robert_Eva.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Middlesborough_Town_Hall_image_by_Robert_Eva.jpg",
-              "fileTitle": "File:Middlesborough Town Hall image by Robert Eva.jpg",
-              "mimeType": "image/jpeg",
-              "width": 755,
-              "height": 460,
-              "license": {
-                "shortName": "CC BY 2.5",
-                "usageTerms": "Creative Commons Attribution 2.5",
-                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
-                "copyrighted": true,
-                "credit": "https://commons.wikimedia.org/wiki/File:Middlesbrough_town_hall_and_fountains_-_geograph.org.uk_-_5469169.jpg Wiki images",
-                "artist": "Robert Eva"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:31:09.938Z"
-              },
-              "priority": 3
             }
           ]
         }
@@ -63908,7 +62658,7 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-more-research"
         }
       }
     },
@@ -65668,40 +64418,7 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
-          "candidates": [
-            {
-              "assetId": "wikipedia-pageimage-free:New_Brighton_Tower.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/New_Brighton_Tower",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/e/e0/New_Brighton_Tower.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:New_Brighton_Tower.jpg",
-              "fileTitle": "File:New Brighton Tower.jpg",
-              "mimeType": "image/jpeg",
-              "width": 248,
-              "height": 314,
-              "license": {
-                "shortName": "Public domain",
-                "usageTerms": "Public domain",
-                "copyrighted": false,
-                "credit": "postcard",
-                "artist": "Unknown author Unknown author"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:31:11.666Z"
-              },
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -66961,39 +65678,6 @@
                 "checkedAt": "2026-06-20T19:28:04.956Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
-              "fileTitle": "File:Ryan Valentine scores.jpg",
-              "mimeType": "image/jpeg",
-              "width": 3456,
-              "height": 2304,
-              "license": {
-                "shortName": "CC BY 2.5",
-                "usageTerms": "Creative Commons Attribution 2.5",
-                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Markbarnes"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:28:04.956Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -71117,40 +69801,6 @@
                 "checkedAt": "2026-06-20T19:28:10.885Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:The_Main_Stand_at_Court_Place_Farm_-_geograph.org.uk_-_1245335.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Oxford_City_F.C.",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/e/ea/The_Main_Stand_at_Court_Place_Farm_-_geograph.org.uk_-_1245335.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:The_Main_Stand_at_Court_Place_Farm_-_geograph.org.uk_-_1245335.jpg",
-              "fileTitle": "File:The Main Stand at Court Place Farm - geograph.org.uk - 1245335.jpg",
-              "mimeType": "image/jpeg",
-              "width": 640,
-              "height": 427,
-              "license": {
-                "shortName": "CC BY-SA 2.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
-                "copyrighted": true,
-                "attribution": "Steve Daniels",
-                "credit": "From geograph.org.uk",
-                "artist": "Steve Daniels"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:28:10.885Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -71595,38 +70245,6 @@
                 "checkedAt": "2026-06-20T19:28:12.436Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Peterborough_Sports_vs_Guiseley_FC_-_FA_Cup_3rd_qualifying_round_2019.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Peterborough_Sports_F.C.",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/f/f1/Peterborough_Sports_vs_Guiseley_FC_-_FA_Cup_3rd_qualifying_round_2019.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Peterborough_Sports_vs_Guiseley_FC_-_FA_Cup_3rd_qualifying_round_2019.jpg",
-              "fileTitle": "File:Peterborough Sports vs Guiseley FC - FA Cup 3rd qualifying round 2019.jpg",
-              "mimeType": "image/jpeg",
-              "width": 3409,
-              "height": 3372,
-              "license": {
-                "shortName": "CC BY-SA 4.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "JamesRich2019"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:28:12.436Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -75732,52 +74350,7 @@
       },
       "assets": {
         "crest": {
-          "preferred": "generated-placeholder:Generated:redbridge-forest-placeholder-crest.svg",
-          "status": "placeholder",
-          "candidates": [
-            {
-              "assetId": "generated-placeholder:Generated:redbridge-forest-placeholder-crest.svg",
-              "kind": "crest",
-              "status": "placeholder",
-              "source": "generated-placeholder",
-              "placeholder": true,
-              "sourceUrl": "https://en.wikipedia.org/wiki/Redbridge_Forest_F.C.",
-              "imageUrl": "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20256%20256%22%20role%3D%22img%22%3E%3Ctitle%3ERedbridge%20Forest%20generated%20placeholder%20crest%3C%2Ftitle%3E%3Cpath%20d%3D%22M128%2014%20220%2048v68c0%2058-36%20103-92%20126-56-23-92-68-92-126V48l92-34Z%22%20fill%3D%22%23FF0000%22%20stroke%3D%22%23FFFFFF%22%20stroke-width%3D%2210%22%2F%3E%3Cpath%20d%3D%22M128%2026%20210%2056v58c0%2049-30%2088-82%20110V26Z%22%20fill%3D%22%230000FF%22%20opacity%3D%220.92%22%2F%3E%3Cpath%20d%3D%22M50%2084h156v30H50z%22%20fill%3D%22%23FFFFFF%22%20opacity%3D%220.9%22%2F%3E%3Ctext%20x%3D%22128%22%20y%3D%22154%22%20text-anchor%3D%22middle%22%20font-family%3D%22Arial%2C%20Helvetica%2C%20sans-serif%22%20font-size%3D%2258%22%20font-weight%3D%22700%22%20fill%3D%22%23FFFFFF%22%20stroke%3D%22%23111111%22%20stroke-width%3D%223%22%20paint-order%3D%22stroke%22%3ERF%3C%2Ftext%3E%3C%2Fsvg%3E",
-              "fileTitle": "Generated:redbridge-forest-placeholder-crest.svg",
-              "mimeType": "image/svg+xml",
-              "width": 256,
-              "height": 256,
-              "colors": [
-                {
-                  "role": "primary",
-                  "hex": "#FF0000"
-                },
-                {
-                  "role": "secondary",
-                  "hex": "#0000FF"
-                },
-                {
-                  "role": "accent",
-                  "hex": "#FFFFFF"
-                }
-              ],
-              "license": {
-                "shortName": "CC0-1.0",
-                "usageTerms": "Creative Commons Zero v1.0 Universal",
-                "licenseUrl": "https://creativecommons.org/publicdomain/zero/1.0/",
-                "copyrighted": false,
-                "attribution": "footy-data-kit generated placeholder"
-              },
-              "verification": {
-                "identityMatch": "generated-placeholder",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": false
-              },
-              "notes": "Generated placeholder shield from source-backed club colours; not an official or historical club crest.",
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -77676,7 +76249,7 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-more-research"
         }
       }
     },
@@ -78162,38 +76735,6 @@
                 "checkedAt": "2026-06-20T19:31:13.306Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:Silver_Jubilee_Bridge,_Runcorn,_night,_2024.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Runcorn",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/e/e8/Silver_Jubilee_Bridge%2C_Runcorn%2C_night%2C_2024.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Silver_Jubilee_Bridge,_Runcorn,_night,_2024.jpg",
-              "fileTitle": "File:Silver Jubilee Bridge, Runcorn, night, 2024.jpg",
-              "mimeType": "image/jpeg",
-              "width": 3836,
-              "height": 2268,
-              "license": {
-                "shortName": "CC0",
-                "usageTerms": "Creative Commons Zero, Public Domain Dedication",
-                "licenseUrl": "http://creativecommons.org/publicdomain/zero/1.0/deed.en",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Dgp4004"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:31:13.306Z"
-              },
-              "priority": 2
             }
           ]
         }
@@ -81371,41 +79912,7 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
-          "candidates": [
-            {
-              "assetId": "wikidata-image:Shepshed Ground 001 Small.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikidata-image",
-              "sourceUrl": "https://www.wikidata.org/wiki/Q5330596",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Shepshed_Ground_001_Small.jpg",
-              "fileTitle": "File:Shepshed Ground 001 Small.jpg",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/71/Shepshed_Ground_001_Small.jpg",
-              "mimeType": "image/jpeg",
-              "width": 314,
-              "height": 235,
-              "license": {
-                "shortName": "Public domain",
-                "usageTerms": "Public domain",
-                "copyrighted": false,
-                "credit": "Own work",
-                "artist": "Andymac1967 ( talk )"
-              },
-              "verification": {
-                "identityMatch": "weak",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:50:40.960Z"
-              },
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -85473,41 +83980,7 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
-          "candidates": [
-            {
-              "assetId": "wikidata-image:DovervStaines.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikidata-image",
-              "sourceUrl": "https://www.wikidata.org/wiki/Q2511419",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:DovervStaines.jpg",
-              "fileTitle": "File:DovervStaines.jpg",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/cc/DovervStaines.jpg",
-              "mimeType": "image/jpeg",
-              "width": 640,
-              "height": 359,
-              "license": {
-                "shortName": "Public domain",
-                "usageTerms": "Public domain",
-                "copyrighted": false,
-                "credit": "Transferred from en.wikipedia to Commons by Kafuffle using CommonsHelper .",
-                "artist": "ChrisTheDude at English Wikipedia"
-              },
-              "verification": {
-                "identityMatch": "none",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "identity-uncertain",
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:51:00.651Z"
-              },
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -90084,7 +88557,7 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-more-research"
         }
       }
     },
@@ -90433,41 +88906,7 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
-          "candidates": [
-            {
-              "assetId": "wikipedia-pageimage-free:London_Thames_Sunset_panorama_-_Feb_2008.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/River_Thames",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/6e/London_Thames_Sunset_panorama_-_Feb_2008.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:London_Thames_Sunset_panorama_-_Feb_2008.jpg",
-              "fileTitle": "File:London Thames Sunset panorama - Feb 2008.jpg",
-              "mimeType": "image/jpeg",
-              "width": 13126,
-              "height": 4876,
-              "license": {
-                "shortName": "CC BY 3.0",
-                "usageTerms": "Creative Commons Attribution 3.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by/3.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Diliff"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:31:16.121Z"
-              },
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -92866,41 +91305,7 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
-          "candidates": [
-            {
-              "assetId": "wikidata-image:Trowbridge Town F.C..jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikidata-image",
-              "sourceUrl": "https://www.wikidata.org/wiki/Q7846685",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Trowbridge_Town_F.C..jpg",
-              "fileTitle": "File:Trowbridge Town F.C..jpg",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/84/Trowbridge_Town_F.C..jpg",
-              "mimeType": "image/jpeg",
-              "width": 4032,
-              "height": 3024,
-              "license": {
-                "shortName": "CC BY-SA 4.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
-                "copyrighted": true,
-                "credit": "Own work",
-                "artist": "chris_debian"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:51:03.322Z"
-              },
-              "priority": 1
-            }
-          ]
+          "status": "needs-more-research"
         }
       }
     },
@@ -94018,7 +92423,7 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-more-research"
         }
       }
     },
@@ -97204,7 +95609,7 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-more-research"
         }
       }
     },
@@ -98918,7 +97323,7 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-more-research"
         }
       }
     },
@@ -99231,39 +97636,6 @@
                 "checkedAt": "2026-06-20T19:29:24.968Z"
               },
               "priority": 1
-            },
-            {
-              "assetId": "wikipedia-pageimage-free:BroadLaneWivenhoeTown21Jan2017.jpg",
-              "kind": "crest",
-              "status": "needs-review",
-              "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/Wivenhoe_Town_F.C.",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8f/BroadLaneWivenhoeTown21Jan2017.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:BroadLaneWivenhoeTown21Jan2017.jpg",
-              "fileTitle": "File:BroadLaneWivenhoeTown21Jan2017.jpg",
-              "mimeType": "image/jpeg",
-              "width": 480,
-              "height": 360,
-              "license": {
-                "shortName": "CC BY-SA 4.0",
-                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
-                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
-                "copyrighted": true,
-                "attribution": "BarnabyJoe at English Wikipedia",
-                "credit": "No machine-readable source provided. Own work assumed (based on copyright claims).",
-                "artist": "BarnabyJoe"
-              },
-              "verification": {
-                "identityMatch": "possible",
-                "licenseCheck": "pass",
-                "httpCheck": "pass",
-                "needsManualReview": true,
-                "reviewReasons": [
-                  "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:29:24.968Z"
-              },
-              "priority": 2
             }
           ]
         }

--- a/data/club-metadata.json
+++ b/data/club-metadata.json
@@ -2,8 +2,8 @@
   "metadata": {
     "schemaVersion": 1,
     "generator": "club-assets",
-    "generatedAt": "2026-06-20T19:31:27.723Z",
-    "gitSha": "e0edd04",
+    "generatedAt": "2026-06-20T19:54:09.010Z",
+    "gitSha": "798511e",
     "sourceFiles": [
       "/Users/dsteele/repos/footy-data-kit/data-output/all-seasons.json",
       "/Users/dsteele/repos/footy-data-kit-club-assets/data/club-metadata.json"
@@ -134,7 +134,38 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "preferred": "wikidata-coat-of-arms:AberdareAthletic.jpg",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikidata-coat-of-arms:AberdareAthletic.jpg",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikidata-coat-of-arms",
+              "sourceUrl": "https://www.wikidata.org/wiki/Q2045510",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:AberdareAthletic.jpg",
+              "fileTitle": "File:AberdareAthletic.jpg",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0e/AberdareAthletic.jpg",
+              "mimeType": "image/jpeg",
+              "width": 384,
+              "height": 310,
+              "license": {
+                "shortName": "Public domain",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "Image taken from the Rhondda Cynon Taf Library Service archive , where it is explicitly stated that the identity of the photographer is unknown. In conjunction with its age (70+ years) this renders it PD in the UK.",
+                "artist": "Unknown author Unknown author"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T19:50:15.033Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -3797,7 +3828,41 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikidata-image:Andover-2008-Squad.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikidata-image",
+              "sourceUrl": "https://www.wikidata.org/wiki/Q4754611",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Andover-2008-Squad.jpg",
+              "fileTitle": "File:Andover-2008-Squad.jpg",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/88/Andover-2008-Squad.jpg",
+              "mimeType": "image/jpeg",
+              "width": 500,
+              "height": 208,
+              "license": {
+                "shortName": "CC BY 3.0",
+                "usageTerms": "Creative Commons Attribution 3.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by/3.0",
+                "copyrighted": true,
+                "credit": "Len Abrahams (webmaster of www.andover-fc.co.uk)",
+                "artist": "Len Abrahams (webmaster of www.andover-fc.co.uk)"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:50:16.147Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -34441,7 +34506,40 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Eastwood_Town_FC.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Eastwood_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/0d/Eastwood_Town_FC.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Eastwood_Town_FC.png",
+              "fileTitle": "File:Eastwood Town FC.png",
+              "mimeType": "image/png",
+              "width": 200,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Eastwood Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Eastwood_Town_FC.png",
+                "copyrighted": true,
+                "credit": "http://www.eastwoodtownfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:50:20.886Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -47270,10 +47368,10 @@
                 "licenseCheck": "pass",
                 "httpCheck": "pass",
                 "needsManualReview": true,
+                "checkedAt": "2026-06-20T19:31:03.304Z",
                 "reviewReasons": [
                   "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:31:03.304Z"
+                ]
               },
               "priority": 2
             },
@@ -62860,10 +62958,10 @@
                 "licenseCheck": "pass",
                 "httpCheck": "pass",
                 "needsManualReview": true,
+                "checkedAt": "2026-06-20T19:31:09.938Z",
                 "reviewReasons": [
                   "non-crest-filename"
-                ],
-                "checkedAt": "2026-06-20T19:31:09.938Z"
+                ]
               },
               "priority": 2
             },
@@ -80925,7 +81023,41 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikidata-image:Shepshed Ground 001 Small.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikidata-image",
+              "sourceUrl": "https://www.wikidata.org/wiki/Q5330596",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Shepshed_Ground_001_Small.jpg",
+              "fileTitle": "File:Shepshed Ground 001 Small.jpg",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/71/Shepshed_Ground_001_Small.jpg",
+              "mimeType": "image/jpeg",
+              "width": 314,
+              "height": 235,
+              "license": {
+                "shortName": "Public domain",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "Own work",
+                "artist": "Andymac1967 ( talk )"
+              },
+              "verification": {
+                "identityMatch": "weak",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:50:40.960Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -84993,7 +85125,41 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikidata-image:DovervStaines.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikidata-image",
+              "sourceUrl": "https://www.wikidata.org/wiki/Q2511419",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:DovervStaines.jpg",
+              "fileTitle": "File:DovervStaines.jpg",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/cc/DovervStaines.jpg",
+              "mimeType": "image/jpeg",
+              "width": 640,
+              "height": 359,
+              "license": {
+                "shortName": "Public domain",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "Transferred from en.wikipedia to Commons by Kafuffle using CommonsHelper .",
+                "artist": "ChrisTheDude at English Wikipedia"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:51:00.651Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -92311,7 +92477,41 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikidata-image:Trowbridge Town F.C..jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikidata-image",
+              "sourceUrl": "https://www.wikidata.org/wiki/Q7846685",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Trowbridge_Town_F.C..jpg",
+              "fileTitle": "File:Trowbridge Town F.C..jpg",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/84/Trowbridge_Town_F.C..jpg",
+              "mimeType": "image/jpeg",
+              "width": 4032,
+              "height": 3024,
+              "license": {
+                "shortName": "CC BY-SA 4.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "chris_debian"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:51:03.322Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },

--- a/data/club-metadata.json
+++ b/data/club-metadata.json
@@ -1,14 +1,21 @@
 {
   "metadata": {
     "schemaVersion": 1,
-    "generator": "club-metadata-seed",
-    "generatedAt": "2026-06-20T03:17:26.293Z",
-    "gitSha": "fcf1637",
+    "generator": "club-assets",
+    "generatedAt": "2026-06-20T19:11:05.502Z",
+    "gitSha": "afe2785",
     "sourceFiles": [
-      "/Users/dsteele/repos/footy-data-kit/data-output/all-seasons.json"
+      "/Users/dsteele/repos/footy-data-kit/data-output/all-seasons.json",
+      "/Users/dsteele/repos/footy-data-kit-club-assets/data/club-metadata.json"
     ],
     "buildOptions": {
-      "input": "/Users/dsteele/repos/footy-data-kit/data-output/all-seasons.json"
+      "input": "./data/club-metadata.json",
+      "limit": 5,
+      "clubLimit": null,
+      "cache": true,
+      "refreshAssets": false,
+      "requestDelayMs": 0,
+      "inputGenerator": "club-metadata-seed"
     }
   },
   "clubs": {
@@ -123,6 +130,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "accrington": {
@@ -246,6 +258,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "accrington stanley": {
@@ -474,6 +491,44 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Accrington_Stanley_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Accrington_Stanley_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/ba/Accrington_Stanley_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Accrington_Stanley_F.C._logo.svg",
+              "fileTitle": "File:Accrington Stanley F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 200,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Accrington Stanley F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Accrington_Stanley_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Accrington Stanley F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:15.354Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "accrington stanley 1891": {
@@ -740,6 +795,46 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
+              "fileTitle": "File:Ryan Valentine scores.jpg",
+              "mimeType": "image/jpeg",
+              "width": 3456,
+              "height": 2304,
+              "license": {
+                "shortName": "CC BY 2.5",
+                "usageTerms": "Creative Commons Attribution 2.5",
+                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Markbarnes"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:52:16.522Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "addlestone and weybridge town": {
@@ -899,6 +994,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "afc bournemouth": {
@@ -1361,6 +1461,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:AFC_Bournemouth_(2013).svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/AFC_Bournemouth",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e5/AFC_Bournemouth_%282013%29.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:AFC_Bournemouth_(2013).svg",
+              "fileTitle": "File:AFC Bournemouth (2013).svg",
+              "mimeType": "image/svg+xml",
+              "width": 152,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of AFC Bournemouth",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:AFC_Bournemouth_(2013).svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: AFC Bournemouth Official Website AFC Bournemouth"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:18.626Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "afc fylde": {
@@ -1471,6 +1609,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "afc telford united": {
@@ -1681,6 +1824,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:AFC_Telford_United_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/AFC_Telford_United",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e9/AFC_Telford_United_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:AFC_Telford_United_logo.svg",
+              "fileTitle": "File:AFC Telford United logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 203,
+              "height": 493,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of AFC Telford United",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:AFC_Telford_United_logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/afc-telford-united/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:20.775Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "afc totton": {
@@ -1750,6 +1931,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "afc wimbledon": {
@@ -1930,6 +2116,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:AFC_Wimbledon_(2020)_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/AFC_Wimbledon",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/1b/AFC_Wimbledon_%282020%29_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:AFC_Wimbledon_(2020)_logo.svg",
+              "fileTitle": "File:AFC Wimbledon (2020) logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 156,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of AFC Wimbledon",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:AFC_Wimbledon_(2020)_logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from AFC Wimbledon."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:22.817Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "aldershot": {
@@ -2247,6 +2471,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Aldershot_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Aldershot_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/25/Aldershot_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Aldershot_FC_crest.svg",
+              "fileTitle": "File:Aldershot FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Aldershot F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Aldershot_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.brandsoftheworld.com/logo/aldershot-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:23.880Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "aldershot town": {
@@ -2449,6 +2711,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Aldershot_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Aldershot_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/30/Aldershot_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Aldershot_Town_FC_crest.svg",
+              "fileTitle": "File:Aldershot Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 314,
+              "height": 318,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Aldershot Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Aldershot_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/national-league/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:25.001Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "alfreton town": {
@@ -2618,6 +2918,44 @@
             "length": 5
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Alfreton_Town_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Alfreton_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/52/Alfreton_Town_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Alfreton_Town_FC_logo.svg",
+              "fileTitle": "File:Alfreton Town FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 255,
+              "height": 392,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Alfreton Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Alfreton_Town_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "fr:Fichier:Logo Alfreton Town FC 2015.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:26.113Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "altrincham": {
@@ -2880,6 +3218,75 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Altrincham_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Altrincham_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/3b/Altrincham_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Altrincham_FC_crest.svg",
+              "fileTitle": "File:Altrincham FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 307,
+              "height": 326,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Altrincham F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Altrincham_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/wiki/Fichier:Altrincham_FC_(logo).svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:27.246Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Exeter_City_match.JPG",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Altrincham_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/3e/Exeter_City_match.JPG",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Exeter_City_match.JPG",
+              "fileTitle": "File:Exeter City match.JPG",
+              "mimeType": "image/jpeg",
+              "width": 2592,
+              "height": 1944,
+              "license": {
+                "shortName": "CC BY-SA 3.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
+                "licenseUrl": "http://creativecommons.org/licenses/by-sa/3.0/",
+                "copyrighted": true
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:52:27.246Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "alvechurch": {
@@ -3032,6 +3439,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Alvechurch_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Alvechurch_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b6/Alvechurch_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Alvechurch_FC_crest.svg",
+              "fileTitle": "File:Alvechurch FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 297,
+              "height": 336,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Alvechurch F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Alvechurch_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/alvechurch-fc-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:28.376Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "andover": {
@@ -3148,6 +3593,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "arsenal": {
@@ -3663,6 +4113,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Arsenal_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Arsenal_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/53/Arsenal_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Arsenal_FC.svg",
+              "fileTitle": "File:Arsenal FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 292,
+              "height": 343,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Arsenal F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Arsenal_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: https://www.arsenal.com/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:30.530Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "ashford united": {
@@ -3832,6 +4320,44 @@
             "length": 6
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:AshfordUnited.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Ashford_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/1f/AshfordUnited.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:AshfordUnited.png",
+              "fileTitle": "File:AshfordUnited.png",
+              "mimeType": "image/png",
+              "width": 275,
+              "height": 362,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Ashford United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:AshfordUnited.png",
+                "copyrighted": true,
+                "credit": "https://web.archive.org/web/20140501143707/http://ashfordunitedfc.com/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:31.730Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "ashington": {
@@ -3938,6 +4464,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Ashington_A.F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Ashington_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/61/Ashington_A.F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Ashington_A.F.C._logo.png",
+              "fileTitle": "File:Ashington A.F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 348,
+              "height": 285,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Ashington A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Ashington_A.F.C._logo.png",
+                "copyrighted": true,
+                "credit": "Official Facebook page: https://scontent-lax.xx.fbcdn.net/hphotos-xfa1/v/t1.0-9/480898_10151621359197752_325108038_n.jpg?oh=23696f6fee8af9579d05fbdff9d83e55&oe=55D1C744"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:32.859Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "ashton united": {
@@ -4081,6 +4645,44 @@
             "length": 13
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Ashton_United_FC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Ashton_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a2/Ashton_United_FC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Ashton_United_FC_logo.png",
+              "fileTitle": "File:Ashton United FC logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Ashton United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Ashton_United_FC_logo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.pitchero.com/clubs/ashtonunited/ http://www.mossleyweb.com/Clubs2006~07/ClubsAshtonUnited.htm"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:33.906Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "aston villa": {
@@ -4596,6 +5198,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Aston_Villa_FC_new_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Aston_Villa_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9a/Aston_Villa_FC_new_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Aston_Villa_FC_new_crest.svg",
+              "fileTitle": "File:Aston Villa FC new crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 271,
+              "height": 369,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Aston Villa F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Aston_Villa_FC_new_crest.svg",
+                "copyrighted": true,
+                "credit": "fr:Fichier:Aston Villa FC 2024.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:35.037Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "atherstone town": {
@@ -4736,6 +5376,77 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:AtherstoneTownFC.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Atherstone_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/17/AtherstoneTownFC.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:AtherstoneTownFC.png",
+              "fileTitle": "File:AtherstoneTownFC.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Atherstone Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:AtherstoneTownFC.png",
+                "copyrighted": true,
+                "credit": "http://www.theadders.com/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:36.150Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Atherstone_Town_FC_2009.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Atherstone_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b9/Atherstone_Town_FC_2009.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Atherstone_Town_FC_2009.jpg",
+              "fileTitle": "File:Atherstone Town FC 2009.jpg",
+              "mimeType": "image/jpeg",
+              "width": 640,
+              "height": 480,
+              "license": {
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
+                "copyrighted": true,
+                "attribution": "Geoff Pick",
+                "credit": "From geograph.org.uk",
+                "artist": "Geoff Pick"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:52:36.150Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "aveley": {
@@ -4824,6 +5535,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Aveley_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Aveley_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/f0/Aveley_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Aveley_FC_crest.svg",
+              "fileTitle": "File:Aveley FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 259,
+              "height": 387,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Aveley F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Aveley_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/aveley-fc-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:37.277Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "aylesbury united": {
@@ -5012,6 +5761,43 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Aylesbury_United_FC.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Aylesbury_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/1b/Aylesbury_United_FC.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Aylesbury_United_FC.png",
+              "fileTitle": "File:Aylesbury United FC.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Aylesbury_United_FC.png",
+                "copyrighted": true
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:38.470Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "baldock town": {
@@ -5125,6 +5911,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Baldock_Town_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Baldock_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/fa/Baldock_Town_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Baldock_Town_F.C._logo.png",
+              "fileTitle": "File:Baldock Town F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 276,
+              "height": 360,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Baldock Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Baldock_Town_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "Official Twitter account: https://pbs.twimg.com/profile_images/2507805297/0p07vapyemrlckn4mdvb.jpeg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:39.568Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bamber bridge": {
@@ -5228,6 +6052,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bamberbridgefc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bamber_Bridge_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/54/Bamberbridgefc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bamberbridgefc.png",
+              "fileTitle": "File:Bamberbridgefc.png",
+              "mimeType": "image/png",
+              "width": 297,
+              "height": 335,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bamber Bridge F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bamberbridgefc.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.bamberbridgefc.co.uk/ http://www.bamberbridgefc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:40.646Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "banbury united": {
@@ -5345,6 +6207,44 @@
             "length": 40
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Banbury_United_Logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Banbury_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9f/Banbury_United_Logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Banbury_United_Logo.png",
+              "fileTitle": "File:Banbury United Logo.png",
+              "mimeType": "image/png",
+              "width": 313,
+              "height": 313,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Banbury United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Banbury_United_Logo.png",
+                "copyrighted": true,
+                "credit": "http://i.imgur.com/yDRKB6r.png"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:41.764Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bangor city": {
@@ -5517,6 +6417,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bangor_City_FC_Logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bangor_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/48/Bangor_City_FC_Logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bangor_City_FC_Logo.png",
+              "fileTitle": "File:Bangor City FC Logo.png",
+              "mimeType": "image/png",
+              "width": 280,
+              "height": 356,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bangor City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bangor_City_FC_Logo.png",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Bangor City F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:42.906Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "barking": {
@@ -5660,6 +6598,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Barking_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Barking_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e9/Barking_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Barking_F.C._logo.png",
+              "fileTitle": "File:Barking F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 285,
+              "height": 343,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Barking_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "Obtained from the club website"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:43.980Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "barnet": {
@@ -5883,6 +6859,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Barnet_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Barnet_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a2/Barnet_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Barnet_FC.svg",
+              "fileTitle": "File:Barnet FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 289,
+              "height": 346,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Barnet F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Barnet_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Barnet F.C. Official Website Converted to AI format by Vflnet.com and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped the SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:45.158Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "barnsley": {
@@ -6376,6 +7390,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Barnsley_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Barnsley_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c9/Barnsley_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Barnsley_FC.svg",
+              "fileTitle": "File:Barnsley FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 274,
+              "height": 277,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Barnsley F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Barnsley_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Barnsley F.C. Official Website Converted to AI format by Vflnet.com and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped the SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:46.296Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "barrow": {
@@ -6812,6 +7864,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Barrow_AFC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Barrow_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/28/Barrow_AFC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Barrow_AFC_logo.svg",
+              "fileTitle": "File:Barrow AFC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 284,
+              "height": 353,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Barrow A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Barrow_AFC_logo.svg",
+                "copyrighted": true,
+                "credit": "fr:Fichier:Logo Barrow AFC - 2014.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:47.436Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "barry town united": {
@@ -6903,6 +7993,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Barry_Town_United_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Barry_Town_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/fa/Barry_Town_United_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Barry_Town_United_F.C._logo.svg",
+              "fileTitle": "File:Barry Town United F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 314,
+              "height": 318,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Barry Town United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Barry_Town_United_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/wales/barry-town-united/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:48.583Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bashley": {
@@ -6997,6 +8125,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bashleyfc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bashley_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/7e/Bashleyfc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bashleyfc.png",
+              "fileTitle": "File:Bashleyfc.png",
+              "mimeType": "image/png",
+              "width": 312,
+              "height": 312,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bashley F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bashleyfc.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.bashleyfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:49.709Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "basingstoke town": {
@@ -7225,6 +8391,44 @@
             "length": 3
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Basingstoke_town_fc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Basingstoke_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/31/Basingstoke_town_fc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Basingstoke_town_fc.png",
+              "fileTitle": "File:Basingstoke town fc.png",
+              "mimeType": "image/png",
+              "width": 315,
+              "height": 312,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Basingstoke Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Basingstoke_town_fc.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://basingstoketown.net/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:50.885Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bath city": {
@@ -7452,6 +8656,42 @@
             "length": 3
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikipedia-pageimage-free:Bath_City_logo.svg",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Bath_City_logo.svg",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bath_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b7/Bath_City_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bath_City_logo.svg",
+              "fileTitle": "File:Bath City logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 262,
+              "height": 382,
+              "license": {
+                "shortName": "PD",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "fr:Fichier:Logo Bath City FC.svg",
+                "artist": "Bath City F.C."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:52:52.059Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bedford town": {
@@ -7627,6 +8867,44 @@
             "length": 18
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bedford_Town_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bedford_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a1/Bedford_Town_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bedford_Town_F.C._logo.svg",
+              "fileTitle": "File:Bedford Town F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 314,
+              "height": 318,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bedford Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bedford_Town_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/bedford-town/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:53.110Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bedworth united": {
@@ -7764,6 +9042,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bedworth_United_FC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bedworth_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b9/Bedworth_United_FC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bedworth_United_FC_logo.png",
+              "fileTitle": "File:Bedworth United FC logo.png",
+              "mimeType": "image/png",
+              "width": 317,
+              "height": 314,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bedworth United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bedworth_United_FC_logo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Club website"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:54.219Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "billericay town": {
@@ -7979,6 +9295,44 @@
             "length": 5
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Billericay_Town_Football_Club_Badge.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Billericay_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/09/Billericay_Town_Football_Club_Badge.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Billericay_Town_Football_Club_Badge.png",
+              "fileTitle": "File:Billericay Town Football Club Badge.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Billericay Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Billericay_Town_Football_Club_Badge.png",
+                "copyrighted": true,
+                "credit": "https://www.billericaytownfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:55.375Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "birmingham city": {
@@ -8526,6 +9880,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Birmingham_City_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Birmingham_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/68/Birmingham_City_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Birmingham_City_FC_logo.svg",
+              "fileTitle": "File:Birmingham City FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 266,
+              "height": 377,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Birmingham City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Birmingham_City_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "de:Datei:Birmingham city fc.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:56.451Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "birmingham st georges": {
@@ -8627,6 +10019,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "bishop auckland": {
@@ -8748,6 +10145,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "bishops stortford": {
@@ -9011,6 +10413,44 @@
             "length": 6
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bishop's_Stortford_FC.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bishop's_Stortford_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b2/Bishop%27s_Stortford_FC.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bishop%27s_Stortford_FC.png",
+              "fileTitle": "File:Bishop's Stortford FC.png",
+              "mimeType": "image/png",
+              "width": 278,
+              "height": 349,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bishop's Stortford F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bishop%27s_Stortford_FC.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Bishop's Stortford FC Official Website"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:52:59.655Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "blackburn rovers": {
@@ -9526,6 +10966,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Blackburn_Rovers.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Blackburn_Rovers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/0f/Blackburn_Rovers.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Blackburn_Rovers.svg",
+              "fileTitle": "File:Blackburn Rovers.svg",
+              "mimeType": "image/svg+xml",
+              "width": 311,
+              "height": 322,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Blackburn Rovers L.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Blackburn_Rovers.svg",
+                "copyrighted": true,
+                "credit": "Blackburn Rovers Official Website"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:01.730Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "blackpool": {
@@ -10068,6 +11546,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Blackpool_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Blackpool_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/df/Blackpool_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Blackpool_FC_logo.svg",
+              "fileTitle": "File:Blackpool FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Blackpool F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Blackpool_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "de:Datei:FC Blackpool logo.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:02.922Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "blyth spartans": {
@@ -10283,6 +11799,44 @@
             "length": 5
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Blyth_Spartans_AFC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Blyth_Spartans_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/d5/Blyth_Spartans_AFC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Blyth_Spartans_AFC_crest.svg",
+              "fileTitle": "File:Blyth Spartans AFC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 243,
+              "height": 412,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Blyth Spartans A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Blyth_Spartans_AFC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/wiki/Fichier:Logo_Blyth_Spartans_AFC.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:04.054Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bognor regis town": {
@@ -10510,6 +12064,44 @@
             "length": 8
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bognorregistownfc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bognor_Regis_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9f/Bognorregistownfc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bognorregistownfc.png",
+              "fileTitle": "File:Bognorregistownfc.png",
+              "mimeType": "image/png",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bognor Regis Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bognorregistownfc.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.therocks.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:05.201Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bolton wanderers": {
@@ -11034,6 +12626,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bolton_Wanderers_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bolton_Wanderers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/82/Bolton_Wanderers_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bolton_Wanderers_FC_logo.svg",
+              "fileTitle": "File:Bolton Wanderers FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 277,
+              "height": 299,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bolton Wanderers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bolton_Wanderers_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "http://www.boltoncentral.co.uk/assets/uploaded/BoltonCentral/Documents/163_Club%20Together%20Cashback%20Brochure%2013%2014.pdf"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:06.356Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bootle": {
@@ -11151,6 +12781,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "boreham wood": {
@@ -11359,6 +12994,42 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikidata-logo:Boreham Wood FC logo.svg",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikidata-logo:Boreham Wood FC logo.svg",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikidata-logo",
+              "sourceUrl": "https://www.wikidata.org/wiki/Q4094837",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Boreham_Wood_FC_logo.svg",
+              "fileTitle": "File:Boreham Wood FC logo.svg",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/81/Boreham_Wood_FC_logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 933,
+              "height": 933,
+              "license": {
+                "shortName": "Public domain",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "https://www.bbc.com/sport/football/teams/boreham-wood/table",
+                "artist": "Boreham Wood F.C."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:53:08.558Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "boston united": {
@@ -11626,6 +13297,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Boston_United_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Boston_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/53/Boston_United_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Boston_United_FC_logo.svg",
+              "fileTitle": "File:Boston United FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Boston United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Boston_United_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "de:Datei:Boston United Logo.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:09.738Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "brackley town": {
@@ -11742,6 +13451,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:BrackleyTownFCBadge.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Brackley_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/08/BrackleyTownFCBadge.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:BrackleyTownFCBadge.png",
+              "fileTitle": "File:BrackleyTownFCBadge.png",
+              "mimeType": "image/png",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Brackley Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:BrackleyTownFCBadge.png",
+                "copyrighted": true,
+                "credit": "https://southern-football-league.co.uk/team/BrackleyTown/2599//p"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:10.955Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bradford city": {
@@ -12222,6 +13969,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bradford_City_AFC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bradford_City_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/04/Bradford_City_AFC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bradford_City_AFC_crest.svg",
+              "fileTitle": "File:Bradford City AFC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 260,
+              "height": 384,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bradford City A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bradford_City_AFC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/league-one/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:12.096Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bradford park avenue": {
@@ -12743,6 +14528,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bradford_(Park_Avenue)_A.F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bradford_(Park_Avenue)_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/62/Bradford_%28Park_Avenue%29_A.F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bradford_(Park_Avenue)_A.F.C._logo.png",
+              "fileTitle": "File:Bradford (Park Avenue) A.F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 315,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bradford (Park Avenue) A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bradford_(Park_Avenue)_A.F.C._logo.png",
+                "copyrighted": true,
+                "credit": "https://bpafc.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:13.233Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "braintree town": {
@@ -12906,6 +14729,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Braintree_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Braintree_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b5/Braintree_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Braintree_Town_FC_crest.svg",
+              "fileTitle": "File:Braintree Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Braintree Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Braintree_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/braintree-town-fc-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:14.375Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "brentford": {
@@ -13322,6 +15183,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Brentford_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Brentford_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2a/Brentford_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Brentford_FC_crest.svg",
+              "fileTitle": "File:Brentford FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Brentford F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Brentford_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Brentford F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:15.530Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bridgend town": {
@@ -13426,6 +15325,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bridgendtown.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bridgend_Town_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/23/Bridgendtown.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bridgendtown.png",
+              "fileTitle": "File:Bridgendtown.png",
+              "mimeType": "image/png",
+              "width": 168,
+              "height": 180,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bridgend Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bridgendtown.png",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Bridgend Town F.C.."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:16.596Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bridlington town": {
@@ -13511,6 +15448,43 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikipedia-pageimage-any:Bridlington_Town_F.C.png",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bridlington_Town_F.C.png",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bridlington_Town_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/e/e8/Bridlington_Town_F.C.png",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Bridlington_Town_F.C.png",
+              "fileTitle": "File:Bridlington Town F.C.png",
+              "mimeType": "image/png",
+              "width": 848,
+              "height": 848,
+              "license": {
+                "shortName": "CC BY-SA 4.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Alan keysham1"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:53:17.680Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "brighton and hove albion": {
@@ -13925,6 +15899,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Brighton_and_Hove_Albion_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Brighton_%26_Hove_Albion_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/d0/Brighton_and_Hove_Albion_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Brighton_and_Hove_Albion_FC_crest.svg",
+              "fileTitle": "File:Brighton and Hove Albion FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Brighton & Hove Albion F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Brighton_and_Hove_Albion_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.brightonandhovealbion.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:18.831Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bristol city": {
@@ -14410,6 +16422,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bristol_City_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bristol_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/f5/Bristol_City_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bristol_City_crest.svg",
+              "fileTitle": "File:Bristol City crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bristol City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bristol_City_crest.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Bristol Sport."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:20.020Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bristol rovers": {
@@ -14824,6 +16874,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bristol_Rovers_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bristol_Rovers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/47/Bristol_Rovers_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bristol_Rovers_F.C._logo.svg",
+              "fileTitle": "File:Bristol Rovers F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 145,
+              "height": 157,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bristol Rovers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bristol_Rovers_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "[1]"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:21.096Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "bromley": {
@@ -15067,6 +17155,76 @@
             "length": 8
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bromley_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bromley_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/35/Bromley_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bromley_FC_crest.svg",
+              "fileTitle": "File:Bromley FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bromley F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bromley_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/national-league/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:22.179Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Bromley_FC_League_Performance.svg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bromley_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8e/Bromley_FC_League_Performance.svg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Bromley_FC_League_Performance.svg",
+              "fileTitle": "File:Bromley FC League Performance.svg",
+              "mimeType": "image/svg+xml",
+              "width": 1190,
+              "height": 688,
+              "license": {
+                "shortName": "CC BY-SA 4.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "EclecticArkie"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:53:22.179Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "bromsgrove rovers": {
@@ -15279,6 +17437,44 @@
             "length": 4
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bromsgrove_Rovers_Badge.jpg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bromsgrove_Rovers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/7f/Bromsgrove_Rovers_Badge.jpg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bromsgrove_Rovers_Badge.jpg",
+              "fileTitle": "File:Bromsgrove Rovers Badge.jpg",
+              "mimeType": "image/jpeg",
+              "width": 95,
+              "height": 106,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bromsgrove Rovers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bromsgrove_Rovers_Badge.jpg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Bromsgrove Rovers F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:23.329Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "burnley": {
@@ -15803,6 +17999,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Burnley_FC_Logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Burnley_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/6d/Burnley_FC_Logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Burnley_FC_Logo.svg",
+              "fileTitle": "File:Burnley FC Logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 295,
+              "height": 339,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Burnley F.C. Women",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Burnley_FC_Logo.svg",
+                "copyrighted": true,
+                "credit": "Premier League – taken from resources.premierleague.com"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:24.531Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "burscough": {
@@ -15923,6 +18157,44 @@
             "length": 3
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Burscoughafc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Burscough_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/dd/Burscoughafc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Burscoughafc.png",
+              "fileTitle": "File:Burscoughafc.png",
+              "mimeType": "image/png",
+              "width": 273,
+              "height": 366,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Burscough F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Burscoughafc.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.burscoughfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:25.639Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "burton albion": {
@@ -16178,6 +18450,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Burton_Albion_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Burton_Albion_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/93/Burton_Albion_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Burton_Albion_FC_crest.svg",
+              "fileTitle": "File:Burton Albion FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Burton Albion F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Burton_Albion_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "fr:Fichier:Logo Burton Albion FC 2025.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:26.780Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "burton swifts": {
@@ -16319,6 +18629,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "burton united": {
@@ -16512,6 +18827,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "burton wanderers": {
@@ -16632,6 +18952,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "bury": {
@@ -17149,6 +19474,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bury_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bury_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/65/Bury_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bury_FC_crest.svg",
+              "fileTitle": "File:Bury FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 298,
+              "height": 336,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bury F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bury_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://buryfc.co.uk/home/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:31.071Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "buxton": {
@@ -17301,6 +19664,44 @@
             "length": 25
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Buxton_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Buxton_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b2/Buxton_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Buxton_FC_crest.svg",
+              "fileTitle": "File:Buxton FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Buxton F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Buxton_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/fa-cup/scores-fixtures/2025-11"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:32.225Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "caernarfon town": {
@@ -17398,6 +19799,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Caernarfon_Town_F.C.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Caernarfon_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/4a/Caernarfon_Town_F.C.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Caernarfon_Town_F.C.png",
+              "fileTitle": "File:Caernarfon Town F.C.png",
+              "mimeType": "image/png",
+              "width": 260,
+              "height": 384,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Caernarfon Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Caernarfon_Town_F.C.png",
+                "copyrighted": true,
+                "credit": "https://www.caernarfontownfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:33.352Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "cambridge city": {
@@ -17575,6 +20014,44 @@
             "length": 4
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Cambridgecityfc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Cambridge_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/d1/Cambridgecityfc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Cambridgecityfc.png",
+              "fileTitle": "File:Cambridgecityfc.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Cambridge City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Cambridgecityfc.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.cambridgecityfc.com/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:34.418Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "cambridge united": {
@@ -17833,6 +20310,42 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikipedia-pageimage-free:Cambridge_United_FC_crest.svg",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Cambridge_United_FC_crest.svg",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Cambridge_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/57/Cambridge_United_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Cambridge_United_FC_crest.svg",
+              "fileTitle": "File:Cambridge United FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 310,
+              "height": 322,
+              "license": {
+                "shortName": "PD",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "Transferred from French Wikipedia",
+                "artist": "Cambridge United Football Club"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:53:35.563Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "canterbury city": {
@@ -17949,6 +20462,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Canterbury_City_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Canterbury_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/49/Canterbury_City_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Canterbury_City_F.C._logo.png",
+              "fileTitle": "File:Canterbury City F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 303,
+              "height": 308,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Canterbury City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Canterbury_City_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "Official Twitter account: https://pbs.twimg.com/profile_images/378800000002793958/5b2f06234da5d7d38c6d2a8d50a00aae.png"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:36.693Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "canvey island": {
@@ -18060,6 +20611,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Canvey_Island_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Canvey_Island_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2f/Canvey_Island_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Canvey_Island_FC_crest.svg",
+              "fileTitle": "File:Canvey Island FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 139,
+              "height": 174,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Canvey Island F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Canvey_Island_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/w/index.php?title=Fichier:Canvey_Island_(logo).svg&lang=fr"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:37.809Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "cardiff city": {
@@ -18476,6 +21065,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Cardiff_City_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Cardiff_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/3c/Cardiff_City_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Cardiff_City_crest.svg",
+              "fileTitle": "File:Cardiff City crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 310,
+              "height": 323,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Cardiff City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Cardiff_City_crest.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Cardiff City F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:38.943Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "carlisle united": {
@@ -18874,6 +21501,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Carlisle_United_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Carlisle_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/6c/Carlisle_United_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Carlisle_United_FC_crest.svg",
+              "fileTitle": "File:Carlisle United FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 315,
+              "height": 317,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Carlisle United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Carlisle_United_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/league-one/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:40.023Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "carshalton athletic": {
@@ -19051,6 +21716,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Carshalton_Athletic_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Carshalton_Athletic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/90/Carshalton_Athletic_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Carshalton_Athletic_F.C._logo.png",
+              "fileTitle": "File:Carshalton Athletic F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 334,
+              "height": 298,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Carshalton Athletic F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Carshalton_Athletic_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "http://files.pitchero.com/clubs/32624/boysacademytrial2015_130884.pdf"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:41.135Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "charlton athletic": {
@@ -19456,6 +22159,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Charlton_Athletic_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Charlton_Athletic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/f5/Charlton_Athletic_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Charlton_Athletic_FC_crest.svg",
+              "fileTitle": "File:Charlton Athletic FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Charlton Athletic F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Charlton_Athletic_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/league-one/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:42.242Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "chelmsford city": {
@@ -19692,6 +22433,44 @@
             "length": 4
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Chelmsford_City_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Chelmsford_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/ab/Chelmsford_City_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Chelmsford_City_FC_crest.svg",
+              "fileTitle": "File:Chelmsford City FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Chelmsford City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Chelmsford_City_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://worthingfc.com/results/men/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:43.371Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "chelsea": {
@@ -20149,6 +22928,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Chelsea_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Chelsea_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/cc/Chelsea_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Chelsea_FC.svg",
+              "fileTitle": "File:Chelsea FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 210,
+              "height": 210,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Chelsea F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Chelsea_FC.svg",
+                "copyrighted": true,
+                "credit": "2006/07 Corporate Social Responsibility Report"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:44.417Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "cheltenham town": {
@@ -20397,6 +23214,34 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Cheltenham_Town_F.C._logo.svg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Cheltenham_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c3/Cheltenham_Town_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File%3ACheltenham_Town_F.C._logo.svg",
+              "fileTitle": "File:Cheltenham_Town_F.C._logo.svg",
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "unknown",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-unknown"
+                ],
+                "checkedAt": "2026-06-20T18:53:45.521Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "chertsey town": {
@@ -20485,6 +23330,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "chesham united": {
@@ -20625,6 +23475,44 @@
             "length": 21
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Chesham_United_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Chesham_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/11/Chesham_United_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Chesham_United_FC_crest.svg",
+              "fileTitle": "File:Chesham United FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 272,
+              "height": 368,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Chesham United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Chesham_United_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://worthingfc.com/results/men/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:53:59.504Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "cheshunt": {
@@ -20710,6 +23598,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Cheshunt_FC.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Cheshunt_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/58/Cheshunt_FC.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Cheshunt_FC.png",
+              "fileTitle": "File:Cheshunt FC.png",
+              "mimeType": "image/png",
+              "width": 324,
+              "height": 301,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Cheshunt F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Cheshunt_FC.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: https://cheshuntfc.com/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:01.709Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "chester": {
@@ -20862,6 +23788,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Chester-fc.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Chester_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/cb/Chester-fc.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Chester-fc.svg",
+              "fileTitle": "File:Chester-fc.svg",
+              "mimeType": "image/svg+xml",
+              "width": 317,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Chester F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Chester-fc.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.chesterfc.com"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:02.808Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "chester city": {
@@ -21268,6 +24232,46 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
+              "fileTitle": "File:Ryan Valentine scores.jpg",
+              "mimeType": "image/jpeg",
+              "width": 3456,
+              "height": 2304,
+              "license": {
+                "shortName": "CC BY 2.5",
+                "usageTerms": "Creative Commons Attribution 2.5",
+                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Markbarnes"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:54:03.877Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "chesterfield": {
@@ -21680,6 +24684,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Chesterfield_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Chesterfield_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/94/Chesterfield_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Chesterfield_FC_crest.svg",
+              "fileTitle": "File:Chesterfield FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 290,
+              "height": 344,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Chesterfield F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Chesterfield_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Chesterfield F.C Official Website"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:05.026Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "chesterfield town": {
@@ -21841,6 +24883,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Chesterfield_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Chesterfield_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/94/Chesterfield_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Chesterfield_FC_crest.svg",
+              "fileTitle": "File:Chesterfield FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 290,
+              "height": 344,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Chesterfield F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Chesterfield_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Chesterfield F.C Official Website"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:06.159Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "chippenham town": {
@@ -21960,6 +25040,44 @@
             "length": 13
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Chippenham_Town_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Chippenham_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/85/Chippenham_Town_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Chippenham_Town_F.C._logo.svg",
+              "fileTitle": "File:Chippenham Town F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 290,
+              "height": 345,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Chippenham Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Chippenham_Town_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/chippenham-town/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:07.254Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "chorley": {
@@ -22142,6 +25260,44 @@
             "length": 15
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Chorley_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Chorley_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/72/Chorley_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Chorley_FC_crest.svg",
+              "fileTitle": "File:Chorley FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 267,
+              "height": 375,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Chorley F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Chorley_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/wiki/Fichier:Logo_Chorley_FC.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:08.338Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "clevedon town": {
@@ -22230,6 +25386,76 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Clevedontownafc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Clevedon_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/72/Clevedontownafc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Clevedontownafc.png",
+              "fileTitle": "File:Clevedontownafc.png",
+              "mimeType": "image/png",
+              "width": 256,
+              "height": 256,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Clevedon Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Clevedontownafc.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: https://www.clevedontownfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:09.451Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Clevedon_Town_2007.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Clevedon_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/1/15/Clevedon_Town_2007.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Clevedon_Town_2007.jpg",
+              "fileTitle": "File:Clevedon Town 2007.jpg",
+              "mimeType": "image/jpeg",
+              "width": 1019,
+              "height": 681,
+              "license": {
+                "shortName": "CC BY-SA 3.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "NotFromUtrecht"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:54:09.451Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "colchester united": {
@@ -22548,6 +25774,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Colchester_United_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Colchester_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9c/Colchester_United_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Colchester_United_FC_crest.svg",
+              "fileTitle": "File:Colchester United FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 281,
+              "height": 356,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Colchester United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Colchester_United_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "fr:Fichier:Colchester United FC logo.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:10.604Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "colne dynamoes": {
@@ -22661,6 +25925,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Colne_FC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Colne_Dynamoes_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/85/Colne_FC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Colne_FC_logo.png",
+              "fileTitle": "File:Colne FC logo.png",
+              "mimeType": "image/png",
+              "width": 266,
+              "height": 343,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Colne F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Colne_FC_logo.png",
+                "copyrighted": true,
+                "credit": "http://t2.gstatic.com/images?q=tbn:ANd9GcSHhS1MMJRuJy37RxpbFuwJiMTbW1J--XM4Kbe1cgS66pRXKbiJ"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:11.732Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "colwyn bay": {
@@ -22808,6 +26110,44 @@
             "length": 8
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Colwyn_Bay_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Colwyn_Bay_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e7/Colwyn_Bay_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Colwyn_Bay_F.C._logo.svg",
+              "fileTitle": "File:Colwyn Bay F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 246,
+              "height": 407,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Colwyn Bay F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Colwyn_Bay_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/wales/colwyn-bay/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:13.039Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "concord rangers": {
@@ -22920,6 +26260,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Concord_Rangers_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Concord_Rangers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/96/Concord_Rangers_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Concord_Rangers_FC_crest.svg",
+              "fileTitle": "File:Concord Rangers FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 268,
+              "height": 373,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Concord Rangers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Concord_Rangers_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/w/index.php?title=Fichier:Concord_Rangers_FC_(logo).svg&lang=fr"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:14.234Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "corby town": {
@@ -23147,6 +26525,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:CorbyTownFC.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Corby_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/93/CorbyTownFC.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:CorbyTownFC.png",
+              "fileTitle": "File:CorbyTownFC.png",
+              "mimeType": "image/png",
+              "width": 256,
+              "height": 256,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Corby Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:CorbyTownFC.png",
+                "copyrighted": true,
+                "credit": "http://www.corbytown.net/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:15.356Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "coventry city": {
@@ -23565,6 +26981,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Coventry_City_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Coventry_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/7b/Coventry_City_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Coventry_City_FC_crest.svg",
+              "fileTitle": "File:Coventry City FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 278,
+              "height": 360,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Coventry City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Coventry_City_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/live/c04rz215zept"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:16.522Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "crawley town": {
@@ -23810,6 +27264,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Crawley_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Crawley_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/11/Crawley_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Crawley_Town_FC_crest.svg",
+              "fileTitle": "File:Crawley Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Crawley Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Crawley_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/wiki/Fichier:Logo_Crawley_Town_FC_2011.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:17.746Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "crewe alexandra": {
@@ -24277,6 +27769,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Crewe_Alexandra.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Crewe_Alexandra_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9d/Crewe_Alexandra.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Crewe_Alexandra.svg",
+              "fileTitle": "File:Crewe Alexandra.svg",
+              "mimeType": "image/svg+xml",
+              "width": 280,
+              "height": 357,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Crewe Alexandra F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Crewe_Alexandra.svg",
+                "copyrighted": true,
+                "credit": "Crewe Alexandra Official Website"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:18.851Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "croydon": {
@@ -24415,6 +27945,44 @@
             "length": 11
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Croydon_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Croydon_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/6f/Croydon_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Croydon_F.C._logo.png",
+              "fileTitle": "File:Croydon F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Croydon F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Croydon_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "From official website: https://croydonfc.com/wp-content/uploads/2024/07/Croydon-New-Logo-2.png"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:19.964Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "crystal palace": {
@@ -24830,6 +28398,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Crystal_Palace_FC_logo_(2022).svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Crystal_Palace_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a2/Crystal_Palace_FC_logo_%282022%29.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Crystal_Palace_FC_logo_(2022).svg",
+              "fileTitle": "File:Crystal Palace FC logo (2022).svg",
+              "mimeType": "image/svg+xml",
+              "width": 283,
+              "height": 353,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Crystal Palace F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Crystal_Palace_FC_logo_(2022).svg",
+                "copyrighted": true,
+                "credit": "https://www.cpfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:21.076Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "curzon ashton": {
@@ -24929,6 +28535,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Curzon_Ashton_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Curzon_Ashton_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/83/Curzon_Ashton_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Curzon_Ashton_F.C._logo.svg",
+              "fileTitle": "File:Curzon Ashton F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Curzon Ashton F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Curzon_Ashton_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/curzon-ashton/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:22.209Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "dagenham": {
@@ -25092,6 +28736,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "dagenham and redbridge": {
@@ -25324,6 +28973,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Dagenham_and_Redbridge_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dagenham_%26_Redbridge_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e0/Dagenham_and_Redbridge_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Dagenham_and_Redbridge_FC_crest.svg",
+              "fileTitle": "File:Dagenham and Redbridge FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 290,
+              "height": 344,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Dagenham & Redbridge F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Dagenham_and_Redbridge_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/national-league/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:24.372Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "darlington": {
@@ -25492,6 +29179,44 @@
             "length": 4
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Darlington_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Darlington_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/ad/Darlington_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Darlington_FC_crest.svg",
+              "fileTitle": "File:Darlington FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 277,
+              "height": 361,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Darlington F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Darlington_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/wiki/Fichier:Logo_Darlington_FC_1883.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:25.522Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "darlington 1883": {
@@ -25891,6 +29616,46 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
+              "fileTitle": "File:Ryan Valentine scores.jpg",
+              "mimeType": "image/jpeg",
+              "width": 3456,
+              "height": 2304,
+              "license": {
+                "shortName": "CC BY 2.5",
+                "usageTerms": "Creative Commons Attribution 2.5",
+                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Markbarnes"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:54:26.648Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "dartford": {
@@ -26086,6 +29851,44 @@
             "length": 17
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Dartford_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dartford_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9e/Dartford_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Dartford_FC.svg",
+              "fileTitle": "File:Dartford FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 184,
+              "height": 201,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Dartford F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Dartford_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.dartfordfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:27.772Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "darwen": {
@@ -26229,6 +30032,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Darwen_FC_crest.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Darwen_F.C._(1870)",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/fe/Darwen_FC_crest.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Darwen_FC_crest.png",
+              "fileTitle": "File:Darwen FC crest.png",
+              "mimeType": "image/png",
+              "width": 160,
+              "height": 226,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Darwen F.C. (1870)",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Darwen_FC_crest.png",
+                "copyrighted": true,
+                "credit": "https://web.archive.org/web/20070930021248/http://darwenfc.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:28.904Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "derby county": {
@@ -26745,6 +30586,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Derby_County_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Derby_County_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/4a/Derby_County_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Derby_County_crest.svg",
+              "fileTitle": "File:Derby County crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 386,
+              "height": 259,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Derby County F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Derby_County_crest.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Derby County F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:30.047Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "doncaster rovers": {
@@ -27251,6 +31130,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Doncaster_Rovers_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Doncaster_Rovers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c5/Doncaster_Rovers_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Doncaster_Rovers_F.C._logo.svg",
+              "fileTitle": "File:Doncaster Rovers F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 200,
+              "height": 144,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Doncaster Rovers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Doncaster_Rovers_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Doncaster Rovers F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:31.196Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "dorchester town": {
@@ -27461,6 +31378,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Dorchester_Town.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dorchester_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/0c/Dorchester_Town.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Dorchester_Town.png",
+              "fileTitle": "File:Dorchester Town.png",
+              "mimeType": "image/png",
+              "width": 240,
+              "height": 240,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Dorchester Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Dorchester_Town.png",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Dorchester Town F.C.."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:32.340Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "dorking": {
@@ -27559,6 +31514,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Dorkingfc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dorking_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5a/Dorkingfc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Dorkingfc.png",
+              "fileTitle": "File:Dorkingfc.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Dorking F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Dorkingfc.png",
+                "copyrighted": true,
+                "credit": "Williswappen Division Eight 1 webpage"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:33.450Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "dorking wanderers": {
@@ -27654,6 +31647,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Dorking_Wanderers_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dorking_Wanderers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2d/Dorking_Wanderers_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Dorking_Wanderers_FC_crest.svg",
+              "fileTitle": "File:Dorking Wanderers FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Dorking Wanderers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Dorking_Wanderers_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/national-league/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:34.689Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "dover": {
@@ -27790,6 +31821,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Dover_Athletic_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dover_Athletic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c8/Dover_Athletic_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Dover_Athletic_FC_crest.svg",
+              "fileTitle": "File:Dover Athletic FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 301,
+              "height": 332,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Dover Athletic F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Dover_Athletic_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "fr:Fichier:Logo Dover Athletic FC.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:35.890Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "dover athletic": {
@@ -28028,6 +32097,44 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Dover_Athletic_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dover_Athletic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c8/Dover_Athletic_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Dover_Athletic_FC_crest.svg",
+              "fileTitle": "File:Dover Athletic FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 301,
+              "height": 332,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Dover Athletic F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Dover_Athletic_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "fr:Fichier:Logo Dover Athletic FC.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:36.986Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "droylsden": {
@@ -28237,6 +32344,44 @@
             "length": 3
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Droylsden.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Droylsden_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/3d/Droylsden.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Droylsden.png",
+              "fileTitle": "File:Droylsden.png",
+              "mimeType": "image/png",
+              "width": 256,
+              "height": 256,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Droylsden F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Droylsden.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.droylsdenfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:38.075Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "dudley town": {
@@ -28350,6 +32495,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Dudley_Town_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dudley_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/46/Dudley_Town_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Dudley_Town_F.C._logo.png",
+              "fileTitle": "File:Dudley Town F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Dudley Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Dudley_Town_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "https://www.dudleytownfootballclub.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:39.179Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "dulwich hamlet": {
@@ -28545,6 +32728,42 @@
             "length": 17
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikipedia-pageimage-free:Dulwich_Hamlet_F.C._logo.png",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Dulwich_Hamlet_F.C._logo.png",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dulwich_Hamlet_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/07/Dulwich_Hamlet_F.C._logo.png",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Dulwich_Hamlet_F.C._logo.png",
+              "fileTitle": "File:Dulwich Hamlet F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 8000,
+              "height": 8000,
+              "license": {
+                "shortName": "Public domain",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "https://dulwichhamletfc.co.uk",
+                "artist": "Dulwich Hamlet F.C."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:54:40.377Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "dunstable town": {
@@ -28697,6 +32916,45 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Dtfc-badge.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dunstable_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/61/Dtfc-badge.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Dtfc-badge.png",
+              "fileTitle": "File:Dtfc-badge.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Dtfc-badge.png",
+                "copyrighted": true,
+                "credit": "official club website"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted",
+                  "identity-uncertain"
+                ],
+                "checkedAt": "2026-06-20T18:54:41.545Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "durham city": {
@@ -28800,6 +33058,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:DurhamCityBadge.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Durham_City_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/14/DurhamCityBadge.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:DurhamCityBadge.png",
+              "fileTitle": "File:DurhamCityBadge.png",
+              "mimeType": "image/png",
+              "width": 284,
+              "height": 340,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Durham City A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:DurhamCityBadge.png",
+                "copyrighted": true,
+                "credit": "http://www.durhamcityafc.com/images/Rebuild/Header_Image.png"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:42.703Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "east thurrock united": {
@@ -28933,6 +33229,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:East_Thurrock_United_Logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/East_Thurrock_Community_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b0/East_Thurrock_United_Logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:East_Thurrock_United_Logo.png",
+              "fileTitle": "File:East Thurrock United Logo.png",
+              "mimeType": "image/png",
+              "width": 224,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of East Thurrock United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:East_Thurrock_United_Logo.png",
+                "copyrighted": true,
+                "credit": "https://pbs.twimg.com/profile_images/1024658426117402624/dRMA_E-r.jpg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:43.830Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "eastbourne borough": {
@@ -29076,6 +33410,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Eastbourne_Borough_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Eastbourne_Borough_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/bd/Eastbourne_Borough_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Eastbourne_Borough_FC_crest.svg",
+              "fileTitle": "File:Eastbourne Borough FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Eastbourne Borough F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Eastbourne_Borough_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://ebfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:54:44.926Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "eastleigh": {
@@ -29213,6 +33585,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "eastwood town": {
@@ -29363,6 +33740,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "ebbsfleet united": {
@@ -29640,6 +34022,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Ebbsfleet_United_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Ebbsfleet_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/92/Ebbsfleet_United_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Ebbsfleet_United_F.C._logo.svg",
+              "fileTitle": "File:Ebbsfleet United F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Ebbsfleet_United_F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Ebbsfleet_United_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: https://ebbsfleetunited.co.uk Ebbsfleet United FDC"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:01.008Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "emley": {
@@ -29839,6 +34259,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Emley_AFC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Emley_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5e/Emley_AFC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Emley_AFC_crest.svg",
+              "fileTitle": "File:Emley AFC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 289,
+              "height": 346,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Emley A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Emley_AFC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/536000/emley-afc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:02.249Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "enfield": {
@@ -30071,6 +34529,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Enfield_1893_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Enfield_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a1/Enfield_1893_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Enfield_1893_logo.png",
+              "fileTitle": "File:Enfield 1893 logo.png",
+              "mimeType": "image/png",
+              "width": 299,
+              "height": 334,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Enfield F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Enfield_1893_logo.png",
+                "copyrighted": true,
+                "credit": "official website http://images2.pitchero.com/club_logos/17927/1338537165.jpg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:03.390Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "enfield town": {
@@ -30159,6 +34655,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Enfield_Town_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Enfield_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/d1/Enfield_Town_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Enfield_Town_F.C._logo.svg",
+              "fileTitle": "File:Enfield Town F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 292,
+              "height": 342,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Enfield Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Enfield_Town_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/enfield-town/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:04.526Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "epsom and ewell": {
@@ -30247,6 +34781,45 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:EpsomEwellBadge.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Epsom_%26_Ewell_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/09/EpsomEwellBadge.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:EpsomEwellBadge.png",
+              "fileTitle": "File:EpsomEwellBadge.png",
+              "mimeType": "image/png",
+              "width": 311,
+              "height": 311,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Epsom & Ewell F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:EpsomEwellBadge.png",
+                "copyrighted": true,
+                "credit": "https://www.epsomandewellfc.biz"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted",
+                  "identity-uncertain"
+                ],
+                "checkedAt": "2026-06-20T18:55:05.651Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "everton": {
@@ -30754,6 +35327,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Everton_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Everton_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/7c/Everton_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Everton_FC_logo.svg",
+              "fileTitle": "File:Everton FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 313,
+              "height": 320,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Everton F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Everton_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "Extracted from .mw-parser-output cite.citation{font-style:inherit;word-wrap:break-word}.mw-parser-output .citation q{quotes:\"\\\"\"\"\\\"\"\"'\"\"'\"}.mw-parser-output .citation:target{background-color:rgba(0,127,255,0.133)}.mw-parser-output .id-lock-free.id-lock-free a{background:url(\"//upload.wikimedia.org/wikipedia/commons/6/65/Lock-green.svg\")right 0.1em center/9px no-repeat}.mw-parser-output .id-lock-limited.id-lock-limited a,.mw-parser-output .id-lock-registration.id-lock-registration a{background:url(\"//upload.wikimedia.org/wikipedia/commons/d/d6/Lock-gray-alt-2.svg\")right 0.1em center/9px no-repeat}.mw-parser-output .id-lock-subscription.id-lock-subscription a{background:url(\"//upload.wikimedia.org/wikipedia/commons/a/aa/Lock-red-alt-2.svg\")right 0.1em center/9px no-repeat}.mw-parser-output .cs1-ws-icon a{background:url(\"//upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\")right 0.1em center/12px no-repeat}body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-free a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-limited a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-registration a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-subscription a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .cs1-ws-icon a{background-size:contain;padding:0 1em 0 0}.mw-parser-output .cs1-code{color:inherit;background:inherit;border:none;padding:inherit}.mw-parser-output .cs1-hidden-error{display:none;color:var(--color-error,#bf3c2c)}.mw-parser-output .cs1-visible-error{color:var(--color-error,#bf3c2c)}.mw-parser-output .cs1-maint{display:none;color:#085;margin-left:0.3em}.mw-parser-output .cs1-kern-left{padding-left:0.2em}.mw-parser-output .cs1-kern-right{padding-right:0.2em}.mw-parser-output .citation .mw-selflink{font-weight:inherit}@media screen{.mw-parser-output .cs1-format{font-size:95%}html.skin-theme-clientpref-night .mw-parser-output .cs1-maint{color:#18911f}}@media screen and (prefers-color-scheme:dark){html.skin-theme-clientpref-os .mw-parser-output .cs1-maint{color:#18911f}} \"PREMIER LEAGUE HANDBOOK Season 2014/15\" (PDF) . Premier League. p. 13. Archived (PDF) from the original on 20 August 2014 . Retrieved 24 August 2014 ."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:06.783Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "exeter city": {
@@ -31160,6 +35771,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Exeter_City_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Exeter_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/71/Exeter_City_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Exeter_City_FC.svg",
+              "fileTitle": "File:Exeter City FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 200,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Exeter City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Exeter_City_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Exeter City FC - Corporate Brochure 2018–19"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:07.996Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "fareham town": {
@@ -31272,6 +35921,43 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Farehamtownfc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Fareham_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5b/Farehamtownfc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Farehamtownfc.png",
+              "fileTitle": "File:Farehamtownfc.png",
+              "mimeType": "image/png",
+              "width": 284,
+              "height": 349,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Farehamtownfc.png",
+                "copyrighted": true
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:09.138Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "farnborough": {
@@ -31430,6 +36116,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Farnborough_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Farnborough_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/3a/Farnborough_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Farnborough_F.C._logo.svg",
+              "fileTitle": "File:Farnborough F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Farnborough F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Farnborough_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/farnborough/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:10.277Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "farnborough town": {
@@ -31639,6 +36363,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Farnborough_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Farnborough_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/3a/Farnborough_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Farnborough_F.C._logo.svg",
+              "fileTitle": "File:Farnborough F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Farnborough F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Farnborough_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/farnborough/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:11.390Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "farsley celtic": {
@@ -31841,6 +36603,77 @@
             "length": 9
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Farsley_AFC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Farsley_Celtic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/d7/Farsley_AFC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Farsley_AFC_logo.png",
+              "fileTitle": "File:Farsley AFC logo.png",
+              "mimeType": "image/png",
+              "width": 299,
+              "height": 326,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Farsley A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Farsley_AFC_logo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Club website"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:12.454Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Citadel-1.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Farsley_Celtic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/c2/Citadel-1.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Citadel-1.jpg",
+              "fileTitle": "File:Citadel-1.jpg",
+              "mimeType": "image/jpeg",
+              "width": 2048,
+              "height": 1536,
+              "license": {
+                "shortName": "CC BY-SA 4.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Farsleycelticmedia"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:55:12.454Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "fc halifax town": {
@@ -31975,6 +36808,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "fc united of manchester": {
@@ -32069,6 +36907,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:FC_United_of_Manchester_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/F.C._United_of_Manchester",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/4d/FC_United_of_Manchester_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:FC_United_of_Manchester_crest.svg",
+              "fileTitle": "File:FC United of Manchester crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 200,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of F.C. United of Manchester",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:FC_United_of_Manchester_crest.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from F.C. United of Manchester."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:14.546Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "fisher athletic": {
@@ -32284,6 +37160,44 @@
             "length": 5
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Fisherathleticfc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Fisher_Athletic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/f5/Fisherathleticfc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Fisherathleticfc.png",
+              "fileTitle": "File:Fisherathleticfc.png",
+              "mimeType": "image/png",
+              "width": 133,
+              "height": 138,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Fisher Athletic F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Fisherathleticfc.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.fisherathletic.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:15.675Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "fleetwood town": {
@@ -32560,6 +37474,44 @@
             "length": 14
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Fleetwood_Town_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Fleetwood_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/ed/Fleetwood_Town_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Fleetwood_Town_F.C._logo.svg",
+              "fileTitle": "File:Fleetwood Town F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 119,
+              "height": 119,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Fleetwood Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Fleetwood_Town_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://www.fleetwoodtownfc.com/siteassets/news/pdfs/commercial-brochure-17-18.pdf"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:16.719Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "folkestone": {
@@ -32759,6 +37711,11 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "folkestone invicta": {
@@ -32850,6 +37807,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Folkestone_Invicta_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Folkestone_Invicta_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2a/Folkestone_Invicta_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Folkestone_Invicta_FC_crest.svg",
+              "fileTitle": "File:Folkestone Invicta FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Folkestone Invicta F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Folkestone_Invicta_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://folkestoneinvictafc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:18.834Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "forest green rovers": {
@@ -33027,6 +38022,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Forest_Green_Rovers_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Forest_Green_Rovers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/85/Forest_Green_Rovers_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Forest_Green_Rovers_crest.svg",
+              "fileTitle": "File:Forest Green Rovers crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 136,
+              "height": 136,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Forest Green Rovers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Forest_Green_Rovers_crest.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Forest Green Rovers F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:19.936Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "frickley athletic": {
@@ -33192,6 +38225,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Frickley_Athletic_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Frickley_Athletic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/d5/Frickley_Athletic_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Frickley_Athletic_F.C._logo.svg",
+              "fileTitle": "File:Frickley Athletic F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 303,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Frickley Athletic F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Frickley_Athletic_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "http://www.brandsoftheworld.com/logo/frickley-afc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:21.043Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "fulham": {
@@ -33658,6 +38729,42 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikipedia-pageimage-any:Fulham_FC_(shield).svg",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Fulham_FC_(shield).svg",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Fulham_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/eb/Fulham_FC_%28shield%29.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Fulham_FC_(shield).svg",
+              "fileTitle": "File:Fulham FC (shield).svg",
+              "mimeType": "image/svg+xml",
+              "width": 274,
+              "height": 365,
+              "license": {
+                "shortName": "PD",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "Fulham F.C. Official Website",
+                "artist": "Fulham F.C."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:55:22.154Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "gainsborough trinity": {
@@ -33961,6 +39068,76 @@
             "length": 67
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Gainsborough_Trinity_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Gainsborough_Trinity_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/f4/Gainsborough_Trinity_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Gainsborough_Trinity_FC_crest.svg",
+              "fileTitle": "File:Gainsborough Trinity FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 301,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Gainsborough Trinity F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Gainsborough_Trinity_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.gainsboroughtrinity.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:23.235Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Gainsborough_Trinity_1966–67.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Gainsborough_Trinity_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/27/Gainsborough_Trinity_1966%E2%80%9367.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Gainsborough_Trinity_1966%E2%80%9367.jpg",
+              "fileTitle": "File:Gainsborough Trinity 1966–67.jpg",
+              "mimeType": "image/jpeg",
+              "width": 2595,
+              "height": 2099,
+              "license": {
+                "shortName": "CC BY 2.0",
+                "usageTerms": "Creative Commons Attribution 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by/2.0",
+                "copyrighted": true,
+                "credit": "Gainsborough Trinity 1966-67",
+                "artist": "John Spooner"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:55:23.235Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "gateshead": {
@@ -34197,6 +39374,44 @@
             "length": 5
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Gateshead_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Gateshead_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b3/Gateshead_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Gateshead_FC.svg",
+              "fileTitle": "File:Gateshead FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Gateshead F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Gateshead_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Gateshead F.C. Official Website Converted to AI format by Johnny Beaufays (johnny.beaufays@vflnet.com) and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped the SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:24.353Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "gateshead 1899": {
@@ -34466,6 +39681,46 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
+              "fileTitle": "File:Ryan Valentine scores.jpg",
+              "mimeType": "image/jpeg",
+              "width": 3456,
+              "height": 2304,
+              "license": {
+                "shortName": "CC BY 2.5",
+                "usageTerms": "Creative Commons Attribution 2.5",
+                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Markbarnes"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:55:25.483Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "gillingham": {
@@ -34879,6 +40134,44 @@
             "length": 12
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:FC_Gillingham_Logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Gillingham_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5e/FC_Gillingham_Logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:FC_Gillingham_Logo.svg",
+              "fileTitle": "File:FC Gillingham Logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 277,
+              "height": 360,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Gillingham F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:FC_Gillingham_Logo.svg",
+                "copyrighted": true,
+                "credit": "http://www.gillinghamfootballclub.com/page/Home"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:26.638Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "glossop": {
@@ -35051,6 +40344,46 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
+              "fileTitle": "File:Ryan Valentine scores.jpg",
+              "mimeType": "image/jpeg",
+              "width": 3456,
+              "height": 2304,
+              "license": {
+                "shortName": "CC BY 2.5",
+                "usageTerms": "Creative Commons Attribution 2.5",
+                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Markbarnes"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:55:27.756Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "gloucester city": {
@@ -35267,6 +40600,43 @@
             "length": 9
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikipedia-pageimage-free:Gloucester_City_badge.jpg",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Gloucester_City_badge.jpg",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Gloucester_City_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8b/Gloucester_City_badge.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Gloucester_City_badge.jpg",
+              "fileTitle": "File:Gloucester City badge.jpg",
+              "mimeType": "image/jpeg",
+              "width": 2048,
+              "height": 2048,
+              "license": {
+                "shortName": "CC BY-SA 4.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Pablo29"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:55:28.955Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "goole town": {
@@ -35421,6 +40791,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Goole_A.F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Goole_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a6/Goole_A.F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Goole_A.F.C._logo.png",
+              "fileTitle": "File:Goole A.F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Goole A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Goole_A.F.C._logo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.pitchero.com/clubs/gooleafc/ http://www.pitchero.com/clubs/gooleafc/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:30.134Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "gosport borough": {
@@ -35583,6 +40991,44 @@
             "length": 23
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Gosport_Borough_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Gosport_Borough_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2c/Gosport_Borough_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Gosport_Borough_FC_crest.svg",
+              "fileTitle": "File:Gosport Borough FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Gosport Borough F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Gosport_Borough_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://waltonhershamfc.com/fixtures/first-team/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:31.278Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "grantham town": {
@@ -35786,6 +41232,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Grantham_Town_F.C.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Grantham_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2f/Grantham_Town_F.C.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Grantham_Town_F.C.png",
+              "fileTitle": "File:Grantham Town F.C.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Grantham Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Grantham_Town_F.C.png",
+                "copyrighted": true,
+                "credit": "http://www.granthamtownfc.com/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:32.412Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "grays athletic": {
@@ -35953,6 +41437,44 @@
             "length": 3
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Grays_Athletic_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Grays_Athletic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/05/Grays_Athletic_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Grays_Athletic_F.C._logo.png",
+              "fileTitle": "File:Grays Athletic F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 334,
+              "height": 298,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Grays Athletic F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Grays_Athletic_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "From official Twitter account: https://pbs.twimg.com/profile_images/752609699082674176/7C1ZnMlI.jpg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:33.527Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "gresley rovers": {
@@ -36090,6 +41612,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Gresley_Rovers_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Gresley_Rovers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2f/Gresley_Rovers_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Gresley_Rovers_logo.png",
+              "fileTitle": "File:Gresley Rovers logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Gresley Rovers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Gresley_Rovers_logo.png",
+                "copyrighted": true,
+                "credit": "https://www.gresleyrovers.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:34.593Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "grimsby town": {
@@ -36660,6 +42220,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Grimsby_Town_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Grimsby_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/db/Grimsby_Town_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Grimsby_Town_F.C._logo.svg",
+              "fileTitle": "File:Grimsby Town F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 292,
+              "height": 343,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Grimsby Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Grimsby_Town_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: gtfc .co .uk"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:35.640Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "guiseley": {
@@ -36824,6 +42422,44 @@
             "length": 10
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Guiseley_AFC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Guiseley_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/31/Guiseley_AFC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Guiseley_AFC_logo.png",
+              "fileTitle": "File:Guiseley AFC logo.png",
+              "mimeType": "image/png",
+              "width": 296,
+              "height": 336,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Guiseley A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Guiseley_AFC_logo.png",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Guiseley A.F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:36.736Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "halesowen town": {
@@ -36962,6 +42598,44 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Halesowen_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Halesowen_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/13/Halesowen_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Halesowen_Town_FC_crest.svg",
+              "fileTitle": "File:Halesowen Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Halesowen Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Halesowen_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/halesowen-town-fc-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:37.851Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "halifax town": {
@@ -37342,6 +43016,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:HalifaxTownAFC.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Halifax_Town_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/da/HalifaxTownAFC.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:HalifaxTownAFC.png",
+              "fileTitle": "File:HalifaxTownAFC.png",
+              "mimeType": "image/png",
+              "width": 170,
+              "height": 217,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of F.C. Halifax Town",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:HalifaxTownAFC.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.halifaxafc.premiumtv.co.uk/page/Welcome"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:38.969Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hampton and richmond borough": {
@@ -37592,6 +43304,44 @@
             "length": 4
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hampton_&_Richmond_Borough_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hampton_%26_Richmond_Borough_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/df/Hampton_%26_Richmond_Borough_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hampton_%26_Richmond_Borough_F.C._logo.svg",
+              "fileTitle": "File:Hampton & Richmond Borough F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 265,
+              "height": 377,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hampton & Richmond Borough F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hampton_%26_Richmond_Borough_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/hampton-and-richmond/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:40.146Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "harlow town": {
@@ -37709,6 +43459,44 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Harlow_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Harlow_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/fc/Harlow_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Harlow_Town_FC_crest.svg",
+              "fileTitle": "File:Harlow Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Harlow Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Harlow_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/391087/harlow-town-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:41.226Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "harrogate town": {
@@ -37863,6 +43651,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Harrogate_Town_AFC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Harrogate_Town_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/40/Harrogate_Town_AFC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Harrogate_Town_AFC.svg",
+              "fileTitle": "File:Harrogate Town AFC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Harrogate Town A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Harrogate_Town_AFC.svg",
+                "copyrighted": true,
+                "credit": "Direct image source"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:42.287Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "harrow borough": {
@@ -38020,6 +43846,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Harrowborough.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Harrow_Borough_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/56/Harrowborough.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Harrowborough.png",
+              "fileTitle": "File:Harrowborough.png",
+              "mimeType": "image/png",
+              "width": 317,
+              "height": 314,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Harrow Borough F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Harrowborough.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.harrowboro.com/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:43.438Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hartlepool united": {
@@ -38475,6 +44339,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hartlepool_United_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hartlepool_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/42/Hartlepool_United_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hartlepool_United_FC_crest.svg",
+              "fileTitle": "File:Hartlepool United FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hartlepool United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hartlepool_United_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/national-league/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:55:44.604Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hastings united": {
@@ -38638,6 +44540,11 @@
             "length": 3
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "hastings united 1948": {
@@ -38751,6 +44658,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "havant and waterlooville": {
@@ -38983,6 +44895,44 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Havant_&_Waterlooville_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Havant_%26_Waterlooville_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/4e/Havant_%26_Waterlooville_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Havant_%26_Waterlooville_FC_crest.svg",
+              "fileTitle": "File:Havant & Waterlooville FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Havant & Waterlooville F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Havant_%26_Waterlooville_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://havantandwaterloovillefc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:02.734Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hayes": {
@@ -39187,6 +45137,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hayes_&_Yeading_United_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hayes_%26_Yeading_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/36/Hayes_%26_Yeading_United_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hayes_%26_Yeading_United_FC.svg",
+              "fileTitle": "File:Hayes & Yeading United FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 305,
+              "height": 328,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hayes & Yeading United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hayes_%26_Yeading_United_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Hayes & Yeading United F.C. Official Website Converted to AI format by Johnny Beaufays (johnny.beaufays@vflnet.com) and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped to SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:03.937Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hayes and yeading united": {
@@ -39334,6 +45322,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hayes_&_Yeading_United_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hayes_%26_Yeading_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/36/Hayes_%26_Yeading_United_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hayes_%26_Yeading_United_FC.svg",
+              "fileTitle": "File:Hayes & Yeading United FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 305,
+              "height": 328,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hayes & Yeading United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hayes_%26_Yeading_United_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Hayes & Yeading United F.C. Official Website Converted to AI format by Johnny Beaufays (johnny.beaufays@vflnet.com) and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped to SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:05.021Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hednesford town": {
@@ -39539,6 +45565,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hednesford_Town_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hednesford_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a9/Hednesford_Town_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hednesford_Town_F.C._logo.svg",
+              "fileTitle": "File:Hednesford Town F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 317,
+              "height": 315,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hednesford Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hednesford_Town_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/hednesford-town/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:06.151Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hemel hempstead town": {
@@ -39641,6 +45705,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hemel_Hempstead_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hemel_Hempstead_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/60/Hemel_Hempstead_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hemel_Hempstead_Town_FC_crest.svg",
+              "fileTitle": "File:Hemel Hempstead Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hemel Hempstead Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hemel_Hempstead_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/fa-cup/scores-fixtures/2025-11"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:07.260Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hendon": {
@@ -39798,6 +45900,75 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:HendonFcCrest.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hendon_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/4b/HendonFcCrest.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:HendonFcCrest.png",
+              "fileTitle": "File:HendonFcCrest.png",
+              "mimeType": "image/png",
+              "width": 281,
+              "height": 355,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:HendonFcCrest.png",
+                "copyrighted": true
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:08.401Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:HampsteadTownFC1919.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hendon_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/fd/HampsteadTownFC1919.jpg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:HampsteadTownFC1919.jpg",
+              "fileTitle": "File:HampsteadTownFC1919.jpg",
+              "mimeType": "image/jpeg",
+              "width": 500,
+              "height": 357,
+              "license": {
+                "shortName": "Public domain",
+                "usageTerms": "Public domain in the United States",
+                "copyrighted": true,
+                "credit": "[1]",
+                "artist": "Unknown"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:56:08.401Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "hereford": {
@@ -39925,6 +46096,77 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hereford_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hereford_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/64/Hereford_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hereford_FC_crest.svg",
+              "fileTitle": "File:Hereford FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 286,
+              "height": 349,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hereford F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hereford_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/515960/hereford-football-club"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:09.571Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikidata-logo:Forever United, Edgar Street, Hereford - geograph.org.uk - 5596516.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikidata-logo",
+              "sourceUrl": "https://www.wikidata.org/wiki/Q18711379",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Forever_United,_Edgar_Street,_Hereford_-_geograph.org.uk_-_5596516.jpg",
+              "fileTitle": "File:Forever United, Edgar Street, Hereford - geograph.org.uk - 5596516.jpg",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/a/a5/Forever_United%2C_Edgar_Street%2C_Hereford_-_geograph.org.uk_-_5596516.jpg",
+              "mimeType": "image/jpeg",
+              "width": 779,
+              "height": 735,
+              "license": {
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
+                "copyrighted": true,
+                "attribution": "Forever United, Edgar Street, Hereford by Jaggery",
+                "credit": "Geograph Britain and Ireland",
+                "artist": "Jaggery"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:56:09.571Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "hereford united": {
@@ -40187,6 +46429,76 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hereford_United_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hereford_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/75/Hereford_United_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hereford_United_FC.svg",
+              "fileTitle": "File:Hereford United FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 322,
+              "height": 311,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hereford United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hereford_United_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Hereford United F.C. Official Website Converted to AI format by Vflnet.com and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped the SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:11.029Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Hereford_United_League_Performance.svg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hereford_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0e/Hereford_United_League_Performance.svg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Hereford_United_League_Performance.svg",
+              "fileTitle": "File:Hereford United League Performance.svg",
+              "mimeType": "image/svg+xml",
+              "width": 1105,
+              "height": 575,
+              "license": {
+                "shortName": "CC BY-SA 4.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "EclecticArkie"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:56:11.029Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "heybridge swifts": {
@@ -40293,6 +46605,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Heybridge_Swifts_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Heybridge_Swifts_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/7c/Heybridge_Swifts_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Heybridge_Swifts_FC_crest.svg",
+              "fileTitle": "File:Heybridge Swifts FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Heybridge Swifts F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Heybridge_Swifts_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/heybridge-swifts-fc-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:12.152Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hillingdon borough": {
@@ -40445,6 +46795,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hillingdon_Borough_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hillingdon_Borough_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/0d/Hillingdon_Borough_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hillingdon_Borough_F.C._logo.png",
+              "fileTitle": "File:Hillingdon Borough F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hillingdon Borough F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hillingdon_Borough_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.clubwebsite.co.uk/hillingdonboroughfc/ http://www.clubwebsite.co.uk/hillingdonboroughfc/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:13.309Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hinckley united": {
@@ -40610,6 +46998,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hinckley_A.F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hinckley_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/25/Hinckley_A.F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hinckley_A.F.C._logo.svg",
+              "fileTitle": "File:Hinckley A.F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 257,
+              "height": 303,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hinckley A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hinckley_A.F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "http://www.brandsoftheworld.com/logo/hinckley-afc"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:14.402Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "histon": {
@@ -40727,6 +47153,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:HistonFClogo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Histon_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/79/HistonFClogo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:HistonFClogo.png",
+              "fileTitle": "File:HistonFClogo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Histon F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:HistonFClogo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: www.histonfc.co.uk www.histonfc.co.uk"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:15.580Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hitchin town": {
@@ -40904,6 +47368,44 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:HitchinTownFC.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hitchin_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c3/HitchinTownFC.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:HitchinTownFC.png",
+              "fileTitle": "File:HitchinTownFC.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hitchin Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:HitchinTownFC.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Hitchin Town F.C. Official Website"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:16.717Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hornchurch": {
@@ -41116,6 +47618,44 @@
             "length": 11
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hornchurch_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hornchurch_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/78/Hornchurch_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hornchurch_FC_logo.svg",
+              "fileTitle": "File:Hornchurch FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 294,
+              "height": 340,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hornchurch F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hornchurch_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "https://media.touchlinefc.co.uk/hq/2023/04/01105623/hornchurch.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:17.834Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "horsham": {
@@ -41185,6 +47725,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Horsham_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Horsham_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e9/Horsham_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Horsham_F.C._logo.svg",
+              "fileTitle": "File:Horsham F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Horsham F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Horsham_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/horsham/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:18.942Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hounslow": {
@@ -41301,6 +47879,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "hucknall town": {
@@ -41413,6 +47996,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hucknall_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hucknall_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9d/Hucknall_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hucknall_Town_FC_crest.svg",
+              "fileTitle": "File:Hucknall Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 307,
+              "height": 326,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hucknall Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hucknall_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/533952/hucknall-town-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:21.130Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "huddersfield town": {
@@ -41870,6 +48491,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Huddersfield_Town_AFC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Huddersfield_Town_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/43/Huddersfield_Town_AFC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Huddersfield_Town_AFC_crest.svg",
+              "fileTitle": "File:Huddersfield Town AFC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 269,
+              "height": 372,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Huddersfield Town A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Huddersfield_Town_AFC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/wiki/Fichier:Logo_Huddersfield_Town_AFC_2019.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:22.268Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hull city": {
@@ -42342,6 +49001,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hull_City_A.F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hull_City_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/54/Hull_City_A.F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hull_City_A.F.C._logo.svg",
+              "fileTitle": "File:Hull City A.F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 158,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hull City A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hull_City_A.F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Hull City A.F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:23.362Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hungerford town": {
@@ -42445,6 +49142,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hungerford_Town_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hungerford_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/19/Hungerford_Town_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hungerford_Town_F.C._logo.png",
+              "fileTitle": "File:Hungerford Town F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 256,
+              "height": 256,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hungerford Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hungerford_Town_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.pitchero.com/clubs/hungerfordtownfc/ http://www.pitchero.com/clubs/hungerfordtownfc/news/hungerford-celebrates-125-years-of-football-354558.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:24.460Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "hyde united": {
@@ -42690,6 +49425,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hyde_United_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hyde_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/d5/Hyde_United_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hyde_United_F.C._logo.png",
+              "fileTitle": "File:Hyde United F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hyde United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hyde_United_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.hydefc.co.uk/news/hyde-fc-to-return-to-hyde-united-1432047.html http://www.hydefc.co.uk/news/hyde-fc-to-return-to-hyde-united-1432047.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:25.544Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "ilkeston town": {
@@ -42912,6 +49685,44 @@
             "length": 6
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Ilkeston_FC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Ilkeston_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/0e/Ilkeston_FC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Ilkeston_FC_logo.png",
+              "fileTitle": "File:Ilkeston FC logo.png",
+              "mimeType": "image/png",
+              "width": 355,
+              "height": 281,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Ilkeston F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Ilkeston_FC_logo.png",
+                "copyrighted": true,
+                "credit": "http://www.chesterfield-fc.co.uk/cms_images/team/aaifc-main-badge46-2502796.png"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:26.651Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "ipswich town": {
@@ -43264,6 +50075,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Ipswich_Town.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Ipswich_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/43/Ipswich_Town.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Ipswich_Town.svg",
+              "fileTitle": "File:Ipswich Town.svg",
+              "mimeType": "image/svg+xml",
+              "width": 282,
+              "height": 354,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Ipswich Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Ipswich_Town.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Ipswich Town F.C.."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:27.837Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "kendal town": {
@@ -43383,6 +50232,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Kendal_Town_FC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Kendal_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/87/Kendal_Town_FC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Kendal_Town_FC_logo.png",
+              "fileTitle": "File:Kendal Town FC logo.png",
+              "mimeType": "image/png",
+              "width": 294,
+              "height": 339,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Kendal Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Kendal_Town_FC_logo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.kendaltown.com/ http://evostikleague.pitchero.com/club-info.php?id=2974&team_id=38434&Submit=Select"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:28.905Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "kettering town": {
@@ -43633,6 +50520,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Kettering_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Kettering_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/dd/Kettering_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Kettering_Town_FC_crest.svg",
+              "fileTitle": "File:Kettering Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 315,
+              "height": 317,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Kettering Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Kettering_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.brandsoftheworld.com/logo/kettering-town-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:30.002Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "kidderminster harriers": {
@@ -43856,6 +50781,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Kidderminster_Harriers_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Kidderminster_Harriers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/6e/Kidderminster_Harriers_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Kidderminster_Harriers_FC_crest.svg",
+              "fileTitle": "File:Kidderminster Harriers FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 278,
+              "height": 360,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Kidderminster Harriers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Kidderminster_Harriers_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/national-league/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:31.111Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "kings lynn": {
@@ -44068,6 +51031,44 @@
             "length": 6
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:King's_Lynn_F.C._(emblem).png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/King's_Lynn_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/85/King%27s_Lynn_F.C._%28emblem%29.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:King%27s_Lynn_F.C._(emblem).png",
+              "fileTitle": "File:King's Lynn F.C. (emblem).png",
+              "mimeType": "image/png",
+              "width": 125,
+              "height": 138,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of King's Lynn F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:King%27s_Lynn_F.C._(emblem).png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.kingslynnfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:32.196Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "kings lynn town": {
@@ -44179,6 +51180,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:King's_Lynn_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/King's_Lynn_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a1/King%27s_Lynn_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:King%27s_Lynn_Town_FC_crest.svg",
+              "fileTitle": "File:King's Lynn Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of King's Lynn Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:King%27s_Lynn_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://en.namu.wiki/w/%ED%82%B9%EC%8A%A4%20%EB%A6%B0%20%ED%83%80%EC%9A%B4%20FC"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:33.458Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "kingstonian": {
@@ -44326,6 +51365,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Kingstonian_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Kingstonian_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/d2/Kingstonian_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Kingstonian_F.C._logo.png",
+              "fileTitle": "File:Kingstonian F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 293,
+              "height": 340,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Kingstonian F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Kingstonian_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "From official Twitter account: https://pbs.twimg.com/profile_images/460379584555278336/2h0PF5dR_400x400.jpeg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:34.596Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "knowsley united": {
@@ -44445,6 +51522,45 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Knowsley-united.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Knowsley_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/62/Knowsley-united.png",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Knowsley-united.png",
+              "fileTitle": "File:Knowsley-united.png",
+              "mimeType": "image/png",
+              "width": 150,
+              "height": 150,
+              "license": {
+                "shortName": "Copyrighted free use",
+                "usageTerms": "Copyrighted free use",
+                "copyrighted": true,
+                "credit": "Knowsley United F.C. programme 1993-94",
+                "artist": "D. Cookson c/o- Knowsley United FC"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:56:35.935Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "lancaster city": {
@@ -44589,6 +51705,44 @@
             "length": 14
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Lancaster_City_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Lancaster_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/bf/Lancaster_City_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Lancaster_City_FC_crest.svg",
+              "fileTitle": "File:Lancaster City FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Lancaster City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Lancaster_City_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/lancaster-city-fc-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:37.028Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "leamington": {
@@ -44887,6 +52041,77 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Leamington_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Leamington_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/17/Leamington_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Leamington_FC_crest.svg",
+              "fileTitle": "File:Leamington FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Leamington F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Leamington_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/leamington-fc-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:38.159Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:New_North_Bank.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Leamington_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/05/New_North_Bank.jpg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:New_North_Bank.jpg",
+              "fileTitle": "File:New North Bank.jpg",
+              "mimeType": "image/jpeg",
+              "width": 3008,
+              "height": 2000,
+              "license": {
+                "shortName": "Cc-by-sa-3.0",
+                "usageTerms": "Attribution-ShareAlike 3.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0/",
+                "copyrighted": true,
+                "credit": "Ian Oliver",
+                "artist": "Ian Oliver"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:56:38.159Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "leatherhead": {
@@ -44981,6 +52206,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Leatherhead_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Leatherhead_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e8/Leatherhead_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Leatherhead_FC_crest.svg",
+              "fileTitle": "File:Leatherhead FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 303,
+              "height": 331,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Leatherhead F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Leatherhead_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/leatherhead-fc-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:39.275Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "leeds city": {
@@ -45134,6 +52397,43 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Leeds_old_arms.png",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Leeds_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9b/Leeds_old_arms.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Leeds_old_arms.png",
+              "fileTitle": "File:Leeds old arms.png",
+              "mimeType": "image/png",
+              "width": 569,
+              "height": 325,
+              "license": {
+                "shortName": "PD",
+                "usageTerms": "Public domain",
+                "copyrighted": false
+              },
+              "verification": {
+                "identityMatch": "weak",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:56:40.381Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "leeds united": {
@@ -45557,6 +52857,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Leeds_United_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Leeds_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/54/Leeds_United_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Leeds_United_F.C._logo.svg",
+              "fileTitle": "File:Leeds United F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 284,
+              "height": 353,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Leeds United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Leeds_United_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://www.leedsunited.com/en"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:41.546Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "leek town": {
@@ -45680,6 +53018,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Leek_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Leek_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a6/Leek_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Leek_Town_FC_crest.svg",
+              "fileTitle": "File:Leek Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 325,
+              "height": 308,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Leek Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Leek_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/512949/leek-town-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:42.704Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "leicester city": {
@@ -46197,6 +53573,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Leicester_City_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Leicester_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2d/Leicester_City_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Leicester_City_crest.svg",
+              "fileTitle": "File:Leicester City crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Leicester City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Leicester_City_crest.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Leicester City F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:43.813Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "leicester united": {
@@ -46366,6 +53780,11 @@
             "length": 4
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "leigh genesis": {
@@ -46594,6 +54013,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:LeighRMICrest.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Leigh_Genesis_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/8b/LeighRMICrest.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:LeighRMICrest.png",
+              "fileTitle": "File:LeighRMICrest.png",
+              "mimeType": "image/png",
+              "width": 188,
+              "height": 180,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:LeighRMICrest.png",
+                "copyrighted": true,
+                "credit": "official club website"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:46.109Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "lewes": {
@@ -46705,6 +54162,78 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Lewes_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Lewes_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/6e/Lewes_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Lewes_FC_crest.svg",
+              "fileTitle": "File:Lewes FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 345,
+              "height": 290,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Lewes F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Lewes_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://lewesfc.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:47.226Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:DrippingPan.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Lewes_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/4/4b/DrippingPan.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:DrippingPan.jpg",
+              "fileTitle": "File:DrippingPan.jpg",
+              "mimeType": "image/jpeg",
+              "width": 640,
+              "height": 479,
+              "license": {
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
+                "copyrighted": true,
+                "attribution": "Simon Carey",
+                "credit": "From geograph.org.uk",
+                "artist": "Simon Carey"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:56:47.226Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "leyton": {
@@ -46860,6 +54389,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "leyton orient": {
@@ -47383,6 +54917,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Leyton_Orient_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Leyton_Orient_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a8/Leyton_Orient_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Leyton_Orient_F.C._logo.svg",
+              "fileTitle": "File:Leyton Orient F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 200,
+              "height": 192,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Leyton Orient F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Leyton_Orient_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Leyton Orient F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:56:55.287Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "lincoln city": {
@@ -48024,6 +55596,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Lincoln_City_FC_2024_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Lincoln_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/39/Lincoln_City_FC_2024_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Lincoln_City_FC_2024_crest.svg",
+              "fileTitle": "File:Lincoln City FC 2024 crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 244,
+              "height": 410,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Lincoln City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Lincoln_City_FC_2024_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/543240/lincoln-city-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:02.505Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "liverpool": {
@@ -48516,6 +56126,73 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikidata-logo:Logo Liverpool FC (2024).png",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikidata-logo:Logo Liverpool FC (2024).png",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikidata-logo",
+              "sourceUrl": "https://www.wikidata.org/wiki/Q1130849",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Logo_Liverpool_FC_(2024).png",
+              "fileTitle": "File:Logo Liverpool FC (2024).png",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/30/Logo_Liverpool_FC_%282024%29.png",
+              "mimeType": "image/png",
+              "width": 520,
+              "height": 199,
+              "license": {
+                "shortName": "Public domain",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "https://seeklogo.com/vector-logo/547647/liverpool-f-c",
+                "artist": "Liverpool FC"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:57:03.632Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-any:Liverpool_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Liverpool_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/0c/Liverpool_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Liverpool_FC.svg",
+              "fileTitle": "File:Liverpool FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 244,
+              "height": 333,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Liverpool F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Liverpool_FC.svg",
+                "copyrighted": true,
+                "credit": "https://www.liverpoolfc.com/emails/pdf/membership_viewing_guide_chelsea_020512.pdf"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:03.632Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "loughborough": {
@@ -48626,6 +56303,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "lowestoft town": {
@@ -48714,6 +56396,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Lowestoft_Town_Badge.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Lowestoft_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/48/Lowestoft_Town_Badge.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Lowestoft_Town_Badge.png",
+              "fileTitle": "File:Lowestoft Town Badge.png",
+              "mimeType": "image/png",
+              "width": 277,
+              "height": 359,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Lowestoft Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Lowestoft_Town_Badge.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.distintivos.com.br/escudo.asp?cod=10039"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:05.956Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "luton town": {
@@ -49192,6 +56912,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Luton_Town_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Luton_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9d/Luton_Town_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Luton_Town_logo.svg",
+              "fileTitle": "File:Luton Town logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 250,
+              "height": 249,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Luton Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Luton_Town_logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Luton Town F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:07.091Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "macclesfield": {
@@ -49261,6 +57019,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Macclesfield_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Macclesfield_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/75/Macclesfield_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Macclesfield_FC_crest.svg",
+              "fileTitle": "File:Macclesfield FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Macclesfield F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Macclesfield_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/teams/macclesfield-town/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:08.269Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "macclesfield town": {
@@ -49507,6 +57303,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Macclesfield_Town_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Macclesfield_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/40/Macclesfield_Town_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Macclesfield_Town_FC.svg",
+              "fileTitle": "File:Macclesfield Town FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Macclesfield Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Macclesfield_Town_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Macclesfield Town F.C. Official Website Converted to AI format by Vflnet.com and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped the SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:09.366Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "maidenhead united": {
@@ -49705,6 +57539,77 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Maidenhead_United_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Maidenhead_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/33/Maidenhead_United_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Maidenhead_United_FC_crest.svg",
+              "fileTitle": "File:Maidenhead United FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Maidenhead United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Maidenhead_United_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/national-league/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:10.598Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Maidenhead_v_Barnet_022.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Maidenhead_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/5/51/Maidenhead_v_Barnet_022.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Maidenhead_v_Barnet_022.jpg",
+              "fileTitle": "File:Maidenhead v Barnet 022.jpg",
+              "mimeType": "image/jpeg",
+              "width": 4354,
+              "height": 3003,
+              "license": {
+                "shortName": "CC0",
+                "usageTerms": "Creative Commons Zero, Public Domain Dedication",
+                "licenseUrl": "http://creativecommons.org/publicdomain/zero/1.0/deed.en",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Maidenhead United FC"
+              },
+              "verification": {
+                "identityMatch": "weak",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:57:10.598Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "maidstone united": {
@@ -49828,6 +57733,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Maidstone_United_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Maidstone_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b8/Maidstone_United_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Maidstone_United_FC_crest.svg",
+              "fileTitle": "File:Maidstone United FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 295,
+              "height": 339,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Maidstone United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Maidstone_United_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/maidstone-united-fc-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:11.743Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "maidstone united 1897": {
@@ -50007,6 +57950,46 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
+              "fileTitle": "File:Ryan Valentine scores.jpg",
+              "mimeType": "image/jpeg",
+              "width": 3456,
+              "height": 2304,
+              "license": {
+                "shortName": "CC BY 2.5",
+                "usageTerms": "Creative Commons Attribution 2.5",
+                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Markbarnes"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:57:12.873Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "manchester city": {
@@ -50537,6 +58520,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Manchester_City_FC_badge.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Manchester_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/eb/Manchester_City_FC_badge.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Manchester_City_FC_badge.svg",
+              "fileTitle": "File:Manchester City FC badge.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Manchester City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Manchester_City_FC_badge.svg",
+                "copyrighted": true,
+                "credit": "http://www.mancity.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:13.948Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "manchester united": {
@@ -51064,6 +59085,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Manchester_United_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Manchester_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/7a/Manchester_United_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Manchester_United_FC_crest.svg",
+              "fileTitle": "File:Manchester United FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 296,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Manchester United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Manchester_United_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "http://hospitalityguide.manutd.com/global_assets/Wine_List.pdf"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:15.065Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "mansfield town": {
@@ -51445,6 +59504,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Mansfield_Town_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Mansfield_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/7d/Mansfield_Town_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Mansfield_Town_FC.svg",
+              "fileTitle": "File:Mansfield Town FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 286,
+              "height": 350,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Mansfield Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Mansfield_Town_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Mansfield Town F.C. Official Website Converted to AI format by Johnny Beaufays (johnny.beaufays@vflnet.com) and then converted the SVG by Arteyu using Adobe Illustrator . Then cropped to SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:16.227Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "margate": {
@@ -51676,6 +59773,44 @@
             "length": 10
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Margate_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Margate_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/34/Margate_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Margate_FC_crest.svg",
+              "fileTitle": "File:Margate FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 291,
+              "height": 344,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Margate F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Margate_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/341730/margate-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:17.372Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "marine": {
@@ -51843,6 +59978,44 @@
             "length": 20
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Marine_AFC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Marine_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/7f/Marine_AFC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Marine_AFC_crest.svg",
+              "fileTitle": "File:Marine AFC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 302,
+              "height": 331,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Marine A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Marine_AFC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/547230/marine-afc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:18.474Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "marlow": {
@@ -51946,6 +60119,75 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Marlow_FC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Marlow_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5d/Marlow_FC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Marlow_FC_logo.png",
+              "fileTitle": "File:Marlow FC logo.png",
+              "mimeType": "image/png",
+              "width": 308,
+              "height": 308,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Marlow F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Marlow_FC_logo.png",
+                "copyrighted": true,
+                "credit": "https://s3-eu-west-1.amazonaws.com/files.pitchero.com/clubs/35398/t1bImbCORuqDzefCrTiR_Commercial%20Opportunities%202016-17.pdf"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:19.543Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Marlow1894.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Marlow_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/36/Marlow1894.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Marlow1894.jpg",
+              "fileTitle": "File:Marlow1894.jpg",
+              "mimeType": "image/jpeg",
+              "width": 600,
+              "height": 549,
+              "license": {
+                "shortName": "Public domain",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "https://www.historicalkits.co.uk/_images/marlow-fc-1894.jpg",
+                "artist": "Unknown author Unknown author"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:57:19.543Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "matlock town": {
@@ -52079,6 +60321,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Matlock_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Matlock_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/06/Matlock_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Matlock_Town_FC_crest.svg",
+              "fileTitle": "File:Matlock Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Matlock Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Matlock_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/547716/matlock-town-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:20.660Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "merthyr town": {
@@ -52349,6 +60629,44 @@
             "length": 95
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Merthyr_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Merthyr_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/42/Merthyr_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Merthyr_Town_FC_crest.svg",
+              "fileTitle": "File:Merthyr Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 267,
+              "height": 375,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Merthyr Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Merthyr_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://waltonhershamfc.com/fixtures/first-team/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:21.747Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "merthyr tydfil": {
@@ -52587,6 +60905,44 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Merthyr_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Merthyr_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/42/Merthyr_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Merthyr_Town_FC_crest.svg",
+              "fileTitle": "File:Merthyr Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 267,
+              "height": 375,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Merthyr Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Merthyr_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://waltonhershamfc.com/fixtures/first-team/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:22.845Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "middlesbrough": {
@@ -53070,6 +61426,76 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Middlesbrough_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Middlesbrough_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2c/Middlesbrough_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Middlesbrough_FC_crest.svg",
+              "fileTitle": "File:Middlesbrough FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Middlesbrough F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Middlesbrough_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "http://www.premierleague.com/clubs/13/Middlesbrough/overview"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:24.020Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikidata-logo:Middlesbrough Walk (27470064759).jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikidata-logo",
+              "sourceUrl": "https://www.wikidata.org/wiki/Q18661",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Middlesbrough_Walk_(27470064759).jpg",
+              "fileTitle": "File:Middlesbrough Walk (27470064759).jpg",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b5/Middlesbrough_Walk_%2827470064759%29.jpg",
+              "mimeType": "image/jpeg",
+              "width": 2048,
+              "height": 1368,
+              "license": {
+                "shortName": "CC BY 2.0",
+                "usageTerms": "Creative Commons Attribution 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by/2.0",
+                "copyrighted": true,
+                "credit": "Middlesbrough Walk",
+                "artist": "Paul Hudson from United Kingdom"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:57:24.020Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "middlesbrough ironopolis": {
@@ -53168,6 +61594,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "millwall": {
@@ -53583,6 +62014,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Millwall_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Millwall_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/98/Millwall_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Millwall_FC_crest.svg",
+              "fileTitle": "File:Millwall FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Millwall F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Millwall_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/championship/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:26.475Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "milton keynes city": {
@@ -53711,6 +62180,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "milton keynes dons": {
@@ -53895,6 +62369,42 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikipedia-pageimage-free:Milton_Keynes_Dons_FC_2025_crest.svg",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Milton_Keynes_Dons_FC_2025_crest.svg",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Milton_Keynes_Dons_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e5/Milton_Keynes_Dons_FC_2025_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Milton_Keynes_Dons_FC_2025_crest.svg",
+              "fileTitle": "File:Milton Keynes Dons FC 2025 crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "PD",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "https://www.mkdons.com/news/2025/may/06/milton-keynes-dons-reveal-new-club-crest-for-25-26/",
+                "artist": "Milton Keynes Dons Football Club"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:57:28.651Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "minehead": {
@@ -53986,6 +62496,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Minehead_A.F.C.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Minehead_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/80/Minehead_A.F.C.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Minehead_A.F.C.png",
+              "fileTitle": "File:Minehead A.F.C.png",
+              "mimeType": "image/png",
+              "width": 180,
+              "height": 180,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Minehead A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Minehead_A.F.C.png",
+                "copyrighted": true,
+                "credit": "https://twitter.com/MineheadAFC"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:29.792Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "molesey": {
@@ -54077,6 +62625,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Molesey_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Molesey_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/ad/Molesey_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Molesey_FC_crest.svg",
+              "fileTitle": "File:Molesey FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 327,
+              "height": 306,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Molesey F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Molesey_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/molesey-football-club-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:30.914Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "moor green": {
@@ -54253,6 +62839,44 @@
             "length": 6
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:MoorGreenFCCrest.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Moor_Green_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/fc/MoorGreenFCCrest.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:MoorGreenFCCrest.png",
+              "fileTitle": "File:MoorGreenFCCrest.png",
+              "mimeType": "image/png",
+              "width": 198,
+              "height": 234,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:MoorGreenFCCrest.png",
+                "copyrighted": true,
+                "credit": "official club website"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:32.032Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "morecambe": {
@@ -54484,6 +63108,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Morecambe_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Morecambe_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/ee/Morecambe_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Morecambe_FC_crest.svg",
+              "fileTitle": "File:Morecambe FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 293,
+              "height": 341,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Morecambe F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Morecambe_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/league-two/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:33.368Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "mossley": {
@@ -54608,6 +63270,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Mossley_AFC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Mossley_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/bd/Mossley_AFC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Mossley_AFC_logo.png",
+              "fileTitle": "File:Mossley AFC logo.png",
+              "mimeType": "image/png",
+              "width": 301,
+              "height": 324,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Mossley A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Mossley_AFC_logo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Club website"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:34.422Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "needham market": {
@@ -54693,6 +63393,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Needham_Market_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Needham_Market_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/72/Needham_Market_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Needham_Market_FC_crest.svg",
+              "fileTitle": "File:Needham Market FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 317,
+              "height": 315,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Needham Market F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Needham_Market_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.brandsoftheworld.com/logo/needham-market-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:35.600Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "nelson": {
@@ -54813,6 +63551,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Nelson_FC_Logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Nelson_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/94/Nelson_FC_Logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Nelson_FC_Logo.png",
+              "fileTitle": "File:Nelson FC Logo.png",
+              "mimeType": "image/png",
+              "width": 269,
+              "height": 363,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Nelson F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Nelson_FC_Logo.png",
+                "copyrighted": true,
+                "credit": "Official Website http://www.nelsonfootballclub.co.uk/s/match-centre-82778/0-2427150/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:36.673Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "new brighton": {
@@ -55022,6 +63798,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:New_Brighton_AFC_crest.jpg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/New_Brighton_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/ac/New_Brighton_AFC_crest.jpg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:New_Brighton_AFC_crest.jpg",
+              "fileTitle": "File:New Brighton AFC crest.jpg",
+              "mimeType": "image/jpeg",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of New Brighton A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:New_Brighton_AFC_crest.jpg",
+                "copyrighted": true,
+                "credit": "https://x.com/NewBrightonAFC"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:37.753Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "new brighton tower": {
@@ -55126,6 +63940,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "newcastle united": {
@@ -55619,6 +64438,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Newcastle_United_Logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Newcastle_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/56/Newcastle_United_Logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Newcastle_United_Logo.svg",
+              "fileTitle": "File:Newcastle United Logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 302,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Newcastle United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Newcastle_United_Logo.svg",
+                "copyrighted": true,
+                "credit": "Deutsch Wikipedia ( http://de.wikipedia.org/wiki/Bild:Newcastle_United_Logo.svg )"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:40.000Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "newport county": {
@@ -55877,6 +64734,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Newport_County_AFC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Newport_County_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/44/Newport_County_AFC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Newport_County_AFC_crest.svg",
+              "fileTitle": "File:Newport County AFC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 317,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Newport County A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Newport_County_AFC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.newport-county.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:41.048Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "newport county 1912": {
@@ -56273,6 +65168,46 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
+              "fileTitle": "File:Ryan Valentine scores.jpg",
+              "mimeType": "image/jpeg",
+              "width": 3456,
+              "height": 2304,
+              "license": {
+                "shortName": "CC BY 2.5",
+                "usageTerms": "Creative Commons Attribution 2.5",
+                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Markbarnes"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:57:42.191Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "newport isle of wight": {
@@ -56358,6 +65293,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Newportfclogo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Newport_(IOW)_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/99/Newportfclogo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Newportfclogo.png",
+              "fileTitle": "File:Newportfclogo.png",
+              "mimeType": "image/png",
+              "width": 256,
+              "height": 256,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Newport (IOW) F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Newportfclogo.png",
+                "copyrighted": true,
+                "credit": "Official Website"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:44.472Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "north ferriby united": {
@@ -56476,6 +65449,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:North_Ferriby_United_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/North_Ferriby_United_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/58/North_Ferriby_United_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:North_Ferriby_United_logo.png",
+              "fileTitle": "File:North Ferriby United logo.png",
+              "mimeType": "image/png",
+              "width": 295,
+              "height": 336,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of North Ferriby United A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:North_Ferriby_United_logo.png",
+                "copyrighted": true,
+                "credit": "http://www.stockportcounty.com/cms_images/team/north-ferriby-utd43-934713.png"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:45.538Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "northampton town": {
@@ -56890,6 +65901,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Northampton_Town_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Northampton_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2d/Northampton_Town_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Northampton_Town_F.C._logo.svg",
+              "fileTitle": "File:Northampton Town F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 155,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Northampton Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Northampton_Town_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Northampton Town F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:46.631Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "northwich victoria": {
@@ -57135,6 +66184,44 @@
             "length": 85
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Northwich_Victoria_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Northwich_Victoria_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/59/Northwich_Victoria_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Northwich_Victoria_F.C._logo.svg",
+              "fileTitle": "File:Northwich Victoria F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 296,
+              "height": 338,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Northwich Victoria F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Northwich_Victoria_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/northwich-victoria/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:47.757Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "northwood": {
@@ -57220,6 +66307,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "norwich city": {
@@ -57627,6 +66719,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Norwich_City_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Norwich_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/17/Norwich_City_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Norwich_City_FC_logo.svg",
+              "fileTitle": "File:Norwich City FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 221,
+              "height": 250,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Norwich City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Norwich_City_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Norwich City F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:57:58.839Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "nottingham forest": {
@@ -58137,6 +67267,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Nottingham_Forest_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Nottingham_Forest_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e5/Nottingham_Forest_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Nottingham_Forest_F.C._logo.svg",
+              "fileTitle": "File:Nottingham Forest F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 94,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Nottingham Forest F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Nottingham_Forest_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Nottingham Forest F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:03.173Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "notts county": {
@@ -58670,6 +67838,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Notts_County_Logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Notts_County_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2e/Notts_County_Logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Notts_County_Logo.svg",
+              "fileTitle": "File:Notts County Logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 194,
+              "height": 258,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Notts County F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Notts_County_Logo.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/teams/notts-county/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:04.337Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "nuneaton borough": {
@@ -58979,6 +68185,44 @@
             "length": 10
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Nuneaton_Town_FC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Nuneaton_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/44/Nuneaton_Town_FC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Nuneaton_Town_FC_logo.png",
+              "fileTitle": "File:Nuneaton Town FC logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 313,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Nuneaton Borough F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Nuneaton_Town_FC_logo.png",
+                "copyrighted": true,
+                "credit": "https://www.nuneatontownfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:05.500Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "nuneaton town": {
@@ -59109,6 +68353,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Nuneaton_Town_FC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Nuneaton_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/44/Nuneaton_Town_FC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Nuneaton_Town_FC_logo.png",
+              "fileTitle": "File:Nuneaton Town FC logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 313,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Nuneaton Borough F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Nuneaton_Town_FC_logo.png",
+                "copyrighted": true,
+                "credit": "https://www.nuneatontownfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:06.575Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "oldham athletic": {
@@ -59585,6 +68867,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Oldham_Athletic_AFC_(emblem).svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Oldham_Athletic_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a2/Oldham_Athletic_AFC_%28emblem%29.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Oldham_Athletic_AFC_(emblem).svg",
+              "fileTitle": "File:Oldham Athletic AFC (emblem).svg",
+              "mimeType": "image/svg+xml",
+              "width": 204,
+              "height": 490,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Oldham Athletic A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Oldham_Athletic_AFC_(emblem).svg",
+                "copyrighted": true,
+                "credit": "https://svgshare.com/i/fyp.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:07.689Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "oswestry town": {
@@ -59731,6 +69051,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "oxford city": {
@@ -59894,6 +69219,78 @@
             "length": 14
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Oxford_City_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Oxford_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/fb/Oxford_City_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Oxford_City_FC_crest.svg",
+              "fileTitle": "File:Oxford City FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Oxford City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Oxford_City_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/wiki/Fichier:Logo_Oxford_City_FC.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:09.840Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:The_Main_Stand_at_Court_Place_Farm_-_geograph.org.uk_-_1245335.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Oxford_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/e/ea/The_Main_Stand_at_Court_Place_Farm_-_geograph.org.uk_-_1245335.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:The_Main_Stand_at_Court_Place_Farm_-_geograph.org.uk_-_1245335.jpg",
+              "fileTitle": "File:The Main Stand at Court Place Farm - geograph.org.uk - 1245335.jpg",
+              "mimeType": "image/jpeg",
+              "width": 640,
+              "height": 427,
+              "license": {
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
+                "copyrighted": true,
+                "attribution": "Steve Daniels",
+                "credit": "From geograph.org.uk",
+                "artist": "Steve Daniels"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:58:09.840Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "oxford united": {
@@ -60184,6 +69581,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Oxford_United_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Oxford_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/3e/Oxford_United_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Oxford_United_FC_logo.svg",
+              "fileTitle": "File:Oxford United FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 295,
+              "height": 338,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Oxford United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Oxford_United_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Oxford United F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:10.964Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "peterborough sports": {
@@ -60262,6 +69697,76 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Peterborough_Sports_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Peterborough_Sports_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/19/Peterborough_Sports_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Peterborough_Sports_F.C._logo.svg",
+              "fileTitle": "File:Peterborough Sports F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Peterborough Sports F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Peterborough_Sports_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/peterborough-sports/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:12.064Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Peterborough_Sports_vs_Guiseley_FC_-_FA_Cup_3rd_qualifying_round_2019.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Peterborough_Sports_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/f/f1/Peterborough_Sports_vs_Guiseley_FC_-_FA_Cup_3rd_qualifying_round_2019.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Peterborough_Sports_vs_Guiseley_FC_-_FA_Cup_3rd_qualifying_round_2019.jpg",
+              "fileTitle": "File:Peterborough Sports vs Guiseley FC - FA Cup 3rd qualifying round 2019.jpg",
+              "mimeType": "image/jpeg",
+              "width": 3409,
+              "height": 3372,
+              "license": {
+                "shortName": "CC BY-SA 4.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "JamesRich2019"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:58:12.064Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "peterborough united": {
@@ -60542,6 +70047,43 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikipedia-pageimage-free:Peterborough_United's_new_badge.svg",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Peterborough_United's_new_badge.svg",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Peterborough_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/9/97/Peterborough_United%27s_new_badge.svg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Peterborough_United%27s_new_badge.svg",
+              "fileTitle": "File:Peterborough United's new badge.svg",
+              "mimeType": "image/svg+xml",
+              "width": 900,
+              "height": 900,
+              "license": {
+                "shortName": "CC0",
+                "usageTerms": "Creative Commons Zero, Public Domain Dedication",
+                "licenseUrl": "http://creativecommons.org/publicdomain/zero/1.0/deed.en",
+                "copyrighted": true,
+                "credit": "Website - https://www.theposh.com/",
+                "artist": "Peterborough United"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:58:13.297Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "plymouth argyle": {
@@ -60949,6 +70491,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Plymouth_Argyle_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Plymouth_Argyle_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a8/Plymouth_Argyle_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Plymouth_Argyle_F.C._logo.svg",
+              "fileTitle": "File:Plymouth Argyle F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 321,
+              "height": 312,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Plymouth Argyle F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Plymouth_Argyle_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "[1]"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:14.424Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "poole town": {
@@ -61093,6 +70673,44 @@
             "length": 24
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Poole_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Poole_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/23/Poole_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Poole_Town_FC_crest.svg",
+              "fileTitle": "File:Poole Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Poole Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Poole_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/poole-town-fc-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:15.581Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "port vale": {
@@ -61651,6 +71269,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Port_Vale_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Port_Vale_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5f/Port_Vale_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Port_Vale_logo.svg",
+              "fileTitle": "File:Port Vale logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 263,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Port Vale F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Port_Vale_logo.svg",
+                "copyrighted": true,
+                "credit": "https://brandlogos.net/port-vale-logo-vector-99923.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:16.751Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "portsmouth": {
@@ -62067,6 +71723,42 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikipedia-pageimage-free:Portsmouth_FC_logo.svg",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Portsmouth_FC_logo.svg",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Portsmouth_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/38/Portsmouth_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Portsmouth_FC_logo.svg",
+              "fileTitle": "File:Portsmouth FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 315,
+              "height": 315,
+              "license": {
+                "shortName": "PD",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "Portsmouth FC via VRTS ticket # 2019021510003653",
+                "artist": "Portsmouth Football Club"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:58:17.941Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "preston north end": {
@@ -62591,6 +72283,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Preston_North_End_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Preston_North_End_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/82/Preston_North_End_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Preston_North_End_FC.svg",
+              "fileTitle": "File:Preston North End FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 276,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Preston North End F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Preston_North_End_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Preston North End F.C.."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:19.094Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "queens park rangers": {
@@ -62997,6 +72727,75 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikipedia-pageimage-free:Queens_Park_Rangers_crest.svg",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Queens_Park_Rangers_crest.svg",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Queens_Park_Rangers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/31/Queens_Park_Rangers_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Queens_Park_Rangers_crest.svg",
+              "fileTitle": "File:Queens Park Rangers crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "PD",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "https://qpr.co.uk/",
+                "artist": "Queens Park Rangers Football Club"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:58:20.266Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikidata-logo:QPr.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikidata-logo",
+              "sourceUrl": "https://www.wikidata.org/wiki/Q18723",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:QPr.jpg",
+              "fileTitle": "File:QPr.jpg",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/3/32/QPr.jpg",
+              "mimeType": "image/jpeg",
+              "width": 960,
+              "height": 960,
+              "license": {
+                "shortName": "CC BY-SA 4.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Martin1994ramos"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:58:20.266Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "radcliffe": {
@@ -63166,6 +72965,44 @@
             "length": 20
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Radcliffe_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Radcliffe_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/02/Radcliffe_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Radcliffe_FC_crest.svg",
+              "fileTitle": "File:Radcliffe FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 283,
+              "height": 353,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Radcliffe F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Radcliffe_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://radcliffefc.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:21.522Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "reading": {
@@ -63581,6 +73418,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Reading_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Reading_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/11/Reading_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Reading_FC.svg",
+              "fileTitle": "File:Reading FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 200,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Reading F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Reading_FC.svg",
+                "copyrighted": true,
+                "credit": "Reading F.C. Official Website"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:22.639Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "redbridge": {
@@ -63702,6 +73577,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Redbridge_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Redbridge_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/57/Redbridge_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Redbridge_F.C._logo.png",
+              "fileTitle": "File:Redbridge F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Redbridge F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Redbridge_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "Sourced from official Twitter account: https://pbs.twimg.com/profile_images/507276592973107201/FulPIgkj.jpeg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:23.814Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "redbridge forest": {
@@ -63953,6 +73866,11 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "redditch united": {
@@ -64120,6 +74038,44 @@
             "length": 15
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:RedditchUnitedFC.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Redditch_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b4/RedditchUnitedFC.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:RedditchUnitedFC.png",
+              "fileTitle": "File:RedditchUnitedFC.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Redditch United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:RedditchUnitedFC.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Redditch United F.C. Official Website"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:25.933Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "rhyl": {
@@ -64261,6 +74217,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Rhyl_FC_Logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Rhyl_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/69/Rhyl_FC_Logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Rhyl_FC_Logo.png",
+              "fileTitle": "File:Rhyl FC Logo.png",
+              "mimeType": "image/png",
+              "width": 315,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Rhyl F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Rhyl_FC_Logo.png",
+                "copyrighted": true,
+                "credit": "www.rhylfc.co.uk"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:27.059Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "road-sea southampton": {
@@ -64391,6 +74385,46 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Road-Sea_Southampton_F.C.jpg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Road-Sea_Southampton_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c5/Road-Sea_Southampton_F.C.jpg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Road-Sea_Southampton_F.C.jpg",
+              "fileTitle": "File:Road-Sea Southampton F.C.jpg",
+              "mimeType": "image/jpeg",
+              "width": 266,
+              "height": 374,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Road-Sea Southampton F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Road-Sea_Southampton_F.C.jpg",
+                "copyrighted": true,
+                "credit": "Official Club Programme",
+                "artist": "Peter Price"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:58:28.184Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "rochdale": {
@@ -64794,6 +74828,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Rochdale_AFC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Rochdale_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/bb/Rochdale_AFC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Rochdale_AFC_crest.svg",
+              "fileTitle": "File:Rochdale AFC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Rochdale A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Rochdale_AFC_crest.svg",
+                "copyrighted": true,
+                "credit": "fr:Fichier:Logo Rochdale AFC 1993.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:29.348Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "rotherham county": {
@@ -64951,6 +75023,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Rotherham_County_FC_crest.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Rotherham_County_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/14/Rotherham_County_FC_crest.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Rotherham_County_FC_crest.png",
+              "fileTitle": "File:Rotherham County FC crest.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Rotherham County F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Rotherham_County_FC_crest.png",
+                "copyrighted": true,
+                "credit": "https://www.thesportsdb.com/team/139945-Rotherham-County-FC"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:30.492Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "rotherham town": {
@@ -65055,6 +75165,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "rotherham united": {
@@ -65467,6 +75582,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Rotherham_United_F.C._svg.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Rotherham_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/42/Rotherham_United_F.C._svg.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Rotherham_United_F.C._svg.svg",
+              "fileTitle": "File:Rotherham United F.C. svg.svg",
+              "mimeType": "image/svg+xml",
+              "width": 250,
+              "height": 332,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Rotherham United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Rotherham_United_F.C._svg.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/wiki/Fichier:Rotherham_United_FC.svg"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:32.981Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "rothwell town": {
@@ -65571,6 +75724,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "rugby town": {
@@ -65722,6 +75880,44 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Rugby_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Rugby_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/f5/Rugby_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Rugby_Town_FC_crest.svg",
+              "fileTitle": "File:Rugby Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 275,
+              "height": 364,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Rugby Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Rugby_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/512311/rugby-town-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:35.240Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "runcorn fc halton": {
@@ -65982,6 +76178,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "rushall olympic": {
@@ -66070,6 +76271,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Rushallolympicfc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Rushall_Olympic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/4b/Rushallolympicfc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Rushallolympicfc.png",
+              "fileTitle": "File:Rushallolympicfc.png",
+              "mimeType": "image/png",
+              "width": 256,
+              "height": 256,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Rushall Olympic F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Rushallolympicfc.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.pitchero.com/clubs/rushallolympic/ http://www.pitchero.com/clubs/rushallolympic/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:37.330Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "rushden and diamonds": {
@@ -66288,6 +76527,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Rushden_&_Diamonds.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Rushden_%26_Diamonds_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/8a/Rushden_%26_Diamonds.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Rushden_%26_Diamonds.svg",
+              "fileTitle": "File:Rushden & Diamonds.svg",
+              "mimeType": "image/svg+xml",
+              "width": 297,
+              "height": 337,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Rushden & Diamonds F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Rushden_%26_Diamonds.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Rushden & Diamonds F.C. Official Website Converted to AI format by Vflnet.com and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped to SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:38.422Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "rushden town": {
@@ -66407,6 +76684,43 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikipedia-pageimage-free:Rushden_Town_badge.png",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Rushden_Town_badge.png",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Rushden_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/7e/Rushden_Town_badge.png",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Rushden_Town_badge.png",
+              "fileTitle": "File:Rushden Town badge.png",
+              "mimeType": "image/png",
+              "width": 1255,
+              "height": 1133,
+              "license": {
+                "shortName": "CC0",
+                "usageTerms": "Creative Commons Zero, Public Domain Dedication",
+                "licenseUrl": "http://creativecommons.org/publicdomain/zero/1.0/deed.en",
+                "copyrighted": true,
+                "credit": "Own work based on: Klimmende Hollandse leeuw.svg",
+                "artist": "That Northern Irish Historian"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:58:39.490Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "salford city": {
@@ -66519,6 +76833,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Salford_City_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Salford_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e7/Salford_City_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Salford_City_FC_crest.svg",
+              "fileTitle": "File:Salford City FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 250,
+              "height": 400,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Salford City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Salford_City_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/wiki/Fichier:Logo_Salford_City_FC.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:40.622Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "salisbury": {
@@ -66641,6 +76993,44 @@
             "length": 37
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Salisbury_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Salisbury_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/80/Salisbury_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Salisbury_F.C._logo.svg",
+              "fileTitle": "File:Salisbury F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Salisbury F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Salisbury_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/salisbury/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:41.827Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "salisbury city": {
@@ -66853,6 +77243,44 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Salisbury_City_FC.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Salisbury_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/91/Salisbury_City_FC.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Salisbury_City_FC.png",
+              "fileTitle": "File:Salisbury City FC.png",
+              "mimeType": "image/png",
+              "width": 180,
+              "height": 180,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Salisbury City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Salisbury_City_FC.png",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Salisbury City F.C.."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:42.936Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "scarborough": {
@@ -67083,6 +77511,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Scarborough_Athletic_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Scarborough_Athletic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b9/Scarborough_Athletic_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Scarborough_Athletic_FC_crest.svg",
+              "fileTitle": "File:Scarborough Athletic FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 295,
+              "height": 339,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Scarborough Athletic F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Scarborough_Athletic_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.scarboroughathletic.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:44.087Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "scarborough athletic": {
@@ -67198,6 +77664,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Scarborough_Athletic_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Scarborough_Athletic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b9/Scarborough_Athletic_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Scarborough_Athletic_FC_crest.svg",
+              "fileTitle": "File:Scarborough Athletic FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 295,
+              "height": 339,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Scarborough Athletic F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Scarborough_Athletic_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.scarboroughathletic.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:45.165Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "scunthorpe united": {
@@ -67547,6 +78051,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Scunthorpe_United_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Scunthorpe_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b3/Scunthorpe_United_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Scunthorpe_United_FC_crest.svg",
+              "fileTitle": "File:Scunthorpe United FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 337,
+              "height": 296,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Scunthorpe United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Scunthorpe_United_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/w/index.php?title=Fichier:Scunthorpe_United_FC_logo.svg&lang=fr"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:46.251Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "sheffield united": {
@@ -68059,6 +78601,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Sheffield_United_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Sheffield_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9c/Sheffield_United_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Sheffield_United_FC_logo.svg",
+              "fileTitle": "File:Sheffield United FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Sheffield United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Sheffield_United_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "de:Datei:Sheffield United.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:58:47.385Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "sheffield wednesday": {
@@ -68593,6 +79173,11 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "shepshed dynamo": {
@@ -68736,6 +79321,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "shrewsbury town": {
@@ -69054,6 +79644,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Shrewsbury_Town_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Shrewsbury_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/1b/Shrewsbury_Town_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Shrewsbury_Town_F.C._logo.svg",
+              "fileTitle": "File:Shrewsbury Town F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 200,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Shrewsbury Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Shrewsbury_Town_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Shrewsbury Town F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:02.606Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "sittingbourne": {
@@ -69168,6 +79796,44 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Sittingbourne_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Sittingbourne_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/86/Sittingbourne_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Sittingbourne_FC_crest.svg",
+              "fileTitle": "File:Sittingbourne FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 328,
+              "height": 305,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Sittingbourne F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Sittingbourne_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.erithtown.com/club/sittingbourne-fc/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:03.698Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "slough town": {
@@ -69352,6 +80018,44 @@
             "length": 17
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Slough_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Slough_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/1e/Slough_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Slough_Town_FC_crest.svg",
+              "fileTitle": "File:Slough Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Slough Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Slough_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.brandsoftheworld.com/logo/slough-town-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:04.840Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "solihull borough": {
@@ -69478,6 +80182,46 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Solihullboroughafc.jpg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Solihull_Borough_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e8/Solihullboroughafc.jpg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Solihullboroughafc.jpg",
+              "fileTitle": "File:Solihullboroughafc.jpg",
+              "mimeType": "image/jpeg",
+              "width": 100,
+              "height": 100,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Solihullboroughafc.jpg",
+                "copyrighted": true,
+                "credit": "Williswappen Division Seven 4 webpage",
+                "artist": "Unknown"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:59:05.984Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "solihull moors": {
@@ -69649,6 +80393,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Solihull_Moors_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Solihull_Moors_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9b/Solihull_Moors_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Solihull_Moors_FC_crest.svg",
+              "fileTitle": "File:Solihull Moors FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Solihull Moors F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Solihull_Moors_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/national-league/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:07.040Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "south liverpool": {
@@ -69792,6 +80574,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:South_Liverpool_FC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/South_Liverpool_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/28/South_Liverpool_FC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:South_Liverpool_FC_logo.png",
+              "fileTitle": "File:South Liverpool FC logo.png",
+              "mimeType": "image/png",
+              "width": 212,
+              "height": 247,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of South Liverpool F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:South_Liverpool_FC_logo.png",
+                "copyrighted": true,
+                "credit": "https://www.southliverpoolfc.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:08.109Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "south shields": {
@@ -69867,6 +80687,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:South_Shields_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/South_Shields_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e5/South_Shields_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:South_Shields_FC_crest.svg",
+              "fileTitle": "File:South Shields FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 281,
+              "height": 356,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of South Shields F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:South_Shields_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/fa-cup/scores-fixtures/2025-11"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:09.251Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "southampton": {
@@ -70274,6 +81132,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:FC_Southampton.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Southampton_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c9/FC_Southampton.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:FC_Southampton.svg",
+              "fileTitle": "File:FC Southampton.svg",
+              "mimeType": "image/svg+xml",
+              "width": 296,
+              "height": 338,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Southampton F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:FC_Southampton.svg",
+                "copyrighted": true,
+                "credit": "http://www.saintsfc.co.uk/page/ClubSponsors/0,,10280~1655828,00.html"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:10.318Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "southend united": {
@@ -70688,6 +81584,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Southend_United.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Southend_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/79/Southend_United.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Southend_United.svg",
+              "fileTitle": "File:Southend United.svg",
+              "mimeType": "image/svg+xml",
+              "width": 326,
+              "height": 307,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Southend United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Southend_United.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Southend United F.C.."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:11.467Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "southport": {
@@ -71141,6 +82075,44 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Southport_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Southport_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/35/Southport_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Southport_FC_crest.svg",
+              "fileTitle": "File:Southport FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 292,
+              "height": 342,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Southport F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Southport_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/223752/southport-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:12.619Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "spennymoor town": {
@@ -71255,6 +82227,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Spennymoor_Town_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Spennymoor_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/1a/Spennymoor_Town_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Spennymoor_Town_F.C._logo.svg",
+              "fileTitle": "File:Spennymoor Town F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 390,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Spennymoor Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Spennymoor_Town_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/spennymoor-town/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:13.767Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "spennymoor united": {
@@ -71449,6 +82459,44 @@
             "length": 2
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Spennymoor_Town_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Spennymoor_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/1a/Spennymoor_Town_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Spennymoor_Town_F.C._logo.svg",
+              "fileTitle": "File:Spennymoor Town F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 390,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Spennymoor Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Spennymoor_Town_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/spennymoor-town/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:14.831Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "st albans city": {
@@ -71696,6 +82744,44 @@
             "length": 3
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:St_Albans_City_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/St_Albans_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/dc/St_Albans_City_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:St_Albans_City_FC_crest.svg",
+              "fileTitle": "File:St Albans City FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of St Albans City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:St_Albans_City_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://worthingfc.com/results/men/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:15.976Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "st leonards": {
@@ -71818,6 +82904,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:StLeonardsCrest.gif",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/St._Leonards_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/10/StLeonardsCrest.gif",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:StLeonardsCrest.gif",
+              "fileTitle": "File:StLeonardsCrest.gif",
+              "mimeType": "image/gif",
+              "width": 172,
+              "height": 190,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of St. Leonards F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:StLeonardsCrest.gif",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: footballcrests.com"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:17.140Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "stafford rangers": {
@@ -72013,6 +83137,46 @@
             "length": 4
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Staffordfc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Stafford_Rangers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/88/Staffordfc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Staffordfc.png",
+              "fileTitle": "File:Staffordfc.png",
+              "mimeType": "image/png",
+              "width": 256,
+              "height": 256,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Stafford Rangers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Staffordfc.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.staffordrangersfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "weak",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted",
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T18:59:18.281Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "staines town": {
@@ -72225,6 +83389,11 @@
             "length": 12
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "stalybridge celtic": {
@@ -72464,6 +83633,44 @@
             "length": 65
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:StalybridgeCeltic.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Stalybridge_Celtic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c7/StalybridgeCeltic.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:StalybridgeCeltic.png",
+              "fileTitle": "File:StalybridgeCeltic.png",
+              "mimeType": "image/png",
+              "width": 291,
+              "height": 341,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Stalybridge Celtic F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:StalybridgeCeltic.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.stalybridgeceltic.com/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:20.398Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "stevenage": {
@@ -72692,6 +83899,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Stevenage_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Stevenage_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/49/Stevenage_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Stevenage_FC_crest.svg",
+              "fileTitle": "File:Stevenage FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Stevenage F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Stevenage_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/wiki/Fichier:Logo_Stevenage_FC_2019.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:21.542Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "stockport county": {
@@ -73230,6 +84475,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Stockport_County_FC_logo_2020.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Stockport_County_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/43/Stockport_County_FC_logo_2020.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Stockport_County_FC_logo_2020.svg",
+              "fileTitle": "File:Stockport County FC logo 2020.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Stockport County F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Stockport_County_FC_logo_2020.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: https://www.stockportcounty.com/ https://www.stockportcounty.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:22.665Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "stoke city": {
@@ -73772,6 +85055,41 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikipedia-pageimage-any:Stoke_City_FC_crest_2001.svg",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Stoke_City_FC_crest_2001.svg",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Stoke_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5e/Stoke_City_FC_crest_2001.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Stoke_City_FC_crest_2001.svg",
+              "fileTitle": "File:Stoke City FC crest 2001.svg",
+              "mimeType": "image/svg+xml",
+              "width": 292,
+              "height": 342,
+              "license": {
+                "shortName": "PD",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "https://fr.wikipedia.org/w/index.php?title=Fichier:Logo_Stoke_City_FC_2024.svg&lang=fr"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T18:59:23.817Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "stourbridge": {
@@ -73869,6 +85187,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Stourbridge_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Stourbridge_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e0/Stourbridge_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Stourbridge_F.C._logo.png",
+              "fileTitle": "File:Stourbridge F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Stourbridge F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Stourbridge_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "From official Twitter account: https://pbs.twimg.com/profile_images/476715371454406656/20ujBJSb_400x400.jpeg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:24.999Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "sudbury town": {
@@ -73983,6 +85339,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:AFC_Sudbury_Logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/A.F.C._Sudbury",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/49/AFC_Sudbury_Logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:AFC_Sudbury_Logo.png",
+              "fileTitle": "File:AFC Sudbury Logo.png",
+              "mimeType": "image/png",
+              "width": 323,
+              "height": 296,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of A.F.C. Sudbury",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:AFC_Sudbury_Logo.png",
+                "copyrighted": true,
+                "credit": "https://pbs.twimg.com/profile_images/961260580685402118/tRkOSDmD_400x400.jpg"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:26.125Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "sunderland": {
@@ -74491,6 +85885,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Logo_Sunderland.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Sunderland_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/77/Logo_Sunderland.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Logo_Sunderland.svg",
+              "fileTitle": "File:Logo Sunderland.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 250,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Sunderland A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Logo_Sunderland.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.safc.com/ http://www.safc.com/page/Home"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:27.254Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "sunderland albion": {
@@ -74589,6 +86021,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "sutton coldfield town": {
@@ -74674,6 +86111,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Sutton_Coldfield_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Sutton_Coldfield_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b1/Sutton_Coldfield_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Sutton_Coldfield_Town_FC_crest.svg",
+              "fileTitle": "File:Sutton Coldfield Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Sutton Coldfield Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Sutton_Coldfield_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/sutton-coldfield-town-fc-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:29.473Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "sutton united": {
@@ -74938,6 +86413,44 @@
             "length": 3
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Sutton_United_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Sutton_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/eb/Sutton_United_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Sutton_United_FC_crest.svg",
+              "fileTitle": "File:Sutton United FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 284,
+              "height": 353,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Sutton United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Sutton_United_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/wiki/Fichier:Logo_Sutton_United_FC.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:30.606Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "swansea city": {
@@ -75378,6 +86891,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Swansea_City_AFC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Swansea_City_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/f9/Swansea_City_AFC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Swansea_City_AFC_logo.svg",
+              "fileTitle": "File:Swansea City AFC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 310,
+              "height": 284,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Swansea City A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Swansea_City_AFC_logo.svg",
+                "copyrighted": true,
+                "credit": "https://www.swanseacity.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:31.673Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "swindon town": {
@@ -75792,6 +87343,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Swindon_Town_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Swindon_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/a3/Swindon_Town_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Swindon_Town_FC.svg",
+              "fileTitle": "File:Swindon Town FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 314,
+              "height": 318,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Swindon Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Swindon_Town_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.swindontownfc.co.uk Swindon Town FC Official Website & Vflnet.com"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:32.753Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "tamworth": {
@@ -76045,6 +87634,44 @@
             "length": 5
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Tamworth_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Tamworth_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/dd/Tamworth_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Tamworth_FC.svg",
+              "fileTitle": "File:Tamworth FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 279,
+              "height": 359,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Tamworth F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Tamworth_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Tamworth F.C. Official Website Converted to AI format by Johnny Beaufays (johnny.beaufays@vflnet.com) and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped the SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:33.900Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "taunton town": {
@@ -76162,6 +87789,44 @@
             "length": 40
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Taunton_Town_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Taunton_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c8/Taunton_Town_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Taunton_Town_logo.png",
+              "fileTitle": "File:Taunton Town logo.png",
+              "mimeType": "image/png",
+              "width": 314,
+              "height": 313,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Taunton Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Taunton_Town_logo.png",
+                "copyrighted": true,
+                "credit": "extracted from https://youth.tauntontown.com/documents/TTFC_Youth_Welcome_Pack_18-19.pdf"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:35.050Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "team bath": {
@@ -76260,6 +87925,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "telford united": {
@@ -76465,6 +88135,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:AFC_Telford_United_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/AFC_Telford_United",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e9/AFC_Telford_United_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:AFC_Telford_United_logo.svg",
+              "fileTitle": "File:AFC Telford United logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 203,
+              "height": 493,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of AFC Telford United",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:AFC_Telford_United_logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/afc-telford-united/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:37.326Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "thames": {
@@ -76566,6 +88274,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "thurrock": {
@@ -76770,6 +88483,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Thurrock_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Thurrock_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/31/Thurrock_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Thurrock_FC.svg",
+              "fileTitle": "File:Thurrock FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 306,
+              "height": 327,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Thurrock F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Thurrock_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Thurrock F.C. Official Website Converted to AI format by Vflnet.com and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped to SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:39.496Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "tilbury": {
@@ -76855,6 +88606,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Tilbury_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Tilbury_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5f/Tilbury_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Tilbury_F.C._logo.png",
+              "fileTitle": "File:Tilbury F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 282,
+              "height": 277,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Tilbury F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Tilbury_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "http://images.pitchero.com/ui/109569/1299624497_2.jpeg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:40.592Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "tiverton town": {
@@ -76946,6 +88735,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:TivertonTown.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Tiverton_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/ec/TivertonTown.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:TivertonTown.png",
+              "fileTitle": "File:TivertonTown.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Tiverton Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:TivertonTown.png",
+                "copyrighted": true,
+                "credit": "http://www.weltfussballarchiv.com/Vereinsprofilnew.php?ID=9933"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:41.771Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "tonbridge angels": {
@@ -77151,6 +88978,44 @@
             "length": 5
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Tonbridge_Angels_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Tonbridge_Angels_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9e/Tonbridge_Angels_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Tonbridge_Angels_FC_crest.svg",
+              "fileTitle": "File:Tonbridge Angels FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 118,
+              "height": 123,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Tonbridge Angels F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Tonbridge_Angels_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/503323/tonbridge-angels-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:42.873Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "tooting and mitcham united": {
@@ -77263,6 +89128,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Tooting&Mitcham.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Tooting_%26_Mitcham_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c7/Tooting%26Mitcham.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Tooting%26Mitcham.png",
+              "fileTitle": "File:Tooting&Mitcham.png",
+              "mimeType": "image/png",
+              "width": 299,
+              "height": 299,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Tooting & Mitcham United FC",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Tooting%26Mitcham.png",
+                "copyrighted": true,
+                "credit": "http://www.tmunited.org"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:43.976Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "torquay united": {
@@ -77656,6 +89559,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Torquay_United_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Torquay_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2a/Torquay_United_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Torquay_United_FC_crest.svg",
+              "fileTitle": "File:Torquay United FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 299,
+              "height": 334,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Torquay United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Torquay_United_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://worthingfc.com/results/men/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:45.169Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "tottenham hotspur": {
@@ -78104,6 +90045,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Tottenham_Hotspur.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Tottenham_Hotspur_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b4/Tottenham_Hotspur.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Tottenham_Hotspur.svg",
+              "fileTitle": "File:Tottenham Hotspur.svg",
+              "mimeType": "image/svg+xml",
+              "width": 115,
+              "height": 236,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Tottenham Hotspur F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Tottenham_Hotspur.svg",
+                "copyrighted": true,
+                "credit": "Tottenham Hotspur Brand Identity and Style Guide"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T18:59:46.258Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "tranmere rovers": {
@@ -78516,6 +90495,11 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "trowbridge town": {
@@ -78656,6 +90640,11 @@
             "length": 6
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "truro city": {
@@ -78851,6 +90840,44 @@
             "length": 4
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Truro_City_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Truro_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/00/Truro_City_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Truro_City_FC_crest.svg",
+              "fileTitle": "File:Truro City FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 261,
+              "height": 261,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Truro City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Truro_City_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://trurocity.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:01.453Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "vauxhall motors": {
@@ -78972,6 +90999,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Vauxhall_Motors_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Vauxhall_Motors_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/aa/Vauxhall_Motors_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Vauxhall_Motors_F.C._logo.png",
+              "fileTitle": "File:Vauxhall Motors F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 315,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Vauxhall Motors F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Vauxhall_Motors_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "Official Website: http://www.pitchero.com/clubs/vauxhallmotorsfc/a/community-40148.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:02.607Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "walsall": {
@@ -79515,6 +91580,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Walsall_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Walsall_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/ef/Walsall_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Walsall_FC.svg",
+              "fileTitle": "File:Walsall FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 315,
+              "height": 317,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Walsall F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Walsall_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Walsall F.C. Official Website Converted to AI format by Vflnet.com and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped the SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:03.698Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "walthamstow avenue": {
@@ -79655,6 +91758,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "walton and hersham": {
@@ -79772,6 +91880,44 @@
             "length": 1
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Walton_&_Hersham_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Walton_%26_Hersham_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/22/Walton_%26_Hersham_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Walton_%26_Hersham_FC_crest.svg",
+              "fileTitle": "File:Walton & Hersham FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 264,
+              "height": 379,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Walton & Hersham F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Walton_%26_Hersham_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://waltonhershamfc.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:05.807Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "warrington town": {
@@ -79860,6 +92006,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Warrington_Town_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Warrington_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/47/Warrington_Town_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Warrington_Town_F.C._logo.png",
+              "fileTitle": "File:Warrington Town F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 280,
+              "height": 356,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Warrington Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Warrington_Town_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "From official Twitter account: https://pbs.twimg.com/profile_images/493820251780313089/m1j3tHbR.jpeg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:06.940Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "waterlooville": {
@@ -80036,6 +92220,44 @@
             "length": 5
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Havant_&_Waterlooville_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Havant_%26_Waterlooville_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/4e/Havant_%26_Waterlooville_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Havant_%26_Waterlooville_FC_crest.svg",
+              "fileTitle": "File:Havant & Waterlooville FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Havant & Waterlooville F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Havant_%26_Waterlooville_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://havantandwaterloovillefc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:08.082Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "watford": {
@@ -80450,6 +92672,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Watford.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Watford_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e2/Watford.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Watford.svg",
+              "fileTitle": "File:Watford.svg",
+              "mimeType": "image/svg+xml",
+              "width": 299,
+              "height": 334,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Watford F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Watford.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Watford F.C.."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:09.234Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "wealdstone": {
@@ -80620,6 +92880,44 @@
             "length": 22
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Wealdstone_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Wealdstone_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/dc/Wealdstone_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Wealdstone_FC_crest.svg",
+              "fileTitle": "File:Wealdstone FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 315,
+              "height": 317,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Wealdstone F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Wealdstone_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/national-league/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:10.486Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "welling united": {
@@ -80842,6 +93140,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:WellingUnitedBadge.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Welling_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c6/WellingUnitedBadge.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:WellingUnitedBadge.png",
+              "fileTitle": "File:WellingUnitedBadge.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Welling United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:WellingUnitedBadge.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.wellingunited.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:11.636Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "wellingborough town": {
@@ -80958,6 +93294,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Wellingborough_Town_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Wellingborough_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/52/Wellingborough_Town_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Wellingborough_Town_logo.png",
+              "fileTitle": "File:Wellingborough Town logo.png",
+              "mimeType": "image/png",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Wellingborough Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Wellingborough_Town_logo.png",
+                "copyrighted": true,
+                "credit": "http://www.swindon-town-fc.co.uk/images/Badges/3D/180/BadgeWellingborough_Town.png"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:12.715Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "west bromwich albion": {
@@ -81474,6 +93848,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:West_Bromwich_Albion.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/West_Bromwich_Albion_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/8b/West_Bromwich_Albion.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:West_Bromwich_Albion.svg",
+              "fileTitle": "File:West Bromwich Albion.svg",
+              "mimeType": "image/svg+xml",
+              "width": 289,
+              "height": 346,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of West Bromwich Albion F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:West_Bromwich_Albion.svg",
+                "copyrighted": true,
+                "credit": "West Bromwich Albion F.C. Official Website"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:13.991Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "west ham united": {
@@ -81876,6 +94288,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:West_Ham_United_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/West_Ham_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c2/West_Ham_United_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:West_Ham_United_FC_logo.svg",
+              "fileTitle": "File:West Ham United FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 169,
+              "height": 188,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of West Ham United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:West_Ham_United_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "Extracted from .mw-parser-output cite.citation{font-style:inherit;word-wrap:break-word}.mw-parser-output .citation q{quotes:\"\\\"\"\"\\\"\"\"'\"\"'\"}.mw-parser-output .citation:target{background-color:rgba(0,127,255,0.133)}.mw-parser-output .id-lock-free.id-lock-free a{background:url(\"//upload.wikimedia.org/wikipedia/commons/6/65/Lock-green.svg\")right 0.1em center/9px no-repeat}.mw-parser-output .id-lock-limited.id-lock-limited a,.mw-parser-output .id-lock-registration.id-lock-registration a{background:url(\"//upload.wikimedia.org/wikipedia/commons/d/d6/Lock-gray-alt-2.svg\")right 0.1em center/9px no-repeat}.mw-parser-output .id-lock-subscription.id-lock-subscription a{background:url(\"//upload.wikimedia.org/wikipedia/commons/a/aa/Lock-red-alt-2.svg\")right 0.1em center/9px no-repeat}.mw-parser-output .cs1-ws-icon a{background:url(\"//upload.wikimedia.org/wikipedia/commons/4/4c/Wikisource-logo.svg\")right 0.1em center/12px no-repeat}body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-free a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-limited a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-registration a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .id-lock-subscription a,body:not(.skin-timeless):not(.skin-minerva) .mw-parser-output .cs1-ws-icon a{background-size:contain;padding:0 1em 0 0}.mw-parser-output .cs1-code{color:inherit;background:inherit;border:none;padding:inherit}.mw-parser-output .cs1-hidden-error{display:none;color:var(--color-error,#bf3c2c)}.mw-parser-output .cs1-visible-error{color:var(--color-error,#bf3c2c)}.mw-parser-output .cs1-maint{display:none;color:#085;margin-left:0.3em}.mw-parser-output .cs1-kern-left{padding-left:0.2em}.mw-parser-output .cs1-kern-right{padding-right:0.2em}.mw-parser-output .citation .mw-selflink{font-weight:inherit}@media screen{.mw-parser-output .cs1-format{font-size:95%}html.skin-theme-clientpref-night .mw-parser-output .cs1-maint{color:#18911f}}@media screen and (prefers-color-scheme:dark){html.skin-theme-clientpref-os .mw-parser-output .cs1-maint{color:#18911f}} \"We will always be West Ham United\" (PDF) . West Ham United F.C. Archived from the original (PDF) on 28 January 2015 . Retrieved 5 April 2015 ."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:15.247Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "weston-super-mare": {
@@ -82048,6 +94498,44 @@
             "length": 4
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Weston-super-Mare_AFC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Weston-super-Mare_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/bc/Weston-super-Mare_AFC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Weston-super-Mare_AFC_logo.svg",
+              "fileTitle": "File:Weston-super-Mare AFC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 202,
+              "height": 235,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Weston-super-Mare A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Weston-super-Mare_AFC_logo.svg",
+                "copyrighted": true,
+                "credit": "https://media.touchlinefc.co.uk/hq/2023/07/13171643/wsmafc.svg?class=thumbnail"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:16.449Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "weymouth": {
@@ -82318,6 +94806,44 @@
             "length": 9
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Weymouth_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Weymouth_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/08/Weymouth_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Weymouth_F.C._logo.png",
+              "fileTitle": "File:Weymouth F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 256,
+              "height": 256,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Weymouth F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Weymouth_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "https://pbs.twimg.com/profile_images/473435422480035840/EUce9K1L_400x400.png"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:17.669Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "whitby town": {
@@ -82418,6 +94944,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "whitehawk": {
@@ -82515,6 +95046,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Whitehawk_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Whitehawk_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/0c/Whitehawk_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Whitehawk_F.C._logo.svg",
+              "fileTitle": "File:Whitehawk F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 317,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Whitehawk F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Whitehawk_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/whitehawk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:19.864Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "whitley bay": {
@@ -82609,6 +95178,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Whitley_Bay_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Whitley_Bay_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/9d/Whitley_Bay_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Whitley_Bay_FC_logo.svg",
+              "fileTitle": "File:Whitley Bay FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 179,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Whitley Bay F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Whitley_Bay_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "http://whitleybayfc.com/information/club-info/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:20.991Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "wigan athletic": {
@@ -82856,6 +95463,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Wigan_Athletic.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Wigan_Athletic_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/43/Wigan_Athletic.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Wigan_Athletic.svg",
+              "fileTitle": "File:Wigan Athletic.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Wigan Athletic F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Wigan_Athletic.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.wiganathletic.com/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:22.113Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "wigan borough": {
@@ -83009,6 +95654,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Wigan_Borough_FC_crest.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Wigan_Borough_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/52/Wigan_Borough_FC_crest.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Wigan_Borough_FC_crest.png",
+              "fileTitle": "File:Wigan Borough FC crest.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Wigan Borough F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Wigan_Borough_FC_crest.png",
+                "copyrighted": true,
+                "credit": "https://www.thesportsdb.com/team/139950-Wigan-Borough-FC"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:23.276Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "willenhall town": {
@@ -83103,6 +95786,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:WillenhallTownLogo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Willenhall_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/0e/WillenhallTownLogo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:WillenhallTownLogo.png",
+              "fileTitle": "File:WillenhallTownLogo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Willenhall Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:WillenhallTownLogo.png",
+                "copyrighted": true,
+                "credit": "https://twitter.com/wtfcofficial"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:24.638Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "wimbledon": {
@@ -83368,6 +96089,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:AFC_Wimbledon_(2020)_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/AFC_Wimbledon",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/1b/AFC_Wimbledon_%282020%29_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:AFC_Wimbledon_(2020)_logo.svg",
+              "fileTitle": "File:AFC Wimbledon (2020) logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 156,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of AFC Wimbledon",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:AFC_Wimbledon_(2020)_logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from AFC Wimbledon."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:25.802Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "windsor and eton": {
@@ -83515,6 +96274,45 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Windsorandetonfc.jpg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Windsor_%26_Eton_F.C._(1892)",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/cf/Windsorandetonfc.jpg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Windsorandetonfc.jpg",
+              "fileTitle": "File:Windsorandetonfc.jpg",
+              "mimeType": "image/jpeg",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Windsor & Eton F.C. (1892)",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Windsorandetonfc.jpg",
+                "copyrighted": true,
+                "credit": "http://www.wefc.co.uk/images/badges/windsor_eton.jpg"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:00:26.977Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "winsford united": {
@@ -83621,6 +96419,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Winsford_United_Crest.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Winsford_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/1/1b/Winsford_United_Crest.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Winsford_United_Crest.png",
+              "fileTitle": "File:Winsford United Crest.png",
+              "mimeType": "image/png",
+              "width": 166,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Winsford United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Winsford_United_Crest.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.winsfordunitedfc.co.uk"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:28.103Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "witney town": {
@@ -83791,6 +96627,11 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "missing"
+        }
       }
     },
     "witton albion": {
@@ -83935,6 +96776,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Wittonalbionfc.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Witton_Albion_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/84/Wittonalbionfc.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Wittonalbionfc.png",
+              "fileTitle": "File:Wittonalbionfc.png",
+              "mimeType": "image/png",
+              "width": 198,
+              "height": 241,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Witton Albion F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Wittonalbionfc.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.wittonalbion.co.uk/ http://www.wittonalbion.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:30.315Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "wivenhoe town": {
@@ -84029,6 +96908,77 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Wivenhoe_Town_F.C._logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Wivenhoe_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/ac/Wivenhoe_Town_F.C._logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Wivenhoe_Town_F.C._logo.png",
+              "fileTitle": "File:Wivenhoe Town F.C. logo.png",
+              "mimeType": "image/png",
+              "width": 265,
+              "height": 376,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Wivenhoe Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Wivenhoe_Town_F.C._logo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.pitchero.com/clubs/wivenhoetownfc/ http://www.weltfussballarchiv.com/club_profile.php?ID=24106"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:31.440Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:BroadLaneWivenhoeTown21Jan2017.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Wivenhoe_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/8/8f/BroadLaneWivenhoeTown21Jan2017.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:BroadLaneWivenhoeTown21Jan2017.jpg",
+              "fileTitle": "File:BroadLaneWivenhoeTown21Jan2017.jpg",
+              "mimeType": "image/jpeg",
+              "width": 480,
+              "height": 360,
+              "license": {
+                "shortName": "CC BY-SA 4.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
+                "copyrighted": true,
+                "attribution": "BarnabyJoe at English Wikipedia",
+                "credit": "No machine-readable source provided. Own work assumed (based on copyright claims).",
+                "artist": "BarnabyJoe"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:00:31.440Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "woking": {
@@ -84243,6 +97193,74 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "preferred": "wikidata-logo:Logowoking.png",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikidata-logo:Logowoking.png",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikidata-logo",
+              "sourceUrl": "https://www.wikidata.org/wiki/Q18528",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Logowoking.png",
+              "fileTitle": "File:Logowoking.png",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0f/Logowoking.png",
+              "mimeType": "image/png",
+              "width": 200,
+              "height": 250,
+              "license": {
+                "shortName": "CC BY-SA 3.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "R bert"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T19:00:32.666Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-any:Woking_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Woking_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/de/Woking_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Woking_FC_logo.svg",
+              "fileTitle": "File:Woking FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Woking F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Woking_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "de:Datei:Woking FC.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:32.666Z"
+              },
+              "priority": 2
+            }
+          ]
+        }
       }
     },
     "wokingham town": {
@@ -84389,6 +97407,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Wokingham_Emmbrook_Logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Wokingham_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c2/Wokingham_Emmbrook_Logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Wokingham_Emmbrook_Logo.png",
+              "fileTitle": "File:Wokingham Emmbrook Logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Wokingham & Emmbrook F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Wokingham_Emmbrook_Logo.png",
+                "copyrighted": true,
+                "credit": "original gif file https://en.wikipedia.org/wiki/File:Wokingham_%26_Emmbrook_F.C._logo.gif"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:33.875Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "wolverhampton wanderers": {
@@ -84914,6 +97970,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Wolverhampton_Wanderers_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Wolverhampton_Wanderers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c9/Wolverhampton_Wanderers_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Wolverhampton_Wanderers_FC_crest.svg",
+              "fileTitle": "File:Wolverhampton Wanderers FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 340,
+              "height": 294,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Wolverhampton Wanderers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Wolverhampton_Wanderers_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/premier-league/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:35.057Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "worcester city": {
@@ -85118,6 +98212,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Worcester_City_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Worcester_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/32/Worcester_City_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Worcester_City_FC_crest.svg",
+              "fileTitle": "File:Worcester City FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Worcester City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Worcester_City_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.brandsoftheworld.com/logo/worcester-city-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:36.225Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "workington": {
@@ -85414,6 +98546,44 @@
             "length": 17
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Workington_AFC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Workington_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/fe/Workington_AFC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Workington_AFC_crest.svg",
+              "fileTitle": "File:Workington AFC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 310,
+              "height": 323,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Workington A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Workington_AFC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/513221/workington-afc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:37.366Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "worksop town": {
@@ -85607,6 +98777,44 @@
             "length": 18
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Worksop_Town_FC_updated_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Worksop_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5f/Worksop_Town_FC_updated_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Worksop_Town_FC_updated_crest.svg",
+              "fileTitle": "File:Worksop Town FC updated crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Worksop Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Worksop_Town_FC_updated_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/505809/worksop-town-fc"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:38.501Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "worthing": {
@@ -85738,6 +98946,44 @@
             "length": 26
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Worthing_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Worthing_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/88/Worthing_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Worthing_FC_crest.svg",
+              "fileTitle": "File:Worthing FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 150,
+              "height": 150,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Worthing F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Worthing_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://worthingfc.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:39.817Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "wrexham": {
@@ -86149,6 +99395,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Wrexham_A.F.C._Logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Wrexham_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/0d/Wrexham_A.F.C._Logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Wrexham_A.F.C._Logo.svg",
+              "fileTitle": "File:Wrexham A.F.C. Logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 272,
+              "height": 368,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Wrexham A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Wrexham_A.F.C._Logo.svg",
+                "copyrighted": true,
+                "credit": "Wrexham AFC"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:40.915Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "wycombe wanderers": {
@@ -86388,6 +99672,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Wycombe_Wanderers_FC_logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Wycombe_Wanderers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/f/fb/Wycombe_Wanderers_FC_logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Wycombe_Wanderers_FC_logo.svg",
+              "fileTitle": "File:Wycombe Wanderers FC logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Wycombe Wanderers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Wycombe_Wanderers_FC_logo.svg",
+                "copyrighted": true,
+                "credit": "Extracted from http://www.johnstonespainttrophy.com/documents/31/original/12437-spon_johnstones_football_colour_card_2011_2012_low_res_v1.pdf"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:42.093Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "yeading": {
@@ -86544,6 +99866,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hayes_&_Yeading_United_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hayes_%26_Yeading_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/3/36/Hayes_%26_Yeading_United_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hayes_%26_Yeading_United_FC.svg",
+              "fileTitle": "File:Hayes & Yeading United FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 305,
+              "height": 328,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hayes & Yeading United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hayes_%26_Yeading_United_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Hayes & Yeading United F.C. Official Website Converted to AI format by Johnny Beaufays (johnny.beaufays@vflnet.com) and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped to SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:43.241Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "yeovil town": {
@@ -86783,6 +100143,44 @@
             ]
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Yeovil_Town_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Yeovil_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5c/Yeovil_Town_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Yeovil_Town_FC_crest.svg",
+              "fileTitle": "File:Yeovil Town FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 297,
+              "height": 337,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Yeovil Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Yeovil_Town_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://en.namu.wiki/w/%EC%9A%94%EB%B9%8C%20%ED%83%80%EC%9A%B4%20FC"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:44.366Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     },
     "york city": {
@@ -87178,6 +100576,44 @@
             "length": 7
           }
         ]
+      },
+      "assets": {
+        "crest": {
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:York_City_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/York_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/7/71/York_City_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:York_City_FC.svg",
+              "fileTitle": "File:York City FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 256,
+              "height": 390,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of York City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:York_City_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: York City F.C. Official Website Converted to AI format by Johnny Beaufays (johnny.beaufays@vflnet.com) and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped the SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:00:45.564Z"
+              },
+              "priority": 1
+            }
+          ]
+        }
       }
     }
   }

--- a/data/club-metadata.json
+++ b/data/club-metadata.json
@@ -2,8 +2,8 @@
   "metadata": {
     "schemaVersion": 1,
     "generator": "club-assets",
-    "generatedAt": "2026-06-20T19:11:05.502Z",
-    "gitSha": "afe2785",
+    "generatedAt": "2026-06-20T19:31:27.723Z",
+    "gitSha": "e0edd04",
     "sourceFiles": [
       "/Users/dsteele/repos/footy-data-kit/data-output/all-seasons.json",
       "/Users/dsteele/repos/footy-data-kit-club-assets/data/club-metadata.json"
@@ -12,10 +12,11 @@
       "input": "./data/club-metadata.json",
       "limit": 5,
       "clubLimit": null,
+      "clubKeys": null,
       "cache": true,
       "refreshAssets": false,
       "requestDelayMs": 0,
-      "inputGenerator": "club-metadata-seed"
+      "inputGenerator": "club-assets"
     }
   },
   "clubs": {
@@ -261,7 +262,43 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Crown_Ground_sign-geograph-1761360.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Accrington",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/9/9a/Crown_Ground_sign-geograph-1761360.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Crown_Ground_sign-geograph-1761360.jpg",
+              "fileTitle": "File:Crown Ground sign-geograph-1761360.jpg",
+              "mimeType": "image/jpeg",
+              "width": 1632,
+              "height": 1224,
+              "license": {
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
+                "copyrighted": true,
+                "attribution": "robert wade",
+                "credit": "From geograph.org.uk",
+                "artist": "robert wade"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:30:53.942Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -798,8 +835,39 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
+          "status": "restricted",
           "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Accrington_Stanley_F.C._logo.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Accrington_Stanley_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/ba/Accrington_Stanley_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Accrington_Stanley_F.C._logo.svg",
+              "fileTitle": "File:Accrington Stanley F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 200,
+              "height": 200,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Accrington Stanley F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Accrington_Stanley_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Accrington Stanley F.C.."
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:24:44.226Z"
+              },
+              "priority": 1
+            },
             {
               "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
               "kind": "crest",
@@ -829,9 +897,9 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:52:16.522Z"
+                "checkedAt": "2026-06-20T19:24:44.226Z"
               },
-              "priority": 1
+              "priority": 2
             }
           ]
         }
@@ -997,7 +1065,42 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:St_Paul,_Addlestone_-_geograph.org.uk_-_1517212.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Addlestone",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/f/fc/St_Paul%2C_Addlestone_-_geograph.org.uk_-_1517212.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:St_Paul,_Addlestone_-_geograph.org.uk_-_1517212.jpg",
+              "fileTitle": "File:St Paul, Addlestone - geograph.org.uk - 1517212.jpg",
+              "mimeType": "image/jpeg",
+              "width": 640,
+              "height": 414,
+              "license": {
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
+                "copyrighted": true,
+                "attribution": "Michael FORD",
+                "credit": "From geograph.org.uk",
+                "artist": "Michael FORD"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:30:55.586Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -1612,7 +1715,40 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:AFC_Fylde_(2014).svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/AFC_Fylde",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/ab/AFC_Fylde_%282014%29.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:AFC_Fylde_(2014).svg",
+              "fileTitle": "File:AFC Fylde (2014).svg",
+              "mimeType": "image/svg+xml",
+              "width": 333,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of A.F.C. Fylde",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:AFC_Fylde_(2014).svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.afcfylde.co.uk http://www.afcfylde.co.uk/fixtures/Fixtures.pdf"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:24:49.940Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -1934,7 +2070,40 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:AFC_Totton_2024_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/A.F.C._Totton",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/81/AFC_Totton_2024_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:AFC_Totton_2024_crest.svg",
+              "fileTitle": "File:AFC Totton 2024 crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 274,
+              "height": 366,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of A.F.C. Totton",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:AFC_Totton_2024_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.afctotton.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:24:51.683Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -3250,9 +3419,41 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:52:27.246Z"
+                "checkedAt": "2026-06-20T19:24:53.566Z"
               },
               "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Altrincham_Town_Square_-_2024.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Altrincham",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/1/10/Altrincham_Town_Square_-_2024.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Altrincham_Town_Square_-_2024.jpg",
+              "fileTitle": "File:Altrincham Town Square - 2024.jpg",
+              "mimeType": "image/jpeg",
+              "width": 4032,
+              "height": 3024,
+              "license": {
+                "shortName": "CC0",
+                "usageTerms": "Creative Commons Zero, Public Domain Dedication",
+                "licenseUrl": "http://creativecommons.org/publicdomain/zero/1.0/deed.en",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Doomdorm64"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:24:53.566Z"
+              },
+              "priority": 2
             },
             {
               "assetId": "wikipedia-pageimage-free:Exeter_City_match.JPG",
@@ -3281,9 +3482,9 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:52:27.246Z"
+                "checkedAt": "2026-06-20T19:24:53.566Z"
               },
-              "priority": 2
+              "priority": 3
             }
           ]
         }
@@ -5408,7 +5609,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:52:36.150Z"
+                "checkedAt": "2026-06-20T19:24:56.690Z"
               },
               "priority": 1
             },
@@ -5441,7 +5642,7 @@
                 "reviewReasons": [
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:52:36.150Z"
+                "checkedAt": "2026-06-20T19:24:56.690Z"
               },
               "priority": 2
             }
@@ -10148,7 +10349,41 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Bishop_Auckland_Town_Hall.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bishop_Auckland",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/29/Bishop_Auckland_Town_Hall.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Bishop_Auckland_Town_Hall.jpg",
+              "fileTitle": "File:Bishop Auckland Town Hall.jpg",
+              "mimeType": "image/jpeg",
+              "width": 1600,
+              "height": 1200,
+              "license": {
+                "shortName": "CC BY-SA 3.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
+                "licenseUrl": "http://creativecommons.org/licenses/by-sa/3.0/",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Pit-yacker"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:30:58.291Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -12784,7 +13019,73 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Bootle_FC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bootle_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/6c/Bootle_FC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Bootle_FC_logo.png",
+              "fileTitle": "File:Bootle FC logo.png",
+              "mimeType": "image/png",
+              "width": 180,
+              "height": 180,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Bootle F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Bootle_FC_logo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.bootlefc.co.uk/index.php http://www.bootlefc.co.uk/news/details.php?news_id=3637"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:25:02.484Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Bootle_Town_Hall_2020-1.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bootle",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/d/dd/Bootle_Town_Hall_2020-1.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Bootle_Town_Hall_2020-1.jpg",
+              "fileTitle": "File:Bootle Town Hall 2020-1.jpg",
+              "mimeType": "image/jpeg",
+              "width": 3188,
+              "height": 4830,
+              "license": {
+                "shortName": "CC BY-SA 4.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
+                "copyrighted": true,
+                "attribution": "By Phil Nash from Wikimedia Commons CC BY-SA 4.0 & GFDL Views",
+                "credit": "Own work",
+                "artist": "Rodhullandemu"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:25:02.484Z"
+              },
+              "priority": 2
+            }
+          ]
         }
       }
     },
@@ -17187,9 +17488,42 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:53:22.179Z"
+                "checkedAt": "2026-06-20T19:25:04.399Z"
               },
               "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Bromley_-_geograph.org.uk_-_4623007.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Bromley",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/c7/Bromley_-_geograph.org.uk_-_4623007.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Bromley_-_geograph.org.uk_-_4623007.jpg",
+              "fileTitle": "File:Bromley - geograph.org.uk - 4623007.jpg",
+              "mimeType": "image/jpeg",
+              "width": 4000,
+              "height": 2666,
+              "license": {
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
+                "copyrighted": true,
+                "attribution": "Bromley by Peter Trimming",
+                "credit": "Geograph Britain and Ireland",
+                "artist": "Peter Trimming"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:25:04.399Z"
+              },
+              "priority": 2
             },
             {
               "assetId": "wikipedia-pageimage-free:Bromley_FC_League_Performance.svg",
@@ -17219,9 +17553,9 @@
                 "reviewReasons": [
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:53:22.179Z"
+                "checkedAt": "2026-06-20T19:25:04.399Z"
               },
-              "priority": 2
+              "priority": 3
             }
           ]
         }
@@ -23217,26 +23551,36 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
+          "status": "restricted",
           "candidates": [
             {
               "assetId": "wikipedia-pageimage-any:Cheltenham_Town_F.C._logo.svg",
               "kind": "crest",
-              "status": "needs-review",
+              "status": "restricted",
               "source": "wikipedia-pageimage-any",
               "sourceUrl": "https://en.wikipedia.org/wiki/Cheltenham_Town_F.C.",
               "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/c3/Cheltenham_Town_F.C._logo.svg",
-              "pageUrl": "https://en.wikipedia.org/wiki/File%3ACheltenham_Town_F.C._logo.svg",
-              "fileTitle": "File:Cheltenham_Town_F.C._logo.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Cheltenham_Town_F.C._logo.svg",
+              "fileTitle": "File:Cheltenham Town F.C. logo.svg",
+              "mimeType": "image/svg+xml",
+              "width": 296,
+              "height": 337,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Cheltenham Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Cheltenham_Town_F.C._logo.svg",
+                "copyrighted": true,
+                "credit": "http://logos.wikia.com/wiki/File:Cheltenham_Town_FC_logo.svg"
+              },
               "verification": {
                 "identityMatch": "strong",
-                "licenseCheck": "unknown",
+                "licenseCheck": "restricted",
                 "httpCheck": "pass",
                 "needsManualReview": true,
                 "reviewReasons": [
-                  "license-unknown"
+                  "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:53:45.521Z"
+                "checkedAt": "2026-06-20T19:30:59.985Z"
               },
               "priority": 1
             }
@@ -23333,7 +23677,40 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Chertsey_Town_FC_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Chertsey_Town_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/d/d3/Chertsey_Town_FC_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Chertsey_Town_FC_logo.png",
+              "fileTitle": "File:Chertsey Town FC logo.png",
+              "mimeType": "image/png",
+              "width": 293,
+              "height": 340,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Chertsey Town F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Chertsey_Town_FC_logo.png",
+                "copyrighted": true,
+                "credit": "https://chertseytownfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:25:20.892Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -24235,8 +24612,102 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
+          "status": "restricted",
           "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Chester_City_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Chester_City_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/4b/Chester_City_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Chester_City_FC.svg",
+              "fileTitle": "File:Chester City FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 318,
+              "height": 314,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Chester City F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Chester_City_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Chester City F.C. Official Website Converted to AI format by Vflnet.com and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped the SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:25:22.881Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-any:Chester-fc.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Chester_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/c/cb/Chester-fc.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Chester-fc.svg",
+              "fileTitle": "File:Chester-fc.svg",
+              "mimeType": "image/svg+xml",
+              "width": 317,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Chester F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Chester-fc.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.chesterfc.com"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:25:22.881Z"
+              },
+              "priority": 2
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Chester_-_Shops_in_city_centre_-_2005-10-09.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Chester",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b9/Chester_-_Shops_in_city_centre_-_2005-10-09.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Chester_-_Shops_in_city_centre_-_2005-10-09.jpg",
+              "fileTitle": "File:Chester - Shops in city centre - 2005-10-09.jpg",
+              "mimeType": "image/jpeg",
+              "width": 2016,
+              "height": 1512,
+              "license": {
+                "shortName": "CC BY-SA 3.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
+                "licenseUrl": "http://creativecommons.org/licenses/by-sa/3.0/",
+                "copyrighted": true,
+                "credit": "No machine-readable source provided. Own work assumed (based on copyright claims).",
+                "artist": "No machine-readable author provided. Tagishsimon assumed (based on copyright claims)."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:25:22.881Z"
+              },
+              "priority": 3
+            },
             {
               "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
               "kind": "crest",
@@ -24266,9 +24737,9 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:54:03.877Z"
+                "checkedAt": "2026-06-20T19:25:22.881Z"
               },
-              "priority": 1
+              "priority": 4
             }
           ]
         }
@@ -25418,7 +25889,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:54:09.451Z"
+                "checkedAt": "2026-06-20T19:25:25.494Z"
               },
               "priority": 1
             },
@@ -25450,7 +25921,7 @@
                 "reviewReasons": [
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:54:09.451Z"
+                "checkedAt": "2026-06-20T19:25:25.494Z"
               },
               "priority": 2
             }
@@ -28739,7 +29210,41 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Beam_valley_park_and_turbine_1.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dagenham",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/c3/Beam_valley_park_and_turbine_1.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Beam_valley_park_and_turbine_1.jpg",
+              "fileTitle": "File:Beam valley park and turbine 1.jpg",
+              "mimeType": "image/jpeg",
+              "width": 1024,
+              "height": 768,
+              "license": {
+                "shortName": "Public domain",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "Transferred from en.wikipedia to Commons by Teratornis using CommonsHelper .",
+                "artist": "MRSC at English Wikipedia"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:31:01.700Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -29619,8 +30124,72 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
+          "status": "restricted",
           "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Darlington_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Darlington_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/a/ad/Darlington_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Darlington_FC_crest.svg",
+              "fileTitle": "File:Darlington FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 277,
+              "height": 361,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Darlington F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Darlington_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://fr.wikipedia.org/wiki/Fichier:Logo_Darlington_FC_1883.svg"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:25:28.812Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Darlington_clock_tower_and_market_hall_(geograph_6299652).jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Darlington",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/c/c1/Darlington_clock_tower_and_market_hall_%28geograph_6299652%29.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Darlington_clock_tower_and_market_hall_(geograph_6299652).jpg",
+              "fileTitle": "File:Darlington clock tower and market hall (geograph 6299652).jpg",
+              "mimeType": "image/jpeg",
+              "width": 640,
+              "height": 480,
+              "license": {
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
+                "copyrighted": true,
+                "attribution": "Graham Hogg",
+                "credit": "From geograph.org.uk",
+                "artist": "Graham Hogg"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:25:28.812Z"
+              },
+              "priority": 2
+            },
             {
               "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
               "kind": "crest",
@@ -29650,9 +30219,9 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:54:26.648Z"
+                "checkedAt": "2026-06-20T19:25:28.812Z"
               },
-              "priority": 1
+              "priority": 3
             }
           ]
         }
@@ -32949,9 +33518,73 @@
                   "license-restricted",
                   "identity-uncertain"
                 ],
-                "checkedAt": "2026-06-20T18:54:41.545Z"
+                "checkedAt": "2026-06-20T19:25:31.633Z"
               },
               "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-any:Dunstable_FC.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dunstable_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5c/Dunstable_FC.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Dunstable_FC.png",
+              "fileTitle": "File:Dunstable FC.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Dunstable F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Dunstable_FC.png",
+                "copyrighted": true,
+                "credit": "Club X account"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:25:31.633Z"
+              },
+              "priority": 2
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:High_Street_Dunstable_-_geograph.org.uk_-_6524692.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Dunstable",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/f/fa/High_Street_Dunstable_-_geograph.org.uk_-_6524692.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:High_Street_Dunstable_-_geograph.org.uk_-_6524692.jpg",
+              "fileTitle": "File:High Street Dunstable - geograph.org.uk - 6524692.jpg",
+              "mimeType": "image/jpeg",
+              "width": 1884,
+              "height": 1224,
+              "license": {
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
+                "copyrighted": true,
+                "attribution": "High Street Dunstable by David Howard",
+                "credit": "Geograph Britain and Ireland",
+                "artist": "David Howard"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:25:31.633Z"
+              },
+              "priority": 3
             }
           ]
         }
@@ -33588,7 +34221,72 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Eastleigh_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Eastleigh_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5c/Eastleigh_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Eastleigh_FC_crest.svg",
+              "fileTitle": "File:Eastleigh FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 333,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Eastleigh F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Eastleigh_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/national-league/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:25:34.240Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Old_Town_Hall_Eastleigh.JPG",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Eastleigh",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/27/Old_Town_Hall_Eastleigh.JPG",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Old_Town_Hall_Eastleigh.JPG",
+              "fileTitle": "File:Old Town Hall Eastleigh.JPG",
+              "mimeType": "image/jpeg",
+              "width": 2822,
+              "height": 2090,
+              "license": {
+                "shortName": "CC BY-SA 3.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Marek69"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:25:34.240Z"
+              },
+              "priority": 2
+            }
+          ]
         }
       }
     },
@@ -34784,8 +35482,39 @@
       },
       "assets": {
         "crest": {
-          "status": "restricted",
+          "preferred": "wikipedia-pageimage-any:Epsom_and_Ewell_UK_locator_map.svg",
+          "status": "usable",
           "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Epsom_and_Ewell_UK_locator_map.svg",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Epsom_and_Ewell",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/63/Epsom_and_Ewell_UK_locator_map.svg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Epsom_and_Ewell_UK_locator_map.svg",
+              "fileTitle": "File:Epsom and Ewell UK locator map.svg",
+              "mimeType": "image/svg+xml",
+              "width": 1425,
+              "height": 1081,
+              "license": {
+                "shortName": "CC BY-SA 3.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0",
+                "copyrighted": true,
+                "attribution": "Contains Ordnance Survey data © Crown copyright and database right",
+                "credit": "Ordnance Survey OpenData Coastline and administrative boundary data from Boundary-Line product. Lake data from Meridian 2 product. Inset derived from England location map.svg by Spischot .",
+                "artist": "Nilfanion , created using Ordnance Survey data"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T19:25:58.717Z"
+              },
+              "priority": 1
+            },
             {
               "assetId": "wikipedia-pageimage-any:EpsomEwellBadge.png",
               "kind": "crest",
@@ -34814,9 +35543,9 @@
                   "license-restricted",
                   "identity-uncertain"
                 ],
-                "checkedAt": "2026-06-20T18:55:05.651Z"
+                "checkedAt": "2026-06-20T19:25:58.717Z"
               },
-              "priority": 1
+              "priority": 2
             }
           ]
         }
@@ -36635,7 +37364,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:55:12.454Z"
+                "checkedAt": "2026-06-20T19:26:03.489Z"
               },
               "priority": 1
             },
@@ -36668,7 +37397,7 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:55:12.454Z"
+                "checkedAt": "2026-06-20T19:26:03.489Z"
               },
               "priority": 2
             }
@@ -36811,7 +37540,40 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:FC_Halifax_Town_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/FC_Halifax_Town",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e5/FC_Halifax_Town_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:FC_Halifax_Town_crest.svg",
+              "fileTitle": "File:FC Halifax Town crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 300,
+              "height": 300,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of FC Halifax Town",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:FC_Halifax_Town_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/national-league/table"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:26:05.394Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -37714,7 +38476,70 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "preferred": "wikipedia-pageimage-any:Folkestone_Harbour_with_Viaduct_and_Swing_Bridge.png",
+          "status": "usable",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Folkestone_Harbour_with_Viaduct_and_Swing_Bridge.png",
+              "kind": "crest",
+              "status": "usable",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Folkestone",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/4/4c/Folkestone_Harbour_with_Viaduct_and_Swing_Bridge.png",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Folkestone_Harbour_with_Viaduct_and_Swing_Bridge.png",
+              "fileTitle": "File:Folkestone Harbour with Viaduct and Swing Bridge.png",
+              "mimeType": "image/png",
+              "width": 6000,
+              "height": 4000,
+              "license": {
+                "shortName": "CC BY-SA 4.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Claire Noble"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": false,
+                "checkedAt": "2026-06-20T19:26:07.298Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-any:Folkestone_Invicta_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Folkestone_Invicta_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2a/Folkestone_Invicta_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Folkestone_Invicta_FC_crest.svg",
+              "fileTitle": "File:Folkestone Invicta FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Folkestone Invicta F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Folkestone_Invicta_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://folkestoneinvictafc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:26:07.298Z"
+              },
+              "priority": 2
+            }
+          ]
         }
       }
     },
@@ -39100,7 +39925,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:55:23.235Z"
+                "checkedAt": "2026-06-20T19:26:09.958Z"
               },
               "priority": 1
             },
@@ -39132,7 +39957,7 @@
                 "reviewReasons": [
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:55:23.235Z"
+                "checkedAt": "2026-06-20T19:26:09.958Z"
               },
               "priority": 2
             }
@@ -39684,40 +40509,133 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
+          "status": "restricted",
           "candidates": [
             {
-              "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
+              "assetId": "wikipedia-pageimage-any:South_Shields_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/South_Shields_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/e/e5/South_Shields_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:South_Shields_FC_crest.svg",
+              "fileTitle": "File:South Shields FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 281,
+              "height": 356,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of South Shields F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:South_Shields_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.bbc.com/sport/football/fa-cup/scores-fixtures/2025-11"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:26:11.554Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-any:Gateshead_FC.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Gateshead_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b3/Gateshead_FC.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Gateshead_FC.svg",
+              "fileTitle": "File:Gateshead FC.svg",
+              "mimeType": "image/svg+xml",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Gateshead F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Gateshead_FC.svg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: Gateshead F.C. Official Website Converted to AI format by Johnny Beaufays (johnny.beaufays@vflnet.com) and then converted to SVG by Arteyu using Adobe Illustrator . Then cropped the SVG by using Inkscape ."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:26:11.554Z"
+              },
+              "priority": 2
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Angel_of_the_North,_Gateshead,_United_Kingdom.jpg",
               "kind": "crest",
               "status": "needs-review",
               "source": "wikipedia-pageimage-free",
-              "sourceUrl": "https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs",
-              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/0/0c/Ryan_Valentine_scores.jpg",
-              "pageUrl": "https://commons.wikimedia.org/wiki/File:Ryan_Valentine_scores.jpg",
-              "fileTitle": "File:Ryan Valentine scores.jpg",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Gateshead",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/d/d2/Angel_of_the_North%2C_Gateshead%2C_United_Kingdom.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Angel_of_the_North,_Gateshead,_United_Kingdom.jpg",
+              "fileTitle": "File:Angel of the North, Gateshead, United Kingdom.jpg",
               "mimeType": "image/jpeg",
-              "width": 3456,
-              "height": 2304,
+              "width": 3968,
+              "height": 2232,
               "license": {
-                "shortName": "CC BY 2.5",
-                "usageTerms": "Creative Commons Attribution 2.5",
-                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
                 "copyrighted": true,
-                "credit": "Own work",
-                "artist": "Markbarnes"
+                "credit": "https://www.flickr.com/photos/leonghongrui/11654459084/",
+                "artist": "Alvin Leong"
               },
               "verification": {
-                "identityMatch": "none",
+                "identityMatch": "possible",
                 "licenseCheck": "pass",
                 "httpCheck": "pass",
                 "needsManualReview": true,
                 "reviewReasons": [
-                  "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:55:25.483Z"
+                "checkedAt": "2026-06-20T19:26:11.554Z"
               },
-              "priority": 1
+              "priority": 3
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Hôtel_ville_South_Shields_South_Tyneside_28.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/South_Shields",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/5/55/H%C3%B4tel_ville_South_Shields_South_Tyneside_28.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:H%C3%B4tel_ville_South_Shields_South_Tyneside_28.jpg",
+              "fileTitle": "File:Hôtel ville South Shields South Tyneside 28.jpg",
+              "mimeType": "image/jpeg",
+              "width": 10581,
+              "height": 6866,
+              "license": {
+                "shortName": "CC BY-SA 4.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 4.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/4.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Chabe01"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:26:11.554Z"
+              },
+              "priority": 4
             }
           ]
         }
@@ -40347,8 +41265,104 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
+          "status": "restricted",
           "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:GNE_afc_badge.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Glossop_North_End_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/5e/GNE_afc_badge.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:GNE_afc_badge.png",
+              "fileTitle": "File:GNE afc badge.png",
+              "mimeType": "image/png",
+              "width": 276,
+              "height": 361,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Glossop North End A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:GNE_afc_badge.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.glossopnorthendafc.co.uk http://www.glossopnorthendafc.co.uk"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted",
+                  "identity-uncertain"
+                ],
+                "checkedAt": "2026-06-20T19:26:14.645Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-any:North_West_Counties_Football_League_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/North_West_Counties_Football_League",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/8/83/North_West_Counties_Football_League_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:North_West_Counties_Football_League_logo.png",
+              "fileTitle": "File:North West Counties Football League logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of North West Counties Football League",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:North_West_Counties_Football_League_logo.png",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: www.nwcfl.com www.nwcfl.com"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:26:14.645Z"
+              },
+              "priority": 2
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Glossop_-_geograph.org.uk_-_7292918.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Glossop",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/68/Glossop_-_geograph.org.uk_-_7292918.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Glossop_-_geograph.org.uk_-_7292918.jpg",
+              "fileTitle": "File:Glossop - geograph.org.uk - 7292918.jpg",
+              "mimeType": "image/jpeg",
+              "width": 4032,
+              "height": 2268,
+              "license": {
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
+                "copyrighted": true,
+                "attribution": "Glossop by Peter McDermott",
+                "credit": "Geograph Britain and Ireland",
+                "artist": "Peter McDermott"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:26:14.645Z"
+              },
+              "priority": 3
+            },
             {
               "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
               "kind": "crest",
@@ -40378,9 +41392,9 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:55:27.756Z"
+                "checkedAt": "2026-06-20T19:26:14.645Z"
               },
-              "priority": 1
+              "priority": 4
             }
           ]
         }
@@ -44543,7 +45557,40 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hastings_United_F.C._2020_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hastings_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/03/Hastings_United_F.C._2020_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hastings_United_F.C._2020_logo.png",
+              "fileTitle": "File:Hastings United F.C. 2020 logo.png",
+              "mimeType": "image/png",
+              "width": 170,
+              "height": 240,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hastings United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hastings_United_F.C._2020_logo.png",
+                "copyrighted": true,
+                "credit": "https://www.hastingsunited.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:26:17.945Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -44661,7 +45708,40 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Hastings_United_F.C._2020_logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hastings_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/03/Hastings_United_F.C._2020_logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Hastings_United_F.C._2020_logo.png",
+              "fileTitle": "File:Hastings United F.C. 2020 logo.png",
+              "mimeType": "image/png",
+              "width": 170,
+              "height": 240,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Hastings United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Hastings_United_F.C._2020_logo.png",
+                "copyrighted": true,
+                "credit": "https://www.hastingsunited.com/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:26:20.210Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -45931,7 +47011,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:56:08.401Z"
+                "checkedAt": "2026-06-20T19:26:32.611Z"
               },
               "priority": 1
             },
@@ -45963,9 +47043,41 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:56:08.401Z"
+                "checkedAt": "2026-06-20T19:26:32.611Z"
               },
               "priority": 2
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Hendon_Town_Hall_in_December_2011.JPG",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hendon",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/2/2e/Hendon_Town_Hall_in_December_2011.JPG",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Hendon_Town_Hall_in_December_2011.JPG",
+              "fileTitle": "File:Hendon Town Hall in December 2011.JPG",
+              "mimeType": "image/jpeg",
+              "width": 4000,
+              "height": 3000,
+              "license": {
+                "shortName": "CC BY 3.0",
+                "usageTerms": "Creative Commons Attribution 3.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by/3.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Editor5807"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:26:32.611Z"
+              },
+              "priority": 3
             }
           ]
         }
@@ -46128,7 +47240,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:56:09.571Z"
+                "checkedAt": "2026-06-20T19:31:03.304Z"
               },
               "priority": 1
             },
@@ -46161,9 +47273,42 @@
                 "reviewReasons": [
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:56:09.571Z"
+                "checkedAt": "2026-06-20T19:31:03.304Z"
               },
               "priority": 2
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Centre_of_Hereford_-_geograph.org.uk_-_4306743.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hereford",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/be/Centre_of_Hereford_-_geograph.org.uk_-_4306743.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Centre_of_Hereford_-_geograph.org.uk_-_4306743.jpg",
+              "fileTitle": "File:Centre of Hereford - geograph.org.uk - 4306743.jpg",
+              "mimeType": "image/jpeg",
+              "width": 800,
+              "height": 507,
+              "license": {
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
+                "copyrighted": true,
+                "attribution": "Centre of Hereford by Clint Mann",
+                "credit": "Geograph Britain and Ireland",
+                "artist": "Clint Mann"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:31:03.304Z"
+              },
+              "priority": 3
             }
           ]
         }
@@ -46461,7 +47606,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:56:11.029Z"
+                "checkedAt": "2026-06-20T19:26:59.679Z"
               },
               "priority": 1
             },
@@ -46493,7 +47638,7 @@
                 "reviewReasons": [
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:56:11.029Z"
+                "checkedAt": "2026-06-20T19:26:59.679Z"
               },
               "priority": 2
             }
@@ -47882,7 +49027,41 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Hounslow_High_Street.1.JPG",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Hounslow",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/d/d1/Hounslow_High_Street.1.JPG",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Hounslow_High_Street.1.JPG",
+              "fileTitle": "File:Hounslow High Street.1.JPG",
+              "mimeType": "image/jpeg",
+              "width": 2304,
+              "height": 1728,
+              "license": {
+                "shortName": "CC BY-SA 3.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "KTo288"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:31:04.917Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -51555,7 +52734,7 @@
                   "license-restricted",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:56:35.935Z"
+                "checkedAt": "2026-06-20T19:27:04.474Z"
               },
               "priority": 1
             }
@@ -52073,7 +53252,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:56:38.159Z"
+                "checkedAt": "2026-06-20T19:27:06.034Z"
               },
               "priority": 1
             },
@@ -52106,7 +53285,7 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:56:38.159Z"
+                "checkedAt": "2026-06-20T19:27:06.034Z"
               },
               "priority": 2
             }
@@ -52428,7 +53607,7 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:56:40.381Z"
+                "checkedAt": "2026-06-20T19:31:06.558Z"
               },
               "priority": 1
             }
@@ -54194,7 +55373,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:56:47.226Z"
+                "checkedAt": "2026-06-20T19:27:12.463Z"
               },
               "priority": 1
             },
@@ -54228,9 +55407,40 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:56:47.226Z"
+                "checkedAt": "2026-06-20T19:27:12.463Z"
               },
               "priority": 2
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Lewes-udsigt.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Lewes",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/7/73/Lewes-udsigt.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Lewes-udsigt.jpg",
+              "fileTitle": "File:Lewes-udsigt.jpg",
+              "mimeType": "image/jpeg",
+              "width": 1600,
+              "height": 1200,
+              "license": {
+                "shortName": "Public domain",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "Own work",
+                "artist": "Missjensen at da.wikipedia"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:27:12.463Z"
+              },
+              "priority": 3
             }
           ]
         }
@@ -54392,7 +55602,72 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:LeytonFC.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Leyton_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/2/2d/LeytonFC.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:LeytonFC.png",
+              "fileTitle": "File:LeytonFC.png",
+              "mimeType": "image/png",
+              "width": 136,
+              "height": 178,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Leyton F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:LeytonFC.png",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Leyton F.C.."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:27:14.346Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:LeytonCentre.JPG",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Leyton",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b6/LeytonCentre.JPG",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:LeytonCentre.JPG",
+              "fileTitle": "File:LeytonCentre.JPG",
+              "mimeType": "image/jpeg",
+              "width": 3872,
+              "height": 2592,
+              "license": {
+                "shortName": "CC BY-SA 3.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 3.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/3.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Leyton59"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:27:14.346Z"
+              },
+              "priority": 2
+            }
+          ]
         }
       }
     },
@@ -56306,7 +57581,43 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:Town_Hall_-_Market_Place_(geograph_2938168).jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Loughborough",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/b/b7/Town_Hall_-_Market_Place_%28geograph_2938168%29.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Town_Hall_-_Market_Place_(geograph_2938168).jpg",
+              "fileTitle": "File:Town Hall - Market Place (geograph 2938168).jpg",
+              "mimeType": "image/jpeg",
+              "width": 640,
+              "height": 533,
+              "license": {
+                "shortName": "CC BY-SA 2.0",
+                "usageTerms": "Creative Commons Attribution-Share Alike 2.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by-sa/2.0",
+                "copyrighted": true,
+                "attribution": "Betty Longbottom",
+                "credit": "From geograph.org.uk",
+                "artist": "Betty Longbottom"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:31:08.179Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -57571,7 +58882,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:57:10.598Z"
+                "checkedAt": "2026-06-20T19:27:18.534Z"
               },
               "priority": 1
             },
@@ -57604,7 +58915,7 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:57:10.598Z"
+                "checkedAt": "2026-06-20T19:27:18.534Z"
               },
               "priority": 2
             }
@@ -57953,8 +59264,70 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
+          "status": "restricted",
           "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Maidstone_United_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Maidstone_United_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b8/Maidstone_United_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Maidstone_United_FC_crest.svg",
+              "fileTitle": "File:Maidstone United FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 295,
+              "height": 339,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Maidstone United F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Maidstone_United_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://iconape.com/maidstone-united-fc-logo-logo-icon-svg-png.html"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:27:20.144Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-any:Maidstone-utd-logo.jpg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Maidstone_United_F.C._(1897)",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/0/0e/Maidstone-utd-logo.jpg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Maidstone-utd-logo.jpg",
+              "fileTitle": "File:Maidstone-utd-logo.jpg",
+              "mimeType": "image/jpeg",
+              "width": 203,
+              "height": 152,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Maidstone United F.C. (1897)",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Maidstone-utd-logo.jpg",
+                "copyrighted": true,
+                "credit": "The logo is from the following website: http://www.maidstoneunited.co.uk"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:27:20.144Z"
+              },
+              "priority": 2
+            },
             {
               "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
               "kind": "crest",
@@ -57984,9 +59357,9 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:57:12.873Z"
+                "checkedAt": "2026-06-20T19:27:20.144Z"
               },
-              "priority": 1
+              "priority": 3
             }
           ]
         }
@@ -60151,7 +61524,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:57:19.543Z"
+                "checkedAt": "2026-06-20T19:27:23.031Z"
               },
               "priority": 1
             },
@@ -60182,7 +61555,7 @@
                 "reviewReasons": [
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:57:19.543Z"
+                "checkedAt": "2026-06-20T19:27:23.031Z"
               },
               "priority": 2
             }
@@ -61458,7 +62831,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:57:24.020Z"
+                "checkedAt": "2026-06-20T19:31:09.938Z"
               },
               "priority": 1
             },
@@ -61490,9 +62863,42 @@
                 "reviewReasons": [
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:57:24.020Z"
+                "checkedAt": "2026-06-20T19:31:09.938Z"
               },
               "priority": 2
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Middlesborough_Town_Hall_image_by_Robert_Eva.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Middlesbrough",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/a/a3/Middlesborough_Town_Hall_image_by_Robert_Eva.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Middlesborough_Town_Hall_image_by_Robert_Eva.jpg",
+              "fileTitle": "File:Middlesborough Town Hall image by Robert Eva.jpg",
+              "mimeType": "image/jpeg",
+              "width": 755,
+              "height": 460,
+              "license": {
+                "shortName": "CC BY 2.5",
+                "usageTerms": "Creative Commons Attribution 2.5",
+                "licenseUrl": "https://creativecommons.org/licenses/by/2.5",
+                "copyrighted": true,
+                "credit": "https://commons.wikimedia.org/wiki/File:Middlesbrough_town_hall_and_fountains_-_geograph.org.uk_-_5469169.jpg Wiki images",
+                "artist": "Robert Eva"
+              },
+              "verification": {
+                "identityMatch": "none",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "identity-uncertain",
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:31:09.938Z"
+              },
+              "priority": 3
             }
           ]
         }
@@ -63943,7 +65349,40 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:New_Brighton_Tower.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/New_Brighton_Tower",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/e/e0/New_Brighton_Tower.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:New_Brighton_Tower.jpg",
+              "fileTitle": "File:New Brighton Tower.jpg",
+              "mimeType": "image/jpeg",
+              "width": 248,
+              "height": 314,
+              "license": {
+                "shortName": "Public domain",
+                "usageTerms": "Public domain",
+                "copyrighted": false,
+                "credit": "postcard",
+                "artist": "Unknown author Unknown author"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:31:11.666Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -65171,8 +66610,39 @@
       },
       "assets": {
         "crest": {
-          "status": "needs-review",
+          "status": "restricted",
           "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Newport_County_AFC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Newport_County_A.F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/4/44/Newport_County_AFC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Newport_County_AFC_crest.svg",
+              "fileTitle": "File:Newport County AFC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 317,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Newport County A.F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Newport_County_AFC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://www.newport-county.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:28:04.956Z"
+              },
+              "priority": 1
+            },
             {
               "assetId": "wikipedia-pageimage-free:Ryan_Valentine_scores.jpg",
               "kind": "crest",
@@ -65202,9 +66672,9 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:57:42.191Z"
+                "checkedAt": "2026-06-20T19:28:04.956Z"
               },
-              "priority": 1
+              "priority": 2
             }
           ]
         }
@@ -66310,7 +67780,40 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Northwood.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Northwood_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/6/60/Northwood.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Northwood.png",
+              "fileTitle": "File:Northwood.png",
+              "mimeType": "image/png",
+              "width": 181,
+              "height": 216,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Northwood F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Northwood.png",
+                "copyrighted": true,
+                "credit": "The logo may be obtained from Northwood F.C.."
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:28:07.531Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -69251,7 +70754,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:58:09.840Z"
+                "checkedAt": "2026-06-20T19:28:10.885Z"
               },
               "priority": 1
             },
@@ -69285,7 +70788,7 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:58:09.840Z"
+                "checkedAt": "2026-06-20T19:28:10.885Z"
               },
               "priority": 2
             }
@@ -69729,7 +71232,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T18:58:12.064Z"
+                "checkedAt": "2026-06-20T19:28:12.436Z"
               },
               "priority": 1
             },
@@ -69761,7 +71264,7 @@
                 "reviewReasons": [
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:58:12.064Z"
+                "checkedAt": "2026-06-20T19:28:12.436Z"
               },
               "priority": 2
             }
@@ -72757,7 +74260,7 @@
                 "licenseCheck": "pass",
                 "httpCheck": "pass",
                 "needsManualReview": false,
-                "checkedAt": "2026-06-20T18:58:20.266Z"
+                "checkedAt": "2026-06-20T19:28:13.920Z"
               },
               "priority": 1
             },
@@ -72790,7 +74293,7 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:58:20.266Z"
+                "checkedAt": "2026-06-20T19:28:13.920Z"
               },
               "priority": 2
             }
@@ -74419,7 +75922,7 @@
                   "license-restricted",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:58:28.184Z"
+                "checkedAt": "2026-06-20T19:28:18.244Z"
               },
               "priority": 1
             }
@@ -76181,7 +77684,72 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:RuncornLinnetsCrest.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Runcorn_Linnets_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b6/RuncornLinnetsCrest.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:RuncornLinnetsCrest.png",
+              "fileTitle": "File:RuncornLinnetsCrest.png",
+              "mimeType": "image/png",
+              "width": 315,
+              "height": 315,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Runcorn Linnets F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:RuncornLinnetsCrest.png",
+                "copyrighted": true,
+                "credit": "http://www.runcornlinnetsfc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:31:13.306Z"
+              },
+              "priority": 1
+            },
+            {
+              "assetId": "wikipedia-pageimage-free:Silver_Jubilee_Bridge,_Runcorn,_night,_2024.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Runcorn",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/e/e8/Silver_Jubilee_Bridge%2C_Runcorn%2C_night%2C_2024.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:Silver_Jubilee_Bridge,_Runcorn,_night,_2024.jpg",
+              "fileTitle": "File:Silver Jubilee Bridge, Runcorn, night, 2024.jpg",
+              "mimeType": "image/jpeg",
+              "width": 3836,
+              "height": 2268,
+              "license": {
+                "shortName": "CC0",
+                "usageTerms": "Creative Commons Zero, Public Domain Dedication",
+                "licenseUrl": "http://creativecommons.org/publicdomain/zero/1.0/deed.en",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Dgp4004"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:31:13.306Z"
+              },
+              "priority": 2
+            }
+          ]
         }
       }
     },
@@ -79176,7 +80744,40 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Sheffield_Wednesday_FC_2026_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Sheffield_Wednesday_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/b/b8/Sheffield_Wednesday_FC_2026_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Sheffield_Wednesday_FC_2026_crest.svg",
+              "fileTitle": "File:Sheffield Wednesday FC 2026 crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 293,
+              "height": 342,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Sheffield Wednesday F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Sheffield_Wednesday_FC_2026_crest.svg",
+                "copyrighted": true,
+                "credit": "https://football-logos.cc/england/sheffield-wednesday/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:28:59.560Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -80216,7 +81817,7 @@
                   "license-restricted",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:59:05.984Z"
+                "checkedAt": "2026-06-20T19:29:05.394Z"
               },
               "priority": 1
             }
@@ -83171,7 +84772,7 @@
                   "identity-uncertain",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T18:59:18.281Z"
+                "checkedAt": "2026-06-20T19:29:07.051Z"
               },
               "priority": 1
             }
@@ -88277,7 +89878,41 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "needs-review",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-free:London_Thames_Sunset_panorama_-_Feb_2008.jpg",
+              "kind": "crest",
+              "status": "needs-review",
+              "source": "wikipedia-pageimage-free",
+              "sourceUrl": "https://en.wikipedia.org/wiki/River_Thames",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/6e/London_Thames_Sunset_panorama_-_Feb_2008.jpg",
+              "pageUrl": "https://commons.wikimedia.org/wiki/File:London_Thames_Sunset_panorama_-_Feb_2008.jpg",
+              "fileTitle": "File:London Thames Sunset panorama - Feb 2008.jpg",
+              "mimeType": "image/jpeg",
+              "width": 13126,
+              "height": 4876,
+              "license": {
+                "shortName": "CC BY 3.0",
+                "usageTerms": "Creative Commons Attribution 3.0",
+                "licenseUrl": "https://creativecommons.org/licenses/by/3.0",
+                "copyrighted": true,
+                "credit": "Own work",
+                "artist": "Diliff"
+              },
+              "verification": {
+                "identityMatch": "possible",
+                "licenseCheck": "pass",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "non-crest-filename"
+                ],
+                "checkedAt": "2026-06-20T19:31:16.121Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -90498,7 +92133,40 @@
       },
       "assets": {
         "crest": {
-          "status": "missing"
+          "status": "restricted",
+          "candidates": [
+            {
+              "assetId": "wikipedia-pageimage-any:Tranmere_Rovers_FC_crest.svg",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Tranmere_Rovers_F.C.",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/5/55/Tranmere_Rovers_FC_crest.svg",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Tranmere_Rovers_FC_crest.svg",
+              "fileTitle": "File:Tranmere Rovers FC crest.svg",
+              "mimeType": "image/svg+xml",
+              "width": 280,
+              "height": 357,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Tranmere Rovers F.C.",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Tranmere_Rovers_FC_crest.svg",
+                "copyrighted": true,
+                "credit": "https://seeklogo.com/vector-logo/441960/tranmere-rovers-f"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:29:14.960Z"
+              },
+              "priority": 1
+            }
+          ]
         }
       }
     },
@@ -96280,6 +97948,37 @@
           "status": "restricted",
           "candidates": [
             {
+              "assetId": "wikipedia-pageimage-any:Windsor_&_Eton_F.C._(2023)_Logo.png",
+              "kind": "crest",
+              "status": "restricted",
+              "source": "wikipedia-pageimage-any",
+              "sourceUrl": "https://en.wikipedia.org/wiki/Windsor_%26_Eton_F.C._(2023)",
+              "imageUrl": "https://upload.wikimedia.org/wikipedia/en/9/94/Windsor_%26_Eton_F.C._%282023%29_Logo.png",
+              "pageUrl": "https://en.wikipedia.org/wiki/File:Windsor_%26_Eton_F.C._(2023)_Logo.png",
+              "fileTitle": "File:Windsor & Eton F.C. (2023) Logo.png",
+              "mimeType": "image/png",
+              "width": 316,
+              "height": 316,
+              "license": {
+                "shortName": "Fair use",
+                "usageTerms": "Fair use of copyrighted material in the context of Windsor & Eton F.C. (2023)",
+                "licenseUrl": "https://en.wikipedia.org/wiki/File:Windsor_%26_Eton_F.C._(2023)_Logo.png",
+                "copyrighted": true,
+                "credit": "https://wefc.co.uk/"
+              },
+              "verification": {
+                "identityMatch": "strong",
+                "licenseCheck": "restricted",
+                "httpCheck": "pass",
+                "needsManualReview": true,
+                "reviewReasons": [
+                  "license-restricted"
+                ],
+                "checkedAt": "2026-06-20T19:29:21.411Z"
+              },
+              "priority": 1
+            },
+            {
               "assetId": "wikipedia-pageimage-any:Windsorandetonfc.jpg",
               "kind": "crest",
               "status": "restricted",
@@ -96307,9 +98006,9 @@
                   "license-restricted",
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T19:00:26.977Z"
+                "checkedAt": "2026-06-20T19:29:21.411Z"
               },
-              "priority": 1
+              "priority": 2
             }
           ]
         }
@@ -96940,7 +98639,7 @@
                 "reviewReasons": [
                   "license-restricted"
                 ],
-                "checkedAt": "2026-06-20T19:00:31.440Z"
+                "checkedAt": "2026-06-20T19:29:24.968Z"
               },
               "priority": 1
             },
@@ -96973,7 +98672,7 @@
                 "reviewReasons": [
                   "non-crest-filename"
                 ],
-                "checkedAt": "2026-06-20T19:00:31.440Z"
+                "checkedAt": "2026-06-20T19:29:24.968Z"
               },
               "priority": 2
             }

--- a/docs/club-assets-review.css
+++ b/docs/club-assets-review.css
@@ -1,0 +1,538 @@
+.asset-review-shell {
+  width: min(1420px, calc(100% - 40px));
+}
+
+.asset-review-shell h1 {
+  max-width: 12ch;
+}
+
+.review-toolbar {
+  display: grid;
+  grid-template-columns: minmax(220px, 1.5fr) repeat(2, minmax(160px, 0.8fr)) minmax(160px, 0.8fr);
+  gap: 12px;
+  align-items: end;
+}
+
+.review-toolbar label {
+  display: grid;
+  gap: 6px;
+}
+
+.review-toolbar span,
+.asset-muted,
+.candidate-meta dt,
+.review-table th {
+  color: var(--muted);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.review-toolbar input,
+.review-toolbar select,
+.review-toolbar button {
+  min-height: 40px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--ink);
+  font: inherit;
+}
+
+.review-toolbar input,
+.review-toolbar select {
+  width: 100%;
+  padding: 8px 10px;
+}
+
+.review-toolbar button {
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.review-toolbar input:focus,
+.review-toolbar select:focus,
+.review-toolbar button:focus,
+.review-toolbar button:hover {
+  border-color: var(--accent);
+  outline: 2px solid transparent;
+}
+
+.status-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.view-tabs {
+  display: inline-flex;
+  gap: 4px;
+  margin-top: 14px;
+  padding: 4px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 6px;
+}
+
+.view-tabs button {
+  min-height: 34px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  cursor: pointer;
+}
+
+.view-tabs button:hover,
+.view-tabs button:focus,
+.view-tabs button[aria-pressed='true'] {
+  background: var(--accent-soft);
+  color: var(--ink);
+  outline: 0;
+}
+
+.flag-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+  align-items: center;
+  margin-top: 14px;
+}
+
+.flag-filter {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  min-height: 34px;
+  padding: 5px 8px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 4px;
+}
+
+.flag-filter input {
+  margin: 0;
+}
+
+.flag-count,
+.flag-chip {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 24px;
+  padding: 3px 7px;
+  border: 1px solid #d8c27a;
+  border-radius: 4px;
+  color: #f0df9b;
+  font-size: 0.78rem;
+  line-height: 1.2;
+}
+
+.flag-toolbar button,
+.flag-button {
+  min-height: 34px;
+  padding: 6px 10px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--ink);
+  font: inherit;
+  cursor: pointer;
+}
+
+.flag-toolbar button:hover,
+.flag-toolbar button:focus,
+.flag-button:hover,
+.flag-button:focus,
+.flag-button[aria-pressed='true'] {
+  border-color: #d8c27a;
+  color: #f0df9b;
+  outline: 0;
+}
+
+.flag-toolbar button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
+.status-tab {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  min-height: 34px;
+  padding: 6px 10px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 4px;
+  background: var(--bg);
+  color: var(--ink);
+  font: inherit;
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.status-tab[aria-pressed='true'] {
+  border-color: var(--accent-hover);
+  background: var(--accent-soft);
+}
+
+.review-layout {
+  display: grid;
+  grid-template-columns: minmax(340px, 0.92fr) minmax(0, 1.58fr);
+  gap: 22px;
+  align-items: start;
+}
+
+.club-list-panel,
+.club-detail-panel {
+  min-width: 0;
+}
+
+.club-list {
+  display: grid;
+  max-height: 72vh;
+  overflow: auto;
+  border-top: 1px solid var(--rule);
+}
+
+.club-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px 12px;
+  width: 100%;
+  padding: 12px 0;
+  border: 0;
+  border-bottom: 1px solid var(--rule);
+  background: transparent;
+  color: var(--ink);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.club-row:hover,
+.club-row:focus,
+.club-row.is-selected {
+  color: var(--accent-hover);
+  outline: 0;
+}
+
+.club-row-main,
+.club-row-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px 8px;
+  align-items: center;
+  min-width: 0;
+}
+
+.club-row-main strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.club-row-meta {
+  grid-column: 1 / -1;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.status-chip,
+.issue-chip {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  min-height: 24px;
+  padding: 3px 7px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 4px;
+  font-size: 0.78rem;
+  line-height: 1.2;
+}
+
+.status-chip[data-status='usable'] {
+  border-color: #80c98f;
+  color: #a8ddb2;
+}
+
+.status-chip[data-status='placeholder'] {
+  border-color: #d8c27a;
+  color: #f0df9b;
+}
+
+.status-chip[data-status='needs-more-research'] {
+  border-color: #8fc7df;
+  color: #b4dff0;
+}
+
+.status-chip[data-status='restricted'] {
+  border-color: #de9d6a;
+  color: #f0bd8e;
+}
+
+.status-chip[data-status='needs-review'] {
+  border-color: #c6a7f2;
+  color: #d7c2fa;
+}
+
+.status-chip[data-status='missing'] {
+  border-color: #dc7f7f;
+  color: #f0a1a1;
+}
+
+.issue-chip {
+  color: var(--muted);
+}
+
+.detail-heading {
+  display: grid;
+  gap: 8px;
+}
+
+.detail-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+  align-items: center;
+}
+
+.detail-title-row h2 {
+  margin: 0;
+}
+
+.detail-links,
+.candidate-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 12px;
+}
+
+.candidate-grid {
+  display: grid;
+  gap: 16px;
+}
+
+.candidate-card {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) minmax(0, 1fr);
+  gap: 16px;
+  padding-top: 16px;
+  border-top: 1px solid var(--rule);
+}
+
+.candidate-card:has(.flag-button[aria-pressed='true']) {
+  border-top-color: #d8c27a;
+}
+
+.candidate-image-frame {
+  display: grid;
+  place-items: center;
+  min-height: 180px;
+  aspect-ratio: 1;
+  border: 1px solid var(--rule);
+  background: linear-gradient(45deg, rgba(255, 255, 255, 0.04) 25%, transparent 25%),
+    linear-gradient(-45deg, rgba(255, 255, 255, 0.04) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, rgba(255, 255, 255, 0.04) 75%),
+    linear-gradient(-45deg, transparent 75%, rgba(255, 255, 255, 0.04) 75%);
+  background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+  background-size: 16px 16px;
+}
+
+.candidate-image-frame img {
+  display: block;
+  width: 100%;
+  max-width: 180px;
+  max-height: 180px;
+  object-fit: contain;
+}
+
+.candidate-empty {
+  color: var(--muted);
+  font-size: 0.88rem;
+  text-align: center;
+}
+
+.candidate-body {
+  min-width: 0;
+}
+
+.candidate-title {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.candidate-title h3 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.flag-actions {
+  margin: 10px 0;
+}
+
+.candidate-meta {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px 16px;
+  margin: 0 0 12px;
+}
+
+.candidate-meta div {
+  min-width: 0;
+}
+
+.candidate-meta dd {
+  margin: 3px 0 0;
+  overflow-wrap: anywhere;
+}
+
+.swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.swatch {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.swatch i {
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--rule-strong);
+  border-radius: 50%;
+}
+
+.review-table-wrap {
+  overflow-x: auto;
+  border-top: 1px solid var(--rule);
+}
+
+.review-table {
+  width: 100%;
+  min-width: 760px;
+  border-collapse: collapse;
+}
+
+.review-table th,
+.review-table td {
+  padding: 9px 12px 9px 0;
+  border-bottom: 1px solid var(--rule);
+  text-align: left;
+  vertical-align: top;
+}
+
+.review-table td:last-child {
+  color: var(--muted);
+}
+
+.audit-panel[hidden],
+.review-layout[hidden],
+.panel[hidden] {
+  display: none;
+}
+
+.audit-list {
+  display: grid;
+  gap: 18px;
+  border-top: 1px solid var(--rule);
+}
+
+.audit-club {
+  display: grid;
+  gap: 12px;
+  padding-top: 18px;
+}
+
+.audit-club + .audit-club {
+  border-top: 1px solid var(--rule);
+}
+
+.audit-club-heading,
+.audit-badges,
+.audit-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+  align-items: center;
+}
+
+.audit-club-heading {
+  justify-content: space-between;
+}
+
+.audit-club h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.audit-candidates {
+  display: grid;
+  gap: 12px;
+}
+
+.audit-candidates .candidate-card {
+  grid-template-columns: minmax(96px, 128px) minmax(0, 1fr);
+  gap: 12px;
+  padding-top: 12px;
+}
+
+.audit-candidates .candidate-image-frame {
+  min-height: 116px;
+}
+
+.audit-candidates .candidate-image-frame img {
+  max-width: 104px;
+  max-height: 104px;
+}
+
+.empty-state {
+  padding: 18px 0;
+  color: var(--muted);
+}
+
+@media (max-width: 980px) {
+  .review-toolbar,
+  .review-layout,
+  .audit-candidates .candidate-card,
+  .candidate-card {
+    grid-template-columns: 1fr;
+  }
+
+  .club-list {
+    max-height: 360px;
+  }
+}
+
+@media (max-width: 760px) {
+  .asset-review-shell {
+    width: min(calc(100% - 24px), 1420px);
+    overflow-x: hidden;
+  }
+
+  .status-tabs {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .status-tab {
+    width: 100%;
+    justify-content: space-between;
+  }
+}
+
+@media (max-width: 560px) {
+  .candidate-meta {
+    grid-template-columns: 1fr;
+  }
+}

--- a/docs/club-assets-review.html
+++ b/docs/club-assets-review.html
@@ -113,7 +113,12 @@
         </section>
       </section>
 
-      <section id="audit-workspace" class="panel audit-panel" aria-labelledby="audit-heading" hidden>
+      <section
+        id="audit-workspace"
+        class="panel audit-panel"
+        aria-labelledby="audit-heading"
+        hidden
+      >
         <div class="section-heading">
           <h2 id="audit-heading">Crest Audit</h2>
           <span id="audit-count" class="muted-label">-</span>

--- a/docs/club-assets-review.html
+++ b/docs/club-assets-review.html
@@ -1,0 +1,156 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Club asset review | footy-data-kit</title>
+    <meta
+      name="description"
+      content="Review club crest candidates, generated placeholders, license flags, and missing club asset records."
+    />
+    <link rel="stylesheet" href="./styles.css" />
+    <link rel="stylesheet" href="./club-assets-review.css" />
+  </head>
+  <body>
+    <main class="page-shell asset-review-shell">
+      <header class="site-header">
+        <p class="eyebrow">asset review</p>
+        <h1>club crest review</h1>
+        <p class="lede">
+          Inspect club crest candidates, generated placeholders, license warnings, and missing
+          records from the checked-in metadata.
+        </p>
+      </header>
+
+      <section class="panel" aria-labelledby="controls-heading">
+        <div class="section-heading">
+          <h2 id="controls-heading">Controls</h2>
+          <a href="./index.html">docs home</a>
+        </div>
+
+        <div class="review-toolbar">
+          <label>
+            <span>Search</span>
+            <input
+              id="search-input"
+              type="search"
+              autocomplete="off"
+              placeholder="club, source, file, reason"
+            />
+          </label>
+
+          <label>
+            <span>Issue</span>
+            <select id="issue-select"></select>
+          </label>
+
+          <label>
+            <span>Source</span>
+            <select id="source-select"></select>
+          </label>
+
+          <button id="reset-button" type="button">Reset</button>
+        </div>
+
+        <div id="view-tabs" class="view-tabs" aria-label="review view">
+          <button type="button" data-view="review" aria-pressed="true">Review queue</button>
+          <button type="button" data-view="audit" aria-pressed="false">All crest audit</button>
+        </div>
+
+        <div class="flag-toolbar" aria-label="flagged candidate tools">
+          <span id="flag-count" class="flag-count">0 flagged</span>
+          <label class="flag-filter">
+            <input id="flagged-only-input" type="checkbox" />
+            <span>Flagged only</span>
+          </label>
+          <button id="export-flags-button" type="button" disabled>Export flags JSON</button>
+          <button id="clear-flags-button" type="button" disabled>Clear flags</button>
+        </div>
+
+        <div id="status-tabs" class="status-tabs" aria-label="status filters"></div>
+        <p id="load-status" class="asset-muted" role="status">Loading club assets...</p>
+      </section>
+
+      <section class="panel stats" aria-label="asset status summary">
+        <div>
+          <strong id="stat-total">-</strong>
+          <span>clubs</span>
+        </div>
+        <div>
+          <strong id="stat-visible">-</strong>
+          <span>visible</span>
+        </div>
+        <div>
+          <strong id="stat-review">-</strong>
+          <span>review issues</span>
+        </div>
+        <div>
+          <strong id="stat-candidates">-</strong>
+          <span>candidates</span>
+        </div>
+      </section>
+
+      <section id="review-workspace" class="review-layout" aria-label="club asset review workspace">
+        <section class="panel club-list-panel" aria-labelledby="club-list-heading">
+          <div class="section-heading">
+            <h2 id="club-list-heading">Clubs</h2>
+            <span id="club-list-count" class="muted-label">-</span>
+          </div>
+          <div id="club-list" class="club-list"></div>
+        </section>
+
+        <section class="panel club-detail-panel" aria-labelledby="club-detail-heading">
+          <div id="club-detail" class="club-detail">
+            <div class="detail-heading">
+              <div class="detail-title-row">
+                <h2 id="club-detail-heading">Select a club</h2>
+              </div>
+              <p class="asset-muted">
+                Choose a record from the club list to inspect candidate images.
+              </p>
+            </div>
+          </div>
+        </section>
+      </section>
+
+      <section id="audit-workspace" class="panel audit-panel" aria-labelledby="audit-heading" hidden>
+        <div class="section-heading">
+          <h2 id="audit-heading">Crest Audit</h2>
+          <span id="audit-count" class="muted-label">-</span>
+        </div>
+        <div id="audit-list" class="audit-list"></div>
+      </section>
+
+      <section id="issue-workspace" class="panel" aria-labelledby="issue-table-heading">
+        <div class="section-heading">
+          <h2 id="issue-table-heading">Visible Issues</h2>
+          <span id="issue-count" class="muted-label">-</span>
+        </div>
+        <div class="review-table-wrap">
+          <table class="review-table">
+            <thead>
+              <tr>
+                <th scope="col">Club</th>
+                <th scope="col">Issue</th>
+                <th scope="col">Asset</th>
+                <th scope="col">Message</th>
+              </tr>
+            </thead>
+            <tbody id="issue-table-body">
+              <tr>
+                <td colspan="4">Loading issues...</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <footer>
+        <span>local review tool</span>
+        <a href="./club-assets.md">workflow notes</a>
+      </footer>
+    </main>
+
+    <script type="module" src="./club-assets-review.js"></script>
+  </body>
+</html>

--- a/docs/club-assets-review.js
+++ b/docs/club-assets-review.js
@@ -1,0 +1,732 @@
+/* global document, localStorage */
+
+const CLUB_METADATA_URL = '../data/club-metadata.json';
+const REVIEW_URL = '../data/club-assets-review.json';
+const FLAGS_STORAGE_KEY = 'footy-data-kit:club-assets-review-flags:v1';
+const ALL_STATUSES = [
+  'all',
+  'usable',
+  'placeholder',
+  'restricted',
+  'needs-review',
+  'needs-more-research',
+];
+const STATUS_LABELS = {
+  all: 'all',
+  usable: 'usable',
+  placeholder: 'placeholder',
+  restricted: 'restricted',
+  'needs-review': 'needs review',
+  'needs-more-research': 'needs more research',
+};
+
+const state = {
+  clubs: [],
+  issues: [],
+  flags: {},
+  view: 'review',
+  status: 'needs-review',
+  issue: 'all',
+  source: 'all',
+  search: '',
+  flaggedOnly: false,
+  selectedClubKey: null,
+};
+
+const elements = {
+  searchInput: document.querySelector('#search-input'),
+  issueSelect: document.querySelector('#issue-select'),
+  sourceSelect: document.querySelector('#source-select'),
+  resetButton: document.querySelector('#reset-button'),
+  flaggedOnlyInput: document.querySelector('#flagged-only-input'),
+  exportFlagsButton: document.querySelector('#export-flags-button'),
+  clearFlagsButton: document.querySelector('#clear-flags-button'),
+  flagCount: document.querySelector('#flag-count'),
+  viewTabs: document.querySelector('#view-tabs'),
+  statusTabs: document.querySelector('#status-tabs'),
+  loadStatus: document.querySelector('#load-status'),
+  statTotal: document.querySelector('#stat-total'),
+  statVisible: document.querySelector('#stat-visible'),
+  statReview: document.querySelector('#stat-review'),
+  statCandidates: document.querySelector('#stat-candidates'),
+  clubListCount: document.querySelector('#club-list-count'),
+  clubList: document.querySelector('#club-list'),
+  clubDetail: document.querySelector('#club-detail'),
+  reviewWorkspace: document.querySelector('#review-workspace'),
+  auditWorkspace: document.querySelector('#audit-workspace'),
+  issueWorkspace: document.querySelector('#issue-workspace'),
+  auditCount: document.querySelector('#audit-count'),
+  auditList: document.querySelector('#audit-list'),
+  issueCount: document.querySelector('#issue-count'),
+  issueTableBody: document.querySelector('#issue-table-body'),
+};
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function readStoredFlags() {
+  try {
+    const parsed = JSON.parse(localStorage.getItem(FLAGS_STORAGE_KEY) || '{}');
+    if (parsed.flags && typeof parsed.flags === 'object') return parsed.flags;
+    if (parsed && typeof parsed === 'object') return parsed;
+  } catch {
+    return {};
+  }
+  return {};
+}
+
+function writeStoredFlags() {
+  try {
+    localStorage.setItem(
+      FLAGS_STORAGE_KEY,
+      JSON.stringify({
+        metadata: {
+          generator: 'club-assets-review-ui',
+          savedAt: new Date().toISOString(),
+        },
+        flags: state.flags,
+      })
+    );
+  } catch {
+    elements.loadStatus.textContent = 'Flags changed, but browser storage was not available.';
+  }
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Failed to load ${url}: ${response.status}`);
+  return response.json();
+}
+
+function getCrest(club) {
+  return club.assets?.crest || { status: 'needs-more-research' };
+}
+
+function getCandidates(club) {
+  return getCrest(club).candidates || [];
+}
+
+function getCandidateSources(club) {
+  return [
+    ...new Set(
+      getCandidates(club)
+        .map((candidate) => candidate.source)
+        .filter(Boolean)
+    ),
+  ];
+}
+
+function buildSearchText(record) {
+  return [
+    record.clubKey,
+    record.club.canonicalName,
+    record.club.clubId,
+    getCrest(record.club).status,
+    ...getCandidateSources(record.club),
+    ...getCandidates(record.club).flatMap((candidate) => [
+      candidate.assetId,
+      candidate.fileTitle,
+      candidate.status,
+      candidate.source,
+      candidate.license?.shortName,
+      candidate.verification?.reviewReasons?.join(' '),
+      candidate.notes,
+    ]),
+    ...(record.issues || []).flatMap((issue) => [issue.type, issue.message, issue.assetId]),
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase();
+}
+
+function issueCountFor(record) {
+  return record.issues?.length || 0;
+}
+
+function candidateCountFor(record) {
+  return getCandidates(record.club).length;
+}
+
+function flagKeyFor(record, candidate) {
+  return `${record.clubKey}::${candidate.assetId}`;
+}
+
+function isFlagged(record, candidate) {
+  return Boolean(state.flags[flagKeyFor(record, candidate)]);
+}
+
+function recordHasFlag(record) {
+  return getCandidates(record.club).some((candidate) => isFlagged(record, candidate));
+}
+
+function buildFlagRecord(record, candidate) {
+  return {
+    clubKey: record.clubKey,
+    clubId: record.club.clubId || null,
+    canonicalName: record.club.canonicalName,
+    assetKind: candidate.kind || 'crest',
+    assetId: candidate.assetId,
+    fileTitle: candidate.fileTitle || null,
+    candidateStatus: candidate.status || null,
+    crestStatus: getCrest(record.club).status || null,
+    source: candidate.source || null,
+    sourceUrl: candidate.sourceUrl || null,
+    pageUrl: candidate.pageUrl || null,
+    imageUrl: candidate.imageUrl || null,
+    license: candidate.license || null,
+    verification: candidate.verification || null,
+    reviewIssues: record.issues.filter((issue) => issue.assetId === candidate.assetId),
+    flaggedAt: new Date().toISOString(),
+  };
+}
+
+function findCandidateByFlagKey(flagKey) {
+  for (const record of state.clubs) {
+    for (const candidate of getCandidates(record.club)) {
+      if (flagKeyFor(record, candidate) === flagKey) return { record, candidate };
+    }
+  }
+  return null;
+}
+
+function toggleFlag(flagKey) {
+  if (state.flags[flagKey]) {
+    delete state.flags[flagKey];
+  } else {
+    const match = findCandidateByFlagKey(flagKey);
+    if (!match) return;
+    state.flags[flagKey] = buildFlagRecord(match.record, match.candidate);
+  }
+  writeStoredFlags();
+  render();
+}
+
+function exportFlags() {
+  const flags = Object.values(state.flags).sort((left, right) => {
+    const clubDelta = left.canonicalName.localeCompare(right.canonicalName);
+    if (clubDelta) return clubDelta;
+    return String(left.assetId).localeCompare(String(right.assetId));
+  });
+  const payload = {
+    metadata: {
+      generator: 'club-assets-review-ui',
+      exportedAt: new Date().toISOString(),
+      flagCount: flags.length,
+      sourceFiles: [CLUB_METADATA_URL, REVIEW_URL],
+    },
+    flags,
+  };
+  const blob = new Blob([`${JSON.stringify(payload, null, 2)}\n`], {
+    type: 'application/json',
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  const date = new Date().toISOString().slice(0, 10);
+  link.href = url;
+  link.download = `club-asset-flags-${date}.json`;
+  document.body.append(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
+function sortRecords(records) {
+  const statusOrder = {
+    'needs-review': 0,
+    'needs-more-research': 1,
+    restricted: 3,
+    placeholder: 4,
+    usable: 5,
+  };
+
+  return [...records].sort((left, right) => {
+    const statusDelta =
+      (statusOrder[getCrest(left.club).status] ?? 10) -
+      (statusOrder[getCrest(right.club).status] ?? 10);
+    if (statusDelta) return statusDelta;
+    const issueDelta = issueCountFor(right) - issueCountFor(left);
+    if (issueDelta) return issueDelta;
+    return left.club.canonicalName.localeCompare(right.club.canonicalName);
+  });
+}
+
+function getVisibleRecords() {
+  const query = state.search.trim().toLowerCase();
+  return sortRecords(
+    state.clubs.filter((record) => {
+      const crest = getCrest(record.club);
+      if (state.status !== 'all' && crest.status !== state.status) return false;
+      if (state.issue !== 'all' && !record.issues.some((issue) => issue.type === state.issue))
+        return false;
+      if (
+        state.source !== 'all' &&
+        !getCandidates(record.club).some((candidate) => candidate.source === state.source)
+      ) {
+        return false;
+      }
+      if (state.flaggedOnly && !recordHasFlag(record)) return false;
+      if (query && !record.searchText.includes(query)) return false;
+      return true;
+    })
+  );
+}
+
+function getVisibleIssues(records) {
+  const visibleClubKeys = new Set(records.map((record) => record.clubKey));
+  return state.issues.filter((issue) => visibleClubKeys.has(issue.clubKey));
+}
+
+function renderStatusTabs() {
+  const counts = state.clubs.reduce(
+    (result, record) => {
+      const status = getCrest(record.club).status || 'needs-more-research';
+      result.all += 1;
+      result[status] = (result[status] || 0) + 1;
+      return result;
+    },
+    { all: 0 }
+  );
+
+  elements.statusTabs.innerHTML = ALL_STATUSES.map((status) => {
+    const label = STATUS_LABELS[status] || status;
+    const count = counts[status] || 0;
+    return `<button class="status-tab" type="button" data-status="${escapeHtml(
+      status
+    )}" aria-pressed="${state.status === status}"><span>${escapeHtml(
+      label
+    )}</span><strong>${count}</strong></button>`;
+  }).join('');
+}
+
+function renderViewTabs() {
+  elements.viewTabs.querySelectorAll('button[data-view]').forEach((button) => {
+    button.setAttribute('aria-pressed', String(button.dataset.view === state.view));
+  });
+}
+
+function renderFilterOptions() {
+  const issueTypes = [...new Set(state.issues.map((issue) => issue.type))].sort();
+  elements.issueSelect.innerHTML = [
+    '<option value="all">all issues</option>',
+    ...issueTypes.map((type) => `<option value="${escapeHtml(type)}">${escapeHtml(type)}</option>`),
+  ].join('');
+  elements.issueSelect.value = state.issue;
+
+  const sources = [
+    ...new Set(state.clubs.flatMap((record) => getCandidateSources(record.club))),
+  ].sort();
+  elements.sourceSelect.innerHTML = [
+    '<option value="all">all sources</option>',
+    ...sources.map(
+      (source) => `<option value="${escapeHtml(source)}">${escapeHtml(source)}</option>`
+    ),
+  ].join('');
+  elements.sourceSelect.value = state.source;
+}
+
+function renderStats(records, visibleIssues) {
+  const candidateCount = records.reduce((total, record) => total + candidateCountFor(record), 0);
+  const flagCount = Object.keys(state.flags).length;
+  elements.statTotal.textContent = String(state.clubs.length);
+  elements.statVisible.textContent = String(records.length);
+  elements.statReview.textContent = String(visibleIssues.length);
+  elements.statCandidates.textContent = String(candidateCount);
+  elements.clubListCount.textContent = `${records.length} clubs`;
+  elements.auditCount.textContent = `${records.length} clubs`;
+  elements.issueCount.textContent = `${visibleIssues.length} issues`;
+  elements.flagCount.textContent = `${flagCount} flagged`;
+  elements.exportFlagsButton.disabled = flagCount === 0;
+  elements.clearFlagsButton.disabled = flagCount === 0;
+}
+
+function renderSourceRefs(record) {
+  const sourceRefs = [
+    ...(record.club.derived?.identitySources || []),
+    ...(record.club.status?.sourceRefs || []),
+  ].filter((source) => source.sourceUrl);
+  const uniqueSourceRefs = [
+    ...new Map(sourceRefs.map((source) => [source.sourceUrl, source])).values(),
+  ];
+  if (!uniqueSourceRefs.length) return '<span class="asset-muted">no club source links</span>';
+  return uniqueSourceRefs
+    .map(
+      (source) =>
+        `<a class="compact-link" href="${escapeHtml(
+          source.sourceUrl
+        )}" target="_blank" rel="noreferrer">${escapeHtml(source.type || 'source')}</a>`
+    )
+    .join('');
+}
+
+function renderClubList(records) {
+  if (!records.length) {
+    elements.clubList.innerHTML = '<p class="empty-state">No clubs match the current filters.</p>';
+    state.selectedClubKey = null;
+    return;
+  }
+
+  if (
+    !state.selectedClubKey ||
+    !records.some((record) => record.clubKey === state.selectedClubKey)
+  ) {
+    state.selectedClubKey = records[0].clubKey;
+  }
+
+  elements.clubList.innerHTML = records
+    .map((record) => {
+      const crest = getCrest(record.club);
+      const selectedClass = record.clubKey === state.selectedClubKey ? ' is-selected' : '';
+      return `<button class="club-row${selectedClass}" type="button" data-club-key="${escapeHtml(
+        record.clubKey
+      )}">
+        <span class="club-row-main">
+          <strong>${escapeHtml(record.club.canonicalName)}</strong>
+          <span class="status-chip" data-status="${escapeHtml(crest.status)}">${escapeHtml(
+        STATUS_LABELS[crest.status] || crest.status
+      )}</span>
+        </span>
+        <span class="asset-muted">${candidateCountFor(record)}</span>
+        <span class="club-row-meta">
+          <span>${escapeHtml(record.club.status?.current || 'unknown')}</span>
+          <span>${escapeHtml(getCandidateSources(record.club).join(', ') || 'no source')}</span>
+          <span>${issueCountFor(record)} issues</span>
+        </span>
+      </button>`;
+    })
+    .join('');
+}
+
+function renderCandidateImage(candidate, clubName) {
+  if (!candidate.imageUrl) return '<div class="candidate-empty">No image URL</div>';
+  return `<img src="${escapeHtml(candidate.imageUrl)}" alt="${escapeHtml(
+    `${clubName} ${candidate.status} crest candidate`
+  )}" loading="lazy" referrerpolicy="no-referrer" />`;
+}
+
+function renderCandidateLinks(candidate) {
+  const links = [
+    candidate.sourceUrl
+      ? `<a class="compact-link" href="${escapeHtml(
+          candidate.sourceUrl
+        )}" target="_blank" rel="noreferrer">source</a>`
+      : '',
+    candidate.pageUrl
+      ? `<a class="compact-link" href="${escapeHtml(
+          candidate.pageUrl
+        )}" target="_blank" rel="noreferrer">file page</a>`
+      : '',
+    candidate.imageUrl && !candidate.imageUrl.startsWith('data:')
+      ? `<a class="compact-link" href="${escapeHtml(
+          candidate.imageUrl
+        )}" target="_blank" rel="noreferrer">image</a>`
+      : '',
+  ].filter(Boolean);
+  return links.length ? `<div class="candidate-links">${links.join('')}</div>` : '';
+}
+
+function renderSwatches(colors = []) {
+  if (!colors.length) return '';
+  return `<div class="swatches">${colors
+    .map(
+      (color) =>
+        `<span class="swatch"><i style="background:${escapeHtml(color.hex)}"></i>${escapeHtml(
+          color.role
+        )} ${escapeHtml(color.hex)}</span>`
+    )
+    .join('')}</div>`;
+}
+
+function renderReviewReasons(candidate) {
+  const reasons = candidate.verification?.reviewReasons || [];
+  if (!reasons.length) return '<span class="asset-muted">none</span>';
+  return reasons.map((reason) => `<span class="issue-chip">${escapeHtml(reason)}</span>`).join(' ');
+}
+
+function renderCandidate(candidate, record) {
+  const clubName = record.club.canonicalName;
+  const flagKey = flagKeyFor(record, candidate);
+  const flagged = Boolean(state.flags[flagKey]);
+  return `<article class="candidate-card">
+    <div class="candidate-image-frame">${renderCandidateImage(candidate, clubName)}</div>
+    <div class="candidate-body">
+      <div class="candidate-title">
+        <h3>${escapeHtml(candidate.fileTitle || candidate.assetId)}</h3>
+        <span class="status-chip" data-status="${escapeHtml(candidate.status)}">${escapeHtml(
+    STATUS_LABELS[candidate.status] || candidate.status
+  )}</span>
+        ${candidate.placeholder ? '<span class="issue-chip">generated</span>' : ''}
+        ${flagged ? '<span class="flag-chip">flagged</span>' : ''}
+      </div>
+      <dl class="candidate-meta">
+        <div>
+          <dt>Source</dt>
+          <dd>${escapeHtml(candidate.source || '-')}</dd>
+        </div>
+        <div>
+          <dt>License</dt>
+          <dd>${escapeHtml(candidate.license?.shortName || 'unknown')}</dd>
+        </div>
+        <div>
+          <dt>Verification</dt>
+          <dd>${escapeHtml(candidate.verification?.identityMatch || '-')} / ${escapeHtml(
+    candidate.verification?.licenseCheck || '-'
+  )}</dd>
+        </div>
+        <div>
+          <dt>Review reasons</dt>
+          <dd>${renderReviewReasons(candidate)}</dd>
+        </div>
+      </dl>
+      ${renderSwatches(candidate.colors)}
+      ${candidate.notes ? `<p class="asset-muted">${escapeHtml(candidate.notes)}</p>` : ''}
+      <div class="flag-actions">
+        <button class="flag-button" type="button" data-flag-key="${escapeHtml(
+          flagKey
+        )}" aria-pressed="${flagged}">
+          ${flagged ? 'Unflag' : 'Flag image'}
+        </button>
+      </div>
+      ${renderCandidateLinks(candidate)}
+    </div>
+  </article>`;
+}
+
+function renderDetail(records) {
+  const record = records.find((entry) => entry.clubKey === state.selectedClubKey);
+  if (!record) {
+    elements.clubDetail.innerHTML = `<div class="detail-heading">
+      <div class="detail-title-row"><h2>Select a club</h2></div>
+      <p class="asset-muted">Choose a record from the club list to inspect candidate images.</p>
+    </div>`;
+    return;
+  }
+
+  const crest = getCrest(record.club);
+  const candidates = getCandidates(record.club);
+
+  elements.clubDetail.innerHTML = `<div class="detail-heading">
+    <div class="detail-title-row">
+      <h2>${escapeHtml(record.club.canonicalName)}</h2>
+      <span class="status-chip" data-status="${escapeHtml(crest.status)}">${escapeHtml(
+    STATUS_LABELS[crest.status] || crest.status
+  )}</span>
+      <span class="issue-chip">${issueCountFor(record)} issues</span>
+    </div>
+    <p class="asset-muted">${escapeHtml(record.club.clubId || record.clubKey)} · ${escapeHtml(
+    record.club.status?.current || 'unknown'
+  )} · ${escapeHtml(record.club.status?.reasonLabel || record.club.status?.reason || '')}</p>
+    <div class="detail-links">
+      ${renderSourceRefs(record)}
+    </div>
+  </div>
+  <div class="candidate-grid">
+    ${
+      candidates.length
+        ? candidates.map((candidate) => renderCandidate(candidate, record)).join('')
+        : '<p class="empty-state">No crest candidates found for this club.</p>'
+    }
+  </div>`;
+}
+
+function renderAuditClub(record) {
+  const crest = getCrest(record.club);
+  const candidates = getCandidates(record.club);
+  const preferred = candidates.find((candidate) => candidate.assetId === crest.preferred);
+  return `<article class="audit-club">
+    <div class="audit-club-heading">
+      <div>
+        <h3>${escapeHtml(record.club.canonicalName)}</h3>
+        <p class="asset-muted">${escapeHtml(record.club.clubId || record.clubKey)} · ${escapeHtml(
+    record.club.status?.current || 'unknown'
+  )}</p>
+      </div>
+      <div class="audit-badges">
+        <span class="status-chip" data-status="${escapeHtml(crest.status)}">${escapeHtml(
+    STATUS_LABELS[crest.status] || crest.status
+  )}</span>
+        <span class="issue-chip">${candidateCountFor(record)} candidates</span>
+        <span class="issue-chip">${issueCountFor(record)} issues</span>
+      </div>
+    </div>
+    <div class="audit-links">
+      <span class="asset-muted">Club links</span>
+      ${renderSourceRefs(record)}
+    </div>
+    ${
+      preferred
+        ? `<p class="asset-muted">Preferred: ${escapeHtml(
+            preferred.fileTitle || preferred.assetId
+          )}</p>`
+        : ''
+    }
+    <div class="audit-candidates">
+      ${
+        candidates.length
+          ? candidates.map((candidate) => renderCandidate(candidate, record)).join('')
+          : '<p class="empty-state">No crest candidates found for this club.</p>'
+      }
+    </div>
+  </article>`;
+}
+
+function renderAuditList(records) {
+  if (!records.length) {
+    elements.auditList.innerHTML = '<p class="empty-state">No clubs match the current filters.</p>';
+    return;
+  }
+
+  elements.auditList.innerHTML = records.map((record) => renderAuditClub(record)).join('');
+}
+
+function renderIssueTable(issues) {
+  if (!issues.length) {
+    elements.issueTableBody.innerHTML = '<tr><td colspan="4">No visible review issues.</td></tr>';
+    return;
+  }
+
+  elements.issueTableBody.innerHTML = issues
+    .slice(0, 250)
+    .map(
+      (issue) => `<tr>
+        <td>${escapeHtml(issue.canonicalName || issue.clubKey)}</td>
+        <td><span class="issue-chip">${escapeHtml(issue.type)}</span></td>
+        <td>${escapeHtml(issue.assetId || '-')}</td>
+        <td>${escapeHtml(issue.message || '')}</td>
+      </tr>`
+    )
+    .join('');
+}
+
+function render() {
+  const visibleRecords = getVisibleRecords();
+  const visibleIssues = getVisibleIssues(visibleRecords);
+  renderViewTabs();
+  renderStatusTabs();
+  renderFilterOptions();
+  renderStats(visibleRecords, visibleIssues);
+  renderClubList(visibleRecords);
+  renderDetail(visibleRecords);
+  renderIssueTable(visibleIssues);
+  elements.reviewWorkspace.hidden = state.view !== 'review';
+  elements.issueWorkspace.hidden = state.view !== 'review';
+  elements.auditWorkspace.hidden = state.view !== 'audit';
+  if (state.view === 'audit') {
+    renderAuditList(visibleRecords);
+  } else {
+    elements.auditList.innerHTML = '';
+  }
+}
+
+function wireEvents() {
+  elements.searchInput.addEventListener('input', (event) => {
+    state.search = event.target.value;
+    render();
+  });
+  elements.issueSelect.addEventListener('change', (event) => {
+    state.issue = event.target.value;
+    render();
+  });
+  elements.sourceSelect.addEventListener('change', (event) => {
+    state.source = event.target.value;
+    render();
+  });
+  elements.resetButton.addEventListener('click', () => {
+    state.status = state.view === 'audit' ? 'all' : 'needs-review';
+    state.issue = 'all';
+    state.source = 'all';
+    state.search = '';
+    state.flaggedOnly = false;
+    state.selectedClubKey = null;
+    elements.searchInput.value = '';
+    elements.flaggedOnlyInput.checked = false;
+    render();
+  });
+  elements.flaggedOnlyInput.addEventListener('change', (event) => {
+    state.flaggedOnly = event.target.checked;
+    state.selectedClubKey = null;
+    render();
+  });
+  elements.exportFlagsButton.addEventListener('click', () => {
+    exportFlags();
+  });
+  elements.clearFlagsButton.addEventListener('click', () => {
+    if (!Object.keys(state.flags).length) return;
+    state.flags = {};
+    writeStoredFlags();
+    render();
+  });
+  elements.viewTabs.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-view]');
+    if (!button) return;
+    state.view = button.dataset.view;
+    state.status = state.view === 'audit' ? 'all' : 'needs-review';
+    state.issue = 'all';
+    state.source = 'all';
+    state.search = '';
+    state.flaggedOnly = false;
+    state.selectedClubKey = null;
+    elements.searchInput.value = '';
+    elements.flaggedOnlyInput.checked = false;
+    render();
+  });
+  elements.statusTabs.addEventListener('click', (event) => {
+    const button = event.target.closest('button[data-status]');
+    if (!button) return;
+    state.status = button.dataset.status;
+    state.selectedClubKey = null;
+    render();
+  });
+  elements.clubList.addEventListener('click', (event) => {
+    const row = event.target.closest('button[data-club-key]');
+    if (!row) return;
+    state.selectedClubKey = row.dataset.clubKey;
+    render();
+  });
+  document.addEventListener('click', (event) => {
+    const flagButton = event.target.closest('button[data-flag-key]');
+    if (!flagButton) return;
+    toggleFlag(flagButton.dataset.flagKey);
+  });
+}
+
+async function init() {
+  state.flags = readStoredFlags();
+  wireEvents();
+  try {
+    const [metadata, review] = await Promise.all([
+      fetchJson(CLUB_METADATA_URL),
+      fetchJson(REVIEW_URL),
+    ]);
+    const issuesByClub = new Map();
+    for (const issue of review.issues || []) {
+      const list = issuesByClub.get(issue.clubKey) || [];
+      list.push(issue);
+      issuesByClub.set(issue.clubKey, list);
+    }
+
+    state.issues = review.issues || [];
+    state.clubs = Object.entries(metadata.clubs || {}).map(([clubKey, club]) => {
+      const record = {
+        clubKey,
+        club,
+        issues: issuesByClub.get(clubKey) || [],
+      };
+      record.searchText = buildSearchText(record);
+      return record;
+    });
+    elements.loadStatus.textContent = `Loaded ${state.clubs.length} clubs and ${state.issues.length} review issues.`;
+    render();
+  } catch (error) {
+    elements.loadStatus.textContent = error.message;
+    elements.clubList.innerHTML =
+      '<p class="empty-state">Could not load local JSON. Serve the repo root over HTTP and reopen this page.</p>';
+    elements.issueTableBody.innerHTML = '<tr><td colspan="4">No issue data loaded.</td></tr>';
+  }
+}
+
+init();

--- a/docs/club-assets.md
+++ b/docs/club-assets.md
@@ -43,11 +43,18 @@ object with review reasons.
 The current discovery order is:
 
 1. Wikipedia PageImages with `pilicense=free`.
-2. Wikidata `P154` logo image, resolved through Wikimedia image metadata.
+2. Wikidata media properties, resolved through Wikimedia image metadata:
+   - `P154` logo image
+   - `P94` coat of arms image
+   - `P18` image
 3. Wikipedia PageImages with `pilicense=any`.
 
 Restricted candidates are preserved as backups but should not be selected as
 `preferred` while a usable candidate exists.
+
+Wikidata `P154` and `P94` candidates are treated as crest-like when they match
+the club identity. Generic `P18` image candidates still need filename or other
+crest evidence, because they often point to squads, grounds, or match photos.
 
 ## Running Discovery
 
@@ -109,6 +116,9 @@ Expected high-volume findings:
 - Some historical clubs have no discoverable page image.
 - Some free page images are photos, charts, or grounds. These should stay
   `needs-review` unless they clearly represent a crest/badge/logo.
+- Some Victorian or folded clubs may need a future curated
+  `no-known-crest`/historical status. Do not infer that automatically from a
+  missing automated result.
 
 Reviewers should promote a candidate only when both identity and license are
 clear. Do not hand-edit generated output without moving the rule into generator

--- a/docs/club-assets.md
+++ b/docs/club-assets.md
@@ -27,6 +27,9 @@ Each club can expose:
 
 - `usable` means at least one preferred candidate has an acceptable license and
   looks like a crest, badge, logo, shield, or emblem.
+- `placeholder` means the preferred candidate is a generated shield based on
+  curated/source-backed club colours. It is safe to render, but is not an
+  official or historical club crest.
 - `restricted` means candidates exist but the best available candidate is
   restricted, commonly Wikipedia fair use.
 - `needs-review` means candidates exist but identity, license, or crest
@@ -35,7 +38,8 @@ Each club can expose:
 - `failed` means a candidate could not be resolved.
 
 Each candidate includes source fields such as `source`, `sourceUrl`, `imageUrl`,
-`fileTitle`, `mimeType`, dimensions, license metadata, and a `verification`
+`fileTitle`, `mimeType`, dimensions, license metadata, optional structured
+`colors`, a `placeholder` flag for generated shields, and a `verification`
 object with review reasons.
 
 ## Sources
@@ -48,6 +52,8 @@ The current discovery order is:
    - `P94` coat of arms image
    - `P18` image
 3. Wikipedia PageImages with `pilicense=any`.
+4. Generated placeholder shields for curated historical missing clubs with
+   source-backed colours.
 
 Restricted candidates are preserved as backups but should not be selected as
 `preferred` while a usable candidate exists.
@@ -55,6 +61,11 @@ Restricted candidates are preserved as backups but should not be selected as
 Wikidata `P154` and `P94` candidates are treated as crest-like when they match
 the club identity. Generic `P18` image candidates still need filename or other
 crest evidence, because they often point to squads, grounds, or match photos.
+
+Generated placeholders are SVG data URLs. They use `source:
+generated-placeholder`, `status: placeholder`, `placeholder: true`, and CC0
+license metadata so consumers can render or filter them independently from
+official/source-discovered crest candidates.
 
 ## Running Discovery
 
@@ -119,6 +130,9 @@ Expected high-volume findings:
 - Some Victorian or folded clubs may need a future curated
   `no-known-crest`/historical status. Do not infer that automatically from a
   missing automated result.
+- Generated placeholders should only be added from curated colors and should
+  remain visibly simple. They are a fallback for consumers, not evidence that an
+  official crest existed.
 
 Reviewers should promote a candidate only when both identity and license are
 clear. Do not hand-edit generated output without moving the rule into generator

--- a/docs/club-assets.md
+++ b/docs/club-assets.md
@@ -34,7 +34,8 @@ Each club can expose:
   restricted, commonly Wikipedia fair use.
 - `needs-review` means candidates exist but identity, license, or crest
   confidence is unclear.
-- `missing` means no candidate was discovered.
+- `needs-more-research` means no acceptable candidate is available yet. These
+  clubs need color/source research before a generated placeholder can be added.
 - `failed` means a candidate could not be resolved.
 
 Each candidate includes source fields such as `source`, `sourceUrl`, `imageUrl`,
@@ -113,7 +114,7 @@ node wikipedia/data/generate-club-assets.js ./data/club-metadata.json \
 
 The review output reports issue types:
 
-- `club-asset-missing`
+- `club-asset-needs-more-research`
 - `club-asset-license-restricted`
 - `club-asset-identity-uncertain`
 - `club-asset-non-crest-candidate`
@@ -129,7 +130,7 @@ Expected high-volume findings:
   `needs-review` unless they clearly represent a crest/badge/logo.
 - Some Victorian or folded clubs may need a future curated
   `no-known-crest`/historical status. Do not infer that automatically from a
-  missing automated result.
+  `needs-more-research` automated result.
 - Generated placeholders should only be added from curated colors and should
   remain visibly simple. They are a fallback for consumers, not evidence that an
   official crest existed.

--- a/docs/club-assets.md
+++ b/docs/club-assets.md
@@ -63,8 +63,7 @@ Wikidata `P154` and `P94` candidates are treated as crest-like when they match
 the club identity. Generic `P18` image candidates still need filename or other
 crest evidence, because they often point to squads, grounds, or match photos.
 
-Generated placeholders are SVG data URLs. They use `source:
-generated-placeholder`, `status: placeholder`, `placeholder: true`, and CC0
+Generated placeholders are SVG data URLs. They use `source: generated-placeholder`, `status: placeholder`, `placeholder: true`, and CC0
 license metadata so consumers can render or filter them independently from
 official/source-discovered crest candidates.
 

--- a/docs/club-assets.md
+++ b/docs/club-assets.md
@@ -1,0 +1,115 @@
+# Club Asset Metadata
+
+Club assets are optional metadata on `data/club-metadata.json` records. The first
+supported asset kind is `assets.crest`; the shape is intentionally generic so
+future asset kinds can reuse the same bundle and candidate model.
+
+The asset pipeline stores image URLs and provenance only. It does not download
+or commit image binaries.
+
+## Contract
+
+Each club can expose:
+
+```json
+{
+  "assets": {
+    "crest": {
+      "preferred": "wikipedia-pageimage-free:Example_FC_crest.svg",
+      "status": "usable",
+      "candidates": []
+    }
+  }
+}
+```
+
+`assets.crest.status` summarizes the candidate set:
+
+- `usable` means at least one preferred candidate has an acceptable license and
+  looks like a crest, badge, logo, shield, or emblem.
+- `restricted` means candidates exist but the best available candidate is
+  restricted, commonly Wikipedia fair use.
+- `needs-review` means candidates exist but identity, license, or crest
+  confidence is unclear.
+- `missing` means no candidate was discovered.
+- `failed` means a candidate could not be resolved.
+
+Each candidate includes source fields such as `source`, `sourceUrl`, `imageUrl`,
+`fileTitle`, `mimeType`, dimensions, license metadata, and a `verification`
+object with review reasons.
+
+## Sources
+
+The current discovery order is:
+
+1. Wikipedia PageImages with `pilicense=free`.
+2. Wikidata `P154` logo image, resolved through Wikimedia image metadata.
+3. Wikipedia PageImages with `pilicense=any`.
+
+Restricted candidates are preserved as backups but should not be selected as
+`preferred` while a usable candidate exists.
+
+## Running Discovery
+
+Use the standalone command so normal club metadata generation stays
+deterministic unless assets are explicitly refreshed:
+
+```bash
+pnpm -s wiki:club-assets
+```
+
+For full runs, prefer a cache and conservative delay:
+
+```bash
+node wikipedia/data/generate-club-assets.js ./data/club-metadata.json \
+  --output ./data/club-metadata.json \
+  --review-output ./data/club-assets-review.json \
+  --cache ./data/club-assets-cache.json \
+  --request-delay-ms 750
+```
+
+The cache is a resumable working artifact. Commit it only if we decide to make
+asset-discovery state part of the published workflow; otherwise use a temporary
+path during research.
+
+Useful smoke options:
+
+```bash
+# Process only the first 50 clubs
+node wikipedia/data/generate-club-assets.js ./data/club-metadata.json \
+  --output /private/tmp/club-assets-sample.json \
+  --review-output /private/tmp/club-assets-review-sample.json \
+  --cache /private/tmp/club-assets-cache.json \
+  --club-limit 50 \
+  --request-delay-ms 500
+
+# Ignore cache entries and refresh source lookups
+node wikipedia/data/generate-club-assets.js ./data/club-metadata.json \
+  --output /private/tmp/club-assets-refresh.json \
+  --review-output /private/tmp/club-assets-review-refresh.json \
+  --cache /private/tmp/club-assets-cache.json \
+  --refresh-assets
+```
+
+## Manual Review
+
+The review output reports issue types:
+
+- `club-asset-missing`
+- `club-asset-license-restricted`
+- `club-asset-identity-uncertain`
+- `club-asset-non-crest-candidate`
+- `club-asset-url-failed`
+- `club-asset-multiple-review-candidates`
+
+Expected high-volume findings:
+
+- Most active professional club crests from English Wikipedia are fair-use files
+  and should remain `restricted`.
+- Some historical clubs have no discoverable page image.
+- Some free page images are photos, charts, or grounds. These should stay
+  `needs-review` unless they clearly represent a crest/badge/logo.
+
+Reviewers should promote a candidate only when both identity and license are
+clear. Do not hand-edit generated output without moving the rule into generator
+logic or a future curated override file.

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,6 +29,9 @@
           <a class="button-link button-link--primary" href="./explorer-prototype.html"
             >Explore data</a
           >
+          <a class="button-link button-link--secondary" href="./club-assets-review.html"
+            >Review club assets</a
+          >
           <a
             class="button-link button-link--secondary"
             href="https://github.com/dills122/footy-data-kit/releases/latest/download/all-seasons.min.json"
@@ -77,6 +80,7 @@
             <span class="link-group-label">Site</span>
             <div class="link-grid">
               <a href="./explorer-prototype.html">Data explorer</a>
+              <a href="./club-assets-review.html">Club asset review</a>
               <a href="./releases/">Release notes</a>
               <a href="./schema/">Schema docs</a>
             </div>
@@ -335,7 +339,7 @@
           </li>
           <li>
             <code>club-metadata.json</code>
-            <span>Club identity sidecar metadata. 1.9M.</span>
+            <span>Club identity sidecar metadata. 2.5M.</span>
             <a
               class="compact-link"
               href="https://github.com/dills122/footy-data-kit/releases/latest/download/club-metadata.json"

--- a/docs/schema/club-metadata.html
+++ b/docs/schema/club-metadata.html
@@ -99,6 +99,24 @@
           ><a href="#integer-list">
             <span>Integer List</span>
             <code>IntegerList</code> </a
+          ><a href="#metadata-asset-bundle">
+            <span>Metadata Asset Bundle</span>
+            <code>MetadataAssetBundle</code> </a
+          ><a href="#metadata-asset-candidate">
+            <span>Metadata Asset Candidate</span>
+            <code>MetadataAssetCandidate</code> </a
+          ><a href="#metadata-asset-color">
+            <span>Metadata Asset Color</span>
+            <code>MetadataAssetColor</code> </a
+          ><a href="#metadata-asset-license">
+            <span>Metadata Asset License</span>
+            <code>MetadataAssetLicense</code> </a
+          ><a href="#metadata-assets">
+            <span>Metadata Assets</span>
+            <code>MetadataAssets</code> </a
+          ><a href="#metadata-asset-verification">
+            <span>Metadata Asset Verification</span>
+            <code>MetadataAssetVerification</code> </a
           ><a href="#source-refs">
             <span>Source Refs</span>
             <code>SourceRefs</code> </a
@@ -688,6 +706,14 @@
               <th scope="row"><code>derived</code></th>
               <td>
                 <a href="#club-derived-metadata"><code>ClubDerivedMetadata</code></a>
+              </td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>assets</code></th>
+              <td>
+                <a href="#metadata-assets"><code>MetadataAssets</code></a>
               </td>
               <td><span class="schema-requirement is-optional">optional</span></td>
               <td><span class="schema-muted">No description.</span></td>
@@ -1306,6 +1332,396 @@
         </div>
 
         <p class="schema-muted">No named properties.</p>
+      </section>
+      <section class="panel schema-definition" id="metadata-asset-bundle">
+        <div class="section-heading">
+          <div>
+            <h2>Metadata Asset Bundle</h2>
+            <code class="schema-symbol">MetadataAssetBundle</code>
+          </div>
+          <a href="#metadata-asset-bundle">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>1 required</span><span>closed object</span>
+        </div>
+
+        <table class="schema-table">
+          <thead>
+            <tr>
+              <th scope="col">Property key</th>
+              <th scope="col">Type</th>
+              <th scope="col">Use</th>
+              <th scope="col">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row"><code>preferred</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td>
+                assetId for the preferred candidate, or null when no candidate is safe to prefer.
+              </td>
+            </tr>
+            <tr>
+              <th scope="row"><code>status</code></th>
+              <td><code>string</code></td>
+              <td><span class="schema-requirement is-required">required</span></td>
+              <td>
+                Overall bundle status such as usable, placeholder, restricted, needs-review,
+                needs-more-research, or failed.
+              </td>
+            </tr>
+            <tr>
+              <th scope="row"><code>candidates</code></th>
+              <td><code>array</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section class="panel schema-definition" id="metadata-asset-candidate">
+        <div class="section-heading">
+          <div>
+            <h2>Metadata Asset Candidate</h2>
+            <code class="schema-symbol">MetadataAssetCandidate</code>
+          </div>
+          <a href="#metadata-asset-candidate">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>4 required</span><span>closed object</span>
+        </div>
+
+        <table class="schema-table">
+          <thead>
+            <tr>
+              <th scope="col">Property key</th>
+              <th scope="col">Type</th>
+              <th scope="col">Use</th>
+              <th scope="col">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row"><code>assetId</code></th>
+              <td><code>string</code></td>
+              <td><span class="schema-requirement is-required">required</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>kind</code></th>
+              <td><code>string</code></td>
+              <td><span class="schema-requirement is-required">required</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>status</code></th>
+              <td><code>string</code></td>
+              <td><span class="schema-requirement is-required">required</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>priority</code></th>
+              <td><code>integer</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>source</code></th>
+              <td><code>string</code></td>
+              <td><span class="schema-requirement is-required">required</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>sourceUrl</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>imageUrl</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>pageUrl</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>fileTitle</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>mimeType</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>width</code></th>
+              <td><code>integer</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>height</code></th>
+              <td><code>integer</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>license</code></th>
+              <td>
+                <a href="#metadata-asset-license"><code>MetadataAssetLicense</code></a>
+              </td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>colors</code></th>
+              <td><code>array</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td>Structured color hints used by generated placeholders or asset consumers.</td>
+            </tr>
+            <tr>
+              <th scope="row"><code>placeholder</code></th>
+              <td><code>boolean</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td>
+                True when the candidate is a generated placeholder rather than an official or
+                source-discovered asset.
+              </td>
+            </tr>
+            <tr>
+              <th scope="row"><code>verification</code></th>
+              <td>
+                <a href="#metadata-asset-verification"><code>MetadataAssetVerification</code></a>
+              </td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>notes</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section class="panel schema-definition" id="metadata-asset-color">
+        <div class="section-heading">
+          <div>
+            <h2>Metadata Asset Color</h2>
+            <code class="schema-symbol">MetadataAssetColor</code>
+          </div>
+          <a href="#metadata-asset-color">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>2 required</span><span>closed object</span>
+        </div>
+
+        <table class="schema-table">
+          <thead>
+            <tr>
+              <th scope="col">Property key</th>
+              <th scope="col">Type</th>
+              <th scope="col">Use</th>
+              <th scope="col">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row"><code>role</code></th>
+              <td><code>string</code></td>
+              <td><span class="schema-requirement is-required">required</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>hex</code></th>
+              <td><code>string</code></td>
+              <td><span class="schema-requirement is-required">required</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section class="panel schema-definition" id="metadata-asset-license">
+        <div class="section-heading">
+          <div>
+            <h2>Metadata Asset License</h2>
+            <code class="schema-symbol">MetadataAssetLicense</code>
+          </div>
+          <a href="#metadata-asset-license">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>closed object</span>
+        </div>
+
+        <table class="schema-table">
+          <thead>
+            <tr>
+              <th scope="col">Property key</th>
+              <th scope="col">Type</th>
+              <th scope="col">Use</th>
+              <th scope="col">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row"><code>shortName</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>usageTerms</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>licenseUrl</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>copyrighted</code></th>
+              <td><code>boolean</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>attribution</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>credit</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>artist</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section class="panel schema-definition" id="metadata-assets">
+        <div class="section-heading">
+          <div>
+            <h2>Metadata Assets</h2>
+            <code class="schema-symbol">MetadataAssets</code>
+          </div>
+          <a href="#metadata-assets">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+        </div>
+        <p>
+          Visual and media asset candidates for this metadata identity. v1 populates club crest
+          candidates only.
+        </p>
+        <table class="schema-table">
+          <thead>
+            <tr>
+              <th scope="col">Property key</th>
+              <th scope="col">Type</th>
+              <th scope="col">Use</th>
+              <th scope="col">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row"><code>crest</code></th>
+              <td>
+                <a href="#metadata-asset-bundle"><code>MetadataAssetBundle</code></a>
+              </td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+          </tbody>
+        </table>
+      </section>
+      <section class="panel schema-definition" id="metadata-asset-verification">
+        <div class="section-heading">
+          <div>
+            <h2>Metadata Asset Verification</h2>
+            <code class="schema-symbol">MetadataAssetVerification</code>
+          </div>
+          <a href="#metadata-asset-verification">anchor</a>
+        </div>
+        <div class="schema-summary">
+          <span>type <code>object</code></span>
+          <span>closed object</span>
+        </div>
+
+        <table class="schema-table">
+          <thead>
+            <tr>
+              <th scope="col">Property key</th>
+              <th scope="col">Type</th>
+              <th scope="col">Use</th>
+              <th scope="col">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row"><code>identityMatch</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>licenseCheck</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>httpCheck</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>needsManualReview</code></th>
+              <td><code>boolean</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>reviewReasons</code></th>
+              <td>
+                <a href="#string-list"><code>StringList</code></a>
+              </td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+            <tr>
+              <th scope="row"><code>checkedAt</code></th>
+              <td><code>string</code> | <code>null</code></td>
+              <td><span class="schema-requirement is-optional">optional</span></td>
+              <td><span class="schema-muted">No description.</span></td>
+            </tr>
+          </tbody>
+        </table>
       </section>
       <section class="panel schema-definition" id="source-refs">
         <div class="section-heading">

--- a/docs/site-data.json
+++ b/docs/site-data.json
@@ -21,6 +21,7 @@
       "label": "Site",
       "links": [
         { "label": "Data explorer", "url": "./explorer-prototype.html" },
+        { "label": "Club asset review", "url": "./club-assets-review.html" },
         { "label": "Release notes", "url": "./releases/" },
         { "label": "Schema docs", "url": "./schema/" }
       ]
@@ -50,6 +51,11 @@
       "label": "Explore data",
       "url": "./explorer-prototype.html",
       "className": "button-link--primary"
+    },
+    {
+      "label": "Review club assets",
+      "url": "./club-assets-review.html",
+      "className": "button-link--secondary"
     },
     {
       "label": "Download JSON",
@@ -201,7 +207,7 @@
     {
       "file": "club-metadata.json",
       "description": "Club identity sidecar metadata.",
-      "size": "1.9M",
+      "size": "2.5M",
       "links": [
         {
           "label": "json",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "wiki:build:lower-tiers": "node wikipedia/cli/index.js lower-tiers --start 1979 --end 2025 --output ./data-output --force-update",
     "wiki:build:combined": "node wikipedia/data/combine-output-files.js --output ./data-output/all-seasons.json ./data-output/wiki_overview_tables_by_season.json",
     "wiki:club-seed": "node wikipedia/data/generate-club-metadata-seed.js ./data-output/all-seasons.json --output ./data/club-metadata.json",
+    "wiki:club-assets": "node wikipedia/data/generate-club-assets.js ./data/club-metadata.json --output ./data/club-metadata.json",
     "wiki:club-historical-audit": "node wikipedia/data/verify-club-continuity.js --check-historical-reasons --suggest-historical-reasons-from-wikipedia --wikipedia-limit 1000 --output ./data/club-historical-reason-audit.json",
     "wiki:club-historical-audit:check": "node wikipedia/data/verify-club-continuity.js --check-historical-reasons --fail-on-issues",
     "wiki:club-verify": "node wikipedia/data/verify-club-continuity.js",

--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,7 @@ Each run saves season-by-season progress immediately, so reruns are fast. The `c
 
 - `wikipedia/data/combine-output-files.js` – merge multiple FootballData JSON files, drop war-year placeholders, prefer the richest tier record for each season, and show a grouped “missing seasons” summary. Use `--include-empty` to keep placeholder entries, `--compact` for minified JSON, and repeat `--club-metadata <file>` to merge sidecar club metadata.
 - `wikipedia/data/generate-club-metadata-seed.js` – derive the club metadata sidecar from an existing FootballData JSON file plus curated source-backed lifecycle rules.
+- `wikipedia/data/generate-club-assets.js` – discover and verify club crest candidates for the club metadata sidecar. Use `pnpm -s wiki:club-assets` for the default command; see `docs/club-assets.md` for cache, review, and licensing workflow.
 - `wikipedia/data/verify-club-continuity.js` – verify club metadata continuity and historical status reasons. Use `pnpm -s wiki:club-historical-audit` to write the repo review artifact at `data/club-historical-reason-audit.json`; use `pnpm -s wiki:club-historical-audit:check` or `pnpm -s verify:data` for fail-on-issues checks.
 - `wikipedia/data/compare-football-data.js` – compare two FootballData JSON files and report season, tier, table, outcome-list, and metadata changes between releases. Pass `--json` for machine-readable output.
   Pass `--markdown` for a release-note-friendly summary.
@@ -204,8 +205,10 @@ Each run saves season-by-season progress immediately, so reruns are fast. The `c
   - `derived.tiersSeen`
   - `derived.tierSeasons`
   - `derived.coverageGaps`
+  - `assets.crest` with optional crest image candidates, license metadata, verification flags, and a preferred usable candidate when one is available
 - `derived.coverageGaps` means gaps in this dataset's observed league-table coverage, not confirmed inactivity or a financial interruption.
 - `history` is reserved for source-backed facts and explanations. Generated observations should stay under `derived`.
+- `assets` stores image URLs and provenance only. It does not embed or download image binaries. See `docs/club-assets.md` for candidate statuses and manual review rules.
 - `clubId` is additive; season table rows still expose the scraped/canonical `team` text and do not yet embed `clubId`.
 - Each season contains a `seasonInfo` summary object plus one or more `tierN` objects.
 - `seasonInfo` is not a league table. It is a season-level summary that currently stores:
@@ -234,6 +237,9 @@ pnpm -s wiki:build:combined
 
 # Build sidecar club metadata
 pnpm -s wiki:club-seed
+
+# Discover club crest asset candidates
+pnpm -s wiki:club-assets
 
 # Run the data lint pass and historical club-reason check
 pnpm -s verify:data

--- a/schemas/club-metadata.schema.json
+++ b/schemas/club-metadata.schema.json
@@ -257,7 +257,7 @@
         },
         "status": {
           "type": "string",
-          "description": "Overall bundle status such as usable, restricted, needs-review, missing, or failed."
+          "description": "Overall bundle status such as usable, placeholder, restricted, needs-review, needs-more-research, or failed."
         },
         "candidates": {
           "type": "array",

--- a/schemas/club-metadata.schema.json
+++ b/schemas/club-metadata.schema.json
@@ -318,11 +318,36 @@
         "license": {
           "$ref": "#/definitions/MetadataAssetLicense"
         },
+        "colors": {
+          "type": "array",
+          "description": "Structured color hints used by generated placeholders or asset consumers.",
+          "items": {
+            "$ref": "#/definitions/MetadataAssetColor"
+          }
+        },
+        "placeholder": {
+          "type": "boolean",
+          "description": "True when the candidate is a generated placeholder rather than an official or source-discovered asset."
+        },
         "verification": {
           "$ref": "#/definitions/MetadataAssetVerification"
         },
         "notes": {
           "type": ["string", "null"]
+        }
+      }
+    },
+    "MetadataAssetColor": {
+      "type": "object",
+      "required": ["role", "hex"],
+      "additionalProperties": false,
+      "properties": {
+        "role": {
+          "type": "string"
+        },
+        "hex": {
+          "type": "string",
+          "pattern": "^#[0-9A-Fa-f]{6}$"
         }
       }
     },

--- a/schemas/club-metadata.schema.json
+++ b/schemas/club-metadata.schema.json
@@ -77,6 +77,9 @@
         "derived": {
           "$ref": "#/definitions/ClubDerivedMetadata"
         },
+        "assets": {
+          "$ref": "#/definitions/MetadataAssets"
+        },
         "founded": {
           "type": ["string", "null"]
         },
@@ -228,6 +231,151 @@
           "items": {
             "$ref": "#/definitions/ClubCoverageGap"
           }
+        }
+      }
+    },
+    "MetadataAssets": {
+      "type": "object",
+      "description": "Visual and media asset candidates for this metadata identity. v1 populates club crest candidates only.",
+      "additionalProperties": {
+        "$ref": "#/definitions/MetadataAssetBundle"
+      },
+      "properties": {
+        "crest": {
+          "$ref": "#/definitions/MetadataAssetBundle"
+        }
+      }
+    },
+    "MetadataAssetBundle": {
+      "type": "object",
+      "required": ["status"],
+      "additionalProperties": false,
+      "properties": {
+        "preferred": {
+          "type": ["string", "null"],
+          "description": "assetId for the preferred candidate, or null when no candidate is safe to prefer."
+        },
+        "status": {
+          "type": "string",
+          "description": "Overall bundle status such as usable, restricted, needs-review, missing, or failed."
+        },
+        "candidates": {
+          "type": "array",
+          "maxItems": 5,
+          "items": {
+            "$ref": "#/definitions/MetadataAssetCandidate"
+          }
+        }
+      }
+    },
+    "MetadataAssetCandidate": {
+      "type": "object",
+      "required": ["assetId", "kind", "status", "source"],
+      "additionalProperties": false,
+      "properties": {
+        "assetId": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "priority": {
+          "type": ["integer", "null"],
+          "minimum": 1
+        },
+        "source": {
+          "type": "string"
+        },
+        "sourceUrl": {
+          "type": ["string", "null"],
+          "format": "uri"
+        },
+        "imageUrl": {
+          "type": ["string", "null"],
+          "format": "uri"
+        },
+        "pageUrl": {
+          "type": ["string", "null"],
+          "format": "uri"
+        },
+        "fileTitle": {
+          "type": ["string", "null"]
+        },
+        "mimeType": {
+          "type": ["string", "null"]
+        },
+        "width": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "height": {
+          "type": ["integer", "null"],
+          "minimum": 0
+        },
+        "license": {
+          "$ref": "#/definitions/MetadataAssetLicense"
+        },
+        "verification": {
+          "$ref": "#/definitions/MetadataAssetVerification"
+        },
+        "notes": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "MetadataAssetLicense": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "shortName": {
+          "type": ["string", "null"]
+        },
+        "usageTerms": {
+          "type": ["string", "null"]
+        },
+        "licenseUrl": {
+          "type": ["string", "null"],
+          "format": "uri"
+        },
+        "copyrighted": {
+          "type": ["boolean", "null"]
+        },
+        "attribution": {
+          "type": ["string", "null"]
+        },
+        "credit": {
+          "type": ["string", "null"]
+        },
+        "artist": {
+          "type": ["string", "null"]
+        }
+      }
+    },
+    "MetadataAssetVerification": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "identityMatch": {
+          "type": ["string", "null"]
+        },
+        "licenseCheck": {
+          "type": ["string", "null"]
+        },
+        "httpCheck": {
+          "type": ["string", "null"]
+        },
+        "needsManualReview": {
+          "type": "boolean"
+        },
+        "reviewReasons": {
+          "$ref": "#/definitions/StringList"
+        },
+        "checkedAt": {
+          "type": ["string", "null"],
+          "format": "date-time"
         }
       }
     },

--- a/scripts/build-docs-site.js
+++ b/scripts/build-docs-site.js
@@ -692,6 +692,7 @@ function buildSiteData() {
         label: 'Site',
         links: [
           { label: 'Data explorer', url: './explorer-prototype.html' },
+          { label: 'Club asset review', url: './club-assets-review.html' },
           { label: 'Release notes', url: './releases/' },
           { label: 'Schema docs', url: './schema/' },
         ],
@@ -712,6 +713,11 @@ function buildSiteData() {
         label: 'Explore data',
         url: './explorer-prototype.html',
         className: 'button-link--primary',
+      },
+      {
+        label: 'Review club assets',
+        url: './club-assets-review.html',
+        className: 'button-link--secondary',
       },
       {
         label: 'Download JSON',

--- a/wikipedia/__tests__/club-assets.test.js
+++ b/wikipedia/__tests__/club-assets.test.js
@@ -108,6 +108,52 @@ describe('club asset helpers', () => {
     expect(bundle.candidates.map((candidate) => candidate.priority)).toEqual([1, 2, 3]);
   });
 
+  test('does not mark free non-crest page images as usable', () => {
+    const candidate = classifyClubAssetCandidate(
+      {
+        assetId: 'wikipedia-pageimage-free:Example_FC_match.jpg',
+        kind: 'crest',
+        status: 'needs-review',
+        source: 'wikipedia-pageimage-free',
+        imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/example.jpg',
+        fileTitle: 'File:Example FC match.jpg',
+        license: {
+          shortName: 'CC BY-SA 4.0',
+          usageTerms: 'Creative Commons Attribution-Share Alike 4.0',
+          copyrighted: true,
+        },
+      },
+      exampleClub
+    );
+
+    expect(candidate.status).toBe('needs-review');
+    expect(candidate.verification.reviewReasons).toContain('non-crest-filename');
+  });
+
+  test('dedupes equivalent file candidates after ranking', () => {
+    const bundle = buildClubAssetBundle([
+      {
+        assetId: 'wikipedia-pageimage-free:Example_FC_crest.svg',
+        kind: 'crest',
+        status: 'usable',
+        source: 'wikipedia-pageimage-free',
+        imageUrl: 'https://upload.wikimedia.org/example.svg',
+        fileTitle: 'File:Example FC crest.svg',
+      },
+      {
+        assetId: 'wikipedia-pageimage-any:Example_FC_crest.svg',
+        kind: 'crest',
+        status: 'usable',
+        source: 'wikipedia-pageimage-any',
+        imageUrl: 'https://upload.wikimedia.org/example.svg',
+        fileTitle: 'File:Example FC crest.svg',
+      },
+    ]);
+
+    expect(bundle.candidates).toHaveLength(1);
+    expect(bundle.candidates[0].assetId).toBe('wikipedia-pageimage-free:Example_FC_crest.svg');
+  });
+
   test('builds manual review issues for missing and uncertain assets', () => {
     expect(buildClubAssetReviewIssues('example fc', exampleClub, { status: 'missing' })).toEqual([
       expect.objectContaining({

--- a/wikipedia/__tests__/club-assets.test.js
+++ b/wikipedia/__tests__/club-assets.test.js
@@ -112,6 +112,78 @@ describe('club asset helpers', () => {
     expect(candidate.verification.reviewReasons).not.toContain('non-crest-filename');
   });
 
+  test('accepts matching Wikidata coat-of-arms media as a historical crest candidate', () => {
+    const candidate = classifyClubAssetCandidate(
+      {
+        assetId: 'wikidata-coat-of-arms:AberdareAthletic.jpg',
+        kind: 'crest',
+        status: 'needs-review',
+        source: 'wikidata-coat-of-arms',
+        imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/example.jpg',
+        fileTitle: 'File:AberdareAthletic.jpg',
+        license: {
+          shortName: 'PD',
+          usageTerms: 'Public domain',
+          copyrighted: false,
+        },
+      },
+      {
+        clubId: 'aberdare-athletic',
+        canonicalName: 'Aberdare Athletic',
+        derived: {
+          aliases: ['Aberdare Athletic F.C.'],
+        },
+      }
+    );
+
+    expect(candidate.status).toBe('usable');
+    expect(candidate.verification.reviewReasons || []).not.toContain('non-crest-filename');
+  });
+
+  test('does not trust generic Wikidata images without crest signals', () => {
+    const candidate = classifyClubAssetCandidate(
+      {
+        assetId: 'wikidata-image:Example_FC_ground.jpg',
+        kind: 'crest',
+        status: 'needs-review',
+        source: 'wikidata-image',
+        imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/example.jpg',
+        fileTitle: 'File:Example FC ground.jpg',
+        license: {
+          shortName: 'CC BY-SA 4.0',
+          usageTerms: 'Creative Commons Attribution-Share Alike 4.0',
+          copyrighted: true,
+        },
+      },
+      exampleClub
+    );
+
+    expect(candidate.status).toBe('needs-review');
+    expect(candidate.verification.reviewReasons).toContain('non-crest-filename');
+  });
+
+  test('does not trust Wikidata logo properties without crest filename evidence', () => {
+    const candidate = classifyClubAssetCandidate(
+      {
+        assetId: 'wikidata-logo:Example_FC_ground.jpg',
+        kind: 'crest',
+        status: 'needs-review',
+        source: 'wikidata-logo',
+        imageUrl: 'https://upload.wikimedia.org/wikipedia/commons/example.jpg',
+        fileTitle: 'File:Example FC ground.jpg',
+        license: {
+          shortName: 'CC BY-SA 4.0',
+          usageTerms: 'Creative Commons Attribution-Share Alike 4.0',
+          copyrighted: true,
+        },
+      },
+      exampleClub
+    );
+
+    expect(candidate.status).toBe('needs-review');
+    expect(candidate.verification.reviewReasons).toContain('non-crest-filename');
+  });
+
   test('ranks usable candidates before restricted and review candidates', () => {
     const bundle = buildClubAssetBundle([
       {

--- a/wikipedia/__tests__/club-assets.test.js
+++ b/wikipedia/__tests__/club-assets.test.js
@@ -6,6 +6,7 @@ import {
   buildWikipediaArticleTitles,
   classifyAssetLicense,
   classifyClubAssetCandidate,
+  isRejectedClubAssetCandidate,
 } from '../data/assets/club-assets.js';
 
 const exampleClub = {
@@ -142,6 +143,39 @@ describe('club asset helpers', () => {
     expect(candidate.verification.reviewReasons || []).not.toContain('non-crest-filename');
   });
 
+  test('accepts the curated Leeds City historical arms crest candidate', () => {
+    const candidate = classifyClubAssetCandidate(
+      {
+        assetId: 'wikipedia-pageimage-free:Leeds_old_arms.png',
+        kind: 'crest',
+        status: 'needs-review',
+        source: 'wikipedia-pageimage-free',
+        imageUrl: 'https://upload.wikimedia.org/wikipedia/en/9/9b/Leeds_old_arms.png',
+        fileTitle: 'File:Leeds old arms.png',
+        license: {
+          shortName: 'PD',
+          usageTerms: 'Public domain',
+          copyrighted: false,
+        },
+      },
+      {
+        clubId: 'leeds-city',
+        canonicalName: 'Leeds City',
+        derived: {
+          aliases: ['Leeds City F.C.'],
+        },
+      }
+    );
+
+    expect(candidate.status).toBe('usable');
+    expect(candidate.notes).toContain('Leeds City historical crest/arms');
+    expect(candidate.verification).toMatchObject({
+      identityMatch: 'curated',
+      needsManualReview: false,
+    });
+    expect(candidate.verification.reviewReasons || []).toEqual([]);
+  });
+
   test('does not trust generic Wikidata images without crest signals', () => {
     const candidate = classifyClubAssetCandidate(
       {
@@ -162,6 +196,19 @@ describe('club asset helpers', () => {
 
     expect(candidate.status).toBe('needs-review');
     expect(candidate.verification.reviewReasons).toContain('non-crest-filename');
+  });
+
+  test('recognizes curated rejected non-crest image candidates', () => {
+    expect(
+      isRejectedClubAssetCandidate({
+        assetId: 'wikipedia-pageimage-free:Crown_Ground_sign-geograph-1761360.jpg',
+      })
+    ).toBe(true);
+    expect(
+      isRejectedClubAssetCandidate({
+        assetId: 'wikipedia-pageimage-free:Example_FC_crest.svg',
+      })
+    ).toBe(false);
   });
 
   test('does not trust Wikidata logo properties without crest filename evidence', () => {
@@ -230,13 +277,34 @@ describe('club asset helpers', () => {
     expect(candidate.imageUrl).toMatch(/^data:image\/svg\+xml,/);
   });
 
+  test('preserves generated placeholder status during reclassification', () => {
+    const candidate = buildGeneratedPlaceholderCrestCandidate(
+      {
+        clubId: 'sunderland-albion',
+        canonicalName: 'Sunderland Albion',
+      },
+      { checkedAt: '2026-06-20T00:00:00.000Z' }
+    );
+
+    const reclassified = classifyClubAssetCandidate(candidate, {
+      clubId: 'sunderland-albion',
+      canonicalName: 'Sunderland Albion',
+    });
+
+    expect(reclassified.status).toBe('placeholder');
+    expect(reclassified.verification).toMatchObject({
+      identityMatch: 'generated-placeholder',
+      needsManualReview: false,
+    });
+  });
+
   test('uses generated placeholders only when no discovered candidates exist', () => {
     const placeholderBundle = addGeneratedPlaceholderFallback(
       {
         clubId: 'sunderland-albion',
         canonicalName: 'Sunderland Albion',
       },
-      { status: 'missing' }
+      { status: 'needs-more-research' }
     );
 
     expect(placeholderBundle).toMatchObject({
@@ -348,10 +416,12 @@ describe('club asset helpers', () => {
     expect(bundle.candidates[0].assetId).toBe('wikipedia-pageimage-free:Example_FC_crest.svg');
   });
 
-  test('builds manual review issues for missing and uncertain assets', () => {
-    expect(buildClubAssetReviewIssues('example fc', exampleClub, { status: 'missing' })).toEqual([
+  test('builds manual review issues for unresolved and uncertain assets', () => {
+    expect(
+      buildClubAssetReviewIssues('example fc', exampleClub, { status: 'needs-more-research' })
+    ).toEqual([
       expect.objectContaining({
-        type: 'club-asset-missing',
+        type: 'club-asset-needs-more-research',
         clubKey: 'example fc',
       }),
     ]);

--- a/wikipedia/__tests__/club-assets.test.js
+++ b/wikipedia/__tests__/club-assets.test.js
@@ -1,5 +1,7 @@
 import {
+  addGeneratedPlaceholderFallback,
   buildClubAssetBundle,
+  buildGeneratedPlaceholderCrestCandidate,
   buildClubAssetReviewIssues,
   buildWikipediaArticleTitles,
   classifyAssetLicense,
@@ -182,6 +184,87 @@ describe('club asset helpers', () => {
 
     expect(candidate.status).toBe('needs-review');
     expect(candidate.verification.reviewReasons).toContain('non-crest-filename');
+  });
+
+  test('builds generated placeholder crest candidates for curated historical clubs', () => {
+    const candidate = buildGeneratedPlaceholderCrestCandidate(
+      {
+        clubId: 'sunderland-albion',
+        canonicalName: 'Sunderland Albion',
+        status: {
+          sourceRefs: [
+            {
+              type: 'wikipedia-club-page',
+              sourceUrl: 'https://en.wikipedia.org/wiki/Sunderland_Albion_F.C.',
+            },
+          ],
+        },
+      },
+      { checkedAt: '2026-06-20T00:00:00.000Z' }
+    );
+
+    expect(candidate).toMatchObject({
+      assetId: 'generated-placeholder:Generated:sunderland-albion-placeholder-crest.svg',
+      kind: 'crest',
+      status: 'placeholder',
+      source: 'generated-placeholder',
+      placeholder: true,
+      mimeType: 'image/svg+xml',
+      width: 256,
+      height: 256,
+      colors: [
+        { role: 'primary', hex: '#000066' },
+        { role: 'secondary', hex: '#FFFFFF' },
+      ],
+      license: {
+        shortName: 'CC0-1.0',
+        copyrighted: false,
+      },
+      verification: {
+        identityMatch: 'generated-placeholder',
+        licenseCheck: 'pass',
+        httpCheck: 'pass',
+        needsManualReview: false,
+      },
+    });
+    expect(candidate.imageUrl).toMatch(/^data:image\/svg\+xml,/);
+  });
+
+  test('uses generated placeholders only when no discovered candidates exist', () => {
+    const placeholderBundle = addGeneratedPlaceholderFallback(
+      {
+        clubId: 'sunderland-albion',
+        canonicalName: 'Sunderland Albion',
+      },
+      { status: 'missing' }
+    );
+
+    expect(placeholderBundle).toMatchObject({
+      preferred: 'generated-placeholder:Generated:sunderland-albion-placeholder-crest.svg',
+      status: 'placeholder',
+    });
+    expect(placeholderBundle.candidates[0].placeholder).toBe(true);
+
+    const existingBundle = {
+      status: 'restricted',
+      candidates: [
+        {
+          assetId: 'existing',
+          kind: 'crest',
+          status: 'restricted',
+          source: 'wikipedia-pageimage-any',
+        },
+      ],
+    };
+    expect(
+      addGeneratedPlaceholderFallback(
+        {
+          clubId: 'sunderland-albion',
+          canonicalName: 'Sunderland Albion',
+        },
+        existingBundle
+      )
+    ).toBe(existingBundle);
   });
 
   test('ranks usable candidates before restricted and review candidates', () => {

--- a/wikipedia/__tests__/club-assets.test.js
+++ b/wikipedia/__tests__/club-assets.test.js
@@ -70,6 +70,7 @@ describe('club asset helpers', () => {
 
     expect(candidate.status).toBe('restricted');
     expect(candidate.verification.reviewReasons).toContain('license-restricted');
+    expect(candidate.verification.reviewReasons).not.toContain('non-crest-filename');
   });
 
   test('ranks usable candidates before restricted and review candidates', () => {
@@ -115,6 +116,25 @@ describe('club asset helpers', () => {
       }),
     ]);
 
+    const singleCandidateIssues = buildClubAssetReviewIssues('example fc', exampleClub, {
+      status: 'restricted',
+      candidates: [
+        {
+          assetId: 'candidate',
+          kind: 'crest',
+          status: 'restricted',
+          source: 'wikipedia-pageimage-any',
+          verification: {
+            reviewReasons: ['license-restricted'],
+          },
+        },
+      ],
+    });
+
+    expect(singleCandidateIssues.map((issue) => issue.type)).toEqual([
+      'club-asset-license-restricted',
+    ]);
+
     const issues = buildClubAssetReviewIssues('example fc', exampleClub, {
       status: 'restricted',
       candidates: [
@@ -127,6 +147,15 @@ describe('club asset helpers', () => {
             reviewReasons: ['license-restricted', 'identity-uncertain', 'non-crest-filename'],
           },
         },
+        {
+          assetId: 'candidate-2',
+          kind: 'crest',
+          status: 'needs-review',
+          source: 'wikipedia-pageimage-free',
+          verification: {
+            reviewReasons: ['non-crest-filename'],
+          },
+        },
       ],
     });
 
@@ -134,6 +163,7 @@ describe('club asset helpers', () => {
       'club-asset-identity-uncertain',
       'club-asset-license-restricted',
       'club-asset-multiple-review-candidates',
+      'club-asset-non-crest-candidate',
       'club-asset-non-crest-candidate',
     ]);
   });

--- a/wikipedia/__tests__/club-assets.test.js
+++ b/wikipedia/__tests__/club-assets.test.js
@@ -1,0 +1,140 @@
+import {
+  buildClubAssetBundle,
+  buildClubAssetReviewIssues,
+  classifyAssetLicense,
+  classifyClubAssetCandidate,
+} from '../data/assets/club-assets.js';
+
+const exampleClub = {
+  clubId: 'example-fc',
+  canonicalName: 'Example FC',
+  derived: {
+    aliases: ['Example FC'],
+  },
+};
+
+describe('club asset helpers', () => {
+  test('classifies public-domain crest candidates as usable', () => {
+    const candidate = classifyClubAssetCandidate(
+      {
+        assetId: 'wikipedia-pageimage-free:Example_FC_crest.svg',
+        kind: 'crest',
+        status: 'needs-review',
+        source: 'wikipedia-pageimage-free',
+        imageUrl: 'https://upload.wikimedia.org/wikipedia/en/example.svg',
+        fileTitle: 'File:Example_FC_crest.svg',
+        license: {
+          shortName: 'PD',
+          usageTerms: 'Public domain',
+          copyrighted: false,
+        },
+      },
+      exampleClub,
+      { checkedAt: '2026-06-20T00:00:00.000Z' }
+    );
+
+    expect(candidate.status).toBe('usable');
+    expect(candidate.verification).toMatchObject({
+      identityMatch: 'strong',
+      licenseCheck: 'pass',
+      httpCheck: 'pass',
+      needsManualReview: false,
+    });
+  });
+
+  test('keeps fair-use candidates as restricted backup options', () => {
+    expect(
+      classifyAssetLicense({
+        shortName: 'Fair use',
+        usageTerms: 'Fair use of copyrighted material',
+        copyrighted: true,
+      })
+    ).toBe('restricted');
+
+    const candidate = classifyClubAssetCandidate(
+      {
+        assetId: 'wikipedia-pageimage-any:Example_FC_logo.svg',
+        kind: 'crest',
+        status: 'needs-review',
+        source: 'wikipedia-pageimage-any',
+        imageUrl: 'https://upload.wikimedia.org/wikipedia/en/example.svg',
+        fileTitle: 'File:Example_FC_logo.svg',
+        license: {
+          shortName: 'Fair use',
+          usageTerms: 'Fair use of copyrighted material',
+          copyrighted: true,
+        },
+      },
+      exampleClub
+    );
+
+    expect(candidate.status).toBe('restricted');
+    expect(candidate.verification.reviewReasons).toContain('license-restricted');
+  });
+
+  test('ranks usable candidates before restricted and review candidates', () => {
+    const bundle = buildClubAssetBundle([
+      {
+        assetId: 'restricted',
+        kind: 'crest',
+        status: 'restricted',
+        source: 'wikipedia-pageimage-any',
+        fileTitle: 'File:Example_FC_logo.svg',
+      },
+      {
+        assetId: 'usable',
+        kind: 'crest',
+        status: 'usable',
+        source: 'wikipedia-pageimage-free',
+        fileTitle: 'File:Example_FC_crest.svg',
+      },
+      {
+        assetId: 'review',
+        kind: 'crest',
+        status: 'needs-review',
+        source: 'wikipedia-pageimage-free',
+        fileTitle: 'File:Example_photo.jpg',
+      },
+    ]);
+
+    expect(bundle.preferred).toBe('usable');
+    expect(bundle.status).toBe('usable');
+    expect(bundle.candidates.map((candidate) => candidate.assetId)).toEqual([
+      'usable',
+      'restricted',
+      'review',
+    ]);
+    expect(bundle.candidates.map((candidate) => candidate.priority)).toEqual([1, 2, 3]);
+  });
+
+  test('builds manual review issues for missing and uncertain assets', () => {
+    expect(buildClubAssetReviewIssues('example fc', exampleClub, { status: 'missing' })).toEqual([
+      expect.objectContaining({
+        type: 'club-asset-missing',
+        clubKey: 'example fc',
+      }),
+    ]);
+
+    const issues = buildClubAssetReviewIssues('example fc', exampleClub, {
+      status: 'restricted',
+      candidates: [
+        {
+          assetId: 'candidate',
+          kind: 'crest',
+          status: 'restricted',
+          source: 'wikipedia-pageimage-any',
+          verification: {
+            reviewReasons: ['license-restricted', 'identity-uncertain', 'non-crest-filename'],
+          },
+        },
+      ],
+    });
+
+    expect(issues.map((issue) => issue.type).sort()).toEqual([
+      'club-asset-identity-uncertain',
+      'club-asset-license-restricted',
+      'club-asset-multiple-review-candidates',
+      'club-asset-non-crest-candidate',
+    ]);
+  });
+});

--- a/wikipedia/__tests__/club-assets.test.js
+++ b/wikipedia/__tests__/club-assets.test.js
@@ -1,6 +1,7 @@
 import {
   buildClubAssetBundle,
   buildClubAssetReviewIssues,
+  buildWikipediaArticleTitles,
   classifyAssetLicense,
   classifyClubAssetCandidate,
 } from '../data/assets/club-assets.js';
@@ -14,6 +15,44 @@ const exampleClub = {
 };
 
 describe('club asset helpers', () => {
+  test('prefers specific club page titles before generic source pages', () => {
+    const titles = buildWikipediaArticleTitles({
+      canonicalName: 'Chester City',
+      derived: {
+        aliases: ['Chester City'],
+        identitySources: [
+          {
+            type: 'former-efl-clubs-list',
+            sourceUrl: 'https://en.wikipedia.org/wiki/List_of_former_English_Football_League_clubs',
+          },
+          {
+            type: 'wikipedia-club-page',
+            sourceUrl: 'https://en.wikipedia.org/wiki/Chester_City_F.C.',
+          },
+        ],
+      },
+    });
+
+    expect(titles[0]).toBe('Chester City F.C.');
+    expect(titles).toContain('List of former English Football League clubs');
+  });
+
+  test('builds common English club article title fallbacks', () => {
+    expect(
+      buildWikipediaArticleTitles({
+        canonicalName: 'AFC Totton',
+        derived: { aliases: ['AFC Totton'] },
+      }).slice(0, 4)
+    ).toEqual(['AFC Totton', 'A.F.C. Totton', 'AFC Totton F.C.', 'AFC Totton A.F.C.']);
+
+    expect(
+      buildWikipediaArticleTitles({
+        canonicalName: 'Tranmere Rovers',
+        derived: { aliases: ['Tranmere Rovers'] },
+      })
+    ).toContain('Tranmere Rovers F.C.');
+  });
+
   test('classifies public-domain crest candidates as usable', () => {
     const candidate = classifyClubAssetCandidate(
       {

--- a/wikipedia/__tests__/generate-club-assets.test.js
+++ b/wikipedia/__tests__/generate-club-assets.test.js
@@ -118,7 +118,7 @@ describe('generateClubAssets', () => {
         clubs: {
           'example fc': {
             crest: {
-              status: 'missing',
+              status: 'needs-more-research',
             },
           },
         },
@@ -138,7 +138,7 @@ describe('generateClubAssets', () => {
     const review = JSON.parse(fs.readFileSync(reviewOutputFile, 'utf8'));
 
     expect(result.processedClubCount).toBe(1);
-    expect(output.clubs['example fc'].assets.crest.status).toBe('missing');
+    expect(output.clubs['example fc'].assets.crest.status).toBe('needs-more-research');
     expect(output.clubs['other fc'].assets).toBeUndefined();
     expect(review.clubCount).toBe(1);
   });
@@ -168,7 +168,7 @@ describe('generateClubAssets', () => {
         clubs: {
           'sunderland albion': {
             crest: {
-              status: 'missing',
+              status: 'needs-more-research',
             },
           },
         },
@@ -202,6 +202,148 @@ describe('generateClubAssets', () => {
       ],
     });
     expect(review.issueCount).toBe(0);
+  });
+
+  test('drops stale cached generated placeholders for non-curated clubs', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'club-assets-test-'));
+    tmpDirs.push(tmpDir);
+    const inputFile = path.join(tmpDir, 'club-metadata.json');
+    const outputFile = path.join(tmpDir, 'club-metadata-output.json');
+    const reviewOutputFile = path.join(tmpDir, 'club-assets-review.json');
+    const cacheFile = path.join(tmpDir, 'club-assets-cache.json');
+
+    fs.writeFileSync(
+      inputFile,
+      JSON.stringify({
+        clubs: {
+          'redbridge forest': {
+            clubId: 'redbridge-forest',
+            canonicalName: 'Redbridge Forest',
+          },
+        },
+      })
+    );
+    fs.writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        clubs: {
+          'redbridge forest': {
+            crest: {
+              preferred: 'generated-placeholder:Generated:redbridge-forest-placeholder-crest.svg',
+              status: 'placeholder',
+              candidates: [
+                {
+                  assetId: 'generated-placeholder:Generated:redbridge-forest-placeholder-crest.svg',
+                  kind: 'crest',
+                  status: 'placeholder',
+                  source: 'generated-placeholder',
+                  placeholder: true,
+                  imageUrl: 'data:image/svg+xml,%3Csvg%3E%3C%2Fsvg%3E',
+                  fileTitle: 'Generated:redbridge-forest-placeholder-crest.svg',
+                  license: {
+                    shortName: 'CC0-1.0',
+                    usageTerms: 'Creative Commons Zero v1.0 Universal',
+                    copyrighted: false,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+    );
+
+    await generateClubAssets({
+      input: inputFile,
+      output: outputFile,
+      reviewOutput: reviewOutputFile,
+      cache: cacheFile,
+      requestDelayMs: 0,
+      cwd: process.cwd(),
+    });
+
+    const output = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+    const review = JSON.parse(fs.readFileSync(reviewOutputFile, 'utf8'));
+
+    expect(output.clubs['redbridge forest'].assets.crest).toEqual({
+      status: 'needs-more-research',
+    });
+    expect(review.issues).toEqual([
+      expect.objectContaining({
+        type: 'club-asset-needs-more-research',
+        clubKey: 'redbridge forest',
+      }),
+    ]);
+  });
+
+  test('filters rejected cached candidates and marks unresolved clubs for more research', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'club-assets-test-'));
+    tmpDirs.push(tmpDir);
+    const inputFile = path.join(tmpDir, 'club-metadata.json');
+    const outputFile = path.join(tmpDir, 'club-metadata-output.json');
+    const reviewOutputFile = path.join(tmpDir, 'club-assets-review.json');
+    const cacheFile = path.join(tmpDir, 'club-assets-cache.json');
+
+    fs.writeFileSync(
+      inputFile,
+      JSON.stringify({
+        clubs: {
+          accrington: {
+            clubId: 'accrington',
+            canonicalName: 'Accrington',
+          },
+        },
+      })
+    );
+    fs.writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        clubs: {
+          accrington: {
+            crest: {
+              preferred: 'wikipedia-pageimage-free:Crown_Ground_sign-geograph-1761360.jpg',
+              status: 'needs-review',
+              candidates: [
+                {
+                  assetId: 'wikipedia-pageimage-free:Crown_Ground_sign-geograph-1761360.jpg',
+                  kind: 'crest',
+                  status: 'needs-review',
+                  source: 'wikipedia-pageimage-free',
+                  imageUrl:
+                    'https://upload.wikimedia.org/wikipedia/commons/9/9a/Crown_Ground_sign-geograph-1761360.jpg',
+                  fileTitle: 'File:Crown Ground sign-geograph-1761360.jpg',
+                  license: {
+                    shortName: 'CC BY-SA 2.0',
+                    usageTerms: 'Creative Commons Attribution-Share Alike 2.0',
+                    copyrighted: true,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+    );
+
+    await generateClubAssets({
+      input: inputFile,
+      output: outputFile,
+      reviewOutput: reviewOutputFile,
+      cache: cacheFile,
+      requestDelayMs: 0,
+      cwd: process.cwd(),
+    });
+
+    const output = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+    const review = JSON.parse(fs.readFileSync(reviewOutputFile, 'utf8'));
+
+    expect(output.clubs.accrington.assets.crest).toEqual({ status: 'needs-more-research' });
+    expect(review.issues).toEqual([
+      expect.objectContaining({
+        type: 'club-asset-needs-more-research',
+        clubKey: 'accrington',
+      }),
+    ]);
   });
 
   test('reclassifies cached crest bundles with current verification rules', async () => {

--- a/wikipedia/__tests__/generate-club-assets.test.js
+++ b/wikipedia/__tests__/generate-club-assets.test.js
@@ -88,4 +88,82 @@ describe('generateClubAssets', () => {
     });
     expect(review.issueCount).toBe(0);
   });
+
+  test('reclassifies cached crest bundles with current verification rules', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'club-assets-test-'));
+    tmpDirs.push(tmpDir);
+    const inputFile = path.join(tmpDir, 'club-metadata.json');
+    const outputFile = path.join(tmpDir, 'club-metadata-output.json');
+    const reviewOutputFile = path.join(tmpDir, 'club-assets-review.json');
+    const cacheFile = path.join(tmpDir, 'club-assets-cache.json');
+
+    fs.writeFileSync(
+      inputFile,
+      JSON.stringify({
+        clubs: {
+          'example fc': {
+            clubId: 'example-fc',
+            canonicalName: 'Example FC',
+            derived: {
+              aliases: ['Example FC'],
+            },
+          },
+        },
+      })
+    );
+    fs.writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        clubs: {
+          'example fc': {
+            crest: {
+              preferred: 'wikipedia-pageimage-free:Example_FC_match.jpg',
+              status: 'usable',
+              candidates: [
+                {
+                  assetId: 'wikipedia-pageimage-free:Example_FC_match.jpg',
+                  kind: 'crest',
+                  status: 'usable',
+                  source: 'wikipedia-pageimage-free',
+                  imageUrl: 'https://upload.wikimedia.org/example.jpg',
+                  fileTitle: 'File:Example FC match.jpg',
+                  license: {
+                    shortName: 'CC BY-SA 4.0',
+                    usageTerms: 'Creative Commons Attribution-Share Alike 4.0',
+                    copyrighted: true,
+                  },
+                  verification: {
+                    identityMatch: 'possible',
+                    licenseCheck: 'pass',
+                    httpCheck: 'pass',
+                    needsManualReview: false,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+    );
+
+    await generateClubAssets({
+      input: inputFile,
+      output: outputFile,
+      reviewOutput: reviewOutputFile,
+      cache: cacheFile,
+      requestDelayMs: 0,
+      cwd: process.cwd(),
+    });
+
+    const output = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+    const review = JSON.parse(fs.readFileSync(reviewOutputFile, 'utf8'));
+    const crest = output.clubs['example fc'].assets.crest;
+
+    expect(crest).not.toHaveProperty('preferred');
+    expect(crest.status).toBe('needs-review');
+    expect(crest.candidates[0].verification.reviewReasons).toContain('non-crest-filename');
+    expect(review.issueCounts).toMatchObject({
+      'club-asset-non-crest-candidate': 1,
+    });
+  });
 });

--- a/wikipedia/__tests__/generate-club-assets.test.js
+++ b/wikipedia/__tests__/generate-club-assets.test.js
@@ -1,0 +1,91 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { generateClubAssets } from '../data/generate-club-assets.js';
+
+describe('generateClubAssets', () => {
+  const tmpDirs = [];
+
+  afterEach(() => {
+    while (tmpDirs.length) {
+      fs.rmSync(tmpDirs.pop(), { recursive: true, force: true });
+    }
+  });
+
+  test('uses cached crest bundles without network discovery', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'club-assets-test-'));
+    tmpDirs.push(tmpDir);
+    const inputFile = path.join(tmpDir, 'club-metadata.json');
+    const outputFile = path.join(tmpDir, 'club-metadata-output.json');
+    const reviewOutputFile = path.join(tmpDir, 'club-assets-review.json');
+    const cacheFile = path.join(tmpDir, 'club-assets-cache.json');
+
+    fs.writeFileSync(
+      inputFile,
+      JSON.stringify({
+        clubs: {
+          'example fc': {
+            clubId: 'example-fc',
+            canonicalName: 'Example FC',
+            derived: {
+              aliases: ['Example FC'],
+            },
+          },
+        },
+      })
+    );
+    fs.writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        clubs: {
+          'example fc': {
+            crest: {
+              preferred: 'wikipedia-pageimage-free:Example_FC_crest.svg',
+              status: 'usable',
+              candidates: [
+                {
+                  assetId: 'wikipedia-pageimage-free:Example_FC_crest.svg',
+                  kind: 'crest',
+                  status: 'usable',
+                  source: 'wikipedia-pageimage-free',
+                  imageUrl: 'https://upload.wikimedia.org/example.svg',
+                  fileTitle: 'File:Example FC crest.svg',
+                  license: {
+                    shortName: 'PD',
+                    usageTerms: 'Public domain',
+                    copyrighted: false,
+                  },
+                  verification: {
+                    identityMatch: 'strong',
+                    licenseCheck: 'pass',
+                    httpCheck: 'pass',
+                    needsManualReview: false,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+    );
+
+    const result = await generateClubAssets({
+      input: inputFile,
+      output: outputFile,
+      reviewOutput: reviewOutputFile,
+      cache: cacheFile,
+      requestDelayMs: 0,
+      cwd: process.cwd(),
+    });
+
+    const output = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+    const review = JSON.parse(fs.readFileSync(reviewOutputFile, 'utf8'));
+
+    expect(result.processedClubCount).toBe(1);
+    expect(output.clubs['example fc'].assets.crest).toMatchObject({
+      preferred: 'wikipedia-pageimage-free:Example_FC_crest.svg',
+      status: 'usable',
+    });
+    expect(review.issueCount).toBe(0);
+  });
+});

--- a/wikipedia/__tests__/generate-club-assets.test.js
+++ b/wikipedia/__tests__/generate-club-assets.test.js
@@ -143,6 +143,67 @@ describe('generateClubAssets', () => {
     expect(review.clubCount).toBe(1);
   });
 
+  test('adds generated placeholders for curated historical missing crests', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'club-assets-test-'));
+    tmpDirs.push(tmpDir);
+    const inputFile = path.join(tmpDir, 'club-metadata.json');
+    const outputFile = path.join(tmpDir, 'club-metadata-output.json');
+    const reviewOutputFile = path.join(tmpDir, 'club-assets-review.json');
+    const cacheFile = path.join(tmpDir, 'club-assets-cache.json');
+
+    fs.writeFileSync(
+      inputFile,
+      JSON.stringify({
+        clubs: {
+          'sunderland albion': {
+            clubId: 'sunderland-albion',
+            canonicalName: 'Sunderland Albion',
+          },
+        },
+      })
+    );
+    fs.writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        clubs: {
+          'sunderland albion': {
+            crest: {
+              status: 'missing',
+            },
+          },
+        },
+      })
+    );
+
+    await generateClubAssets({
+      input: inputFile,
+      output: outputFile,
+      reviewOutput: reviewOutputFile,
+      cache: cacheFile,
+      requestDelayMs: 0,
+      cwd: process.cwd(),
+    });
+
+    const output = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+    const review = JSON.parse(fs.readFileSync(reviewOutputFile, 'utf8'));
+    const crest = output.clubs['sunderland albion'].assets.crest;
+
+    expect(crest).toMatchObject({
+      preferred: 'generated-placeholder:Generated:sunderland-albion-placeholder-crest.svg',
+      status: 'placeholder',
+    });
+    expect(crest.candidates[0]).toMatchObject({
+      status: 'placeholder',
+      source: 'generated-placeholder',
+      placeholder: true,
+      colors: [
+        { role: 'primary', hex: '#000066' },
+        { role: 'secondary', hex: '#FFFFFF' },
+      ],
+    });
+    expect(review.issueCount).toBe(0);
+  });
+
   test('reclassifies cached crest bundles with current verification rules', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'club-assets-test-'));
     tmpDirs.push(tmpDir);

--- a/wikipedia/__tests__/generate-club-assets.test.js
+++ b/wikipedia/__tests__/generate-club-assets.test.js
@@ -89,6 +89,60 @@ describe('generateClubAssets', () => {
     expect(review.issueCount).toBe(0);
   });
 
+  test('can target selected club keys from cache', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'club-assets-test-'));
+    tmpDirs.push(tmpDir);
+    const inputFile = path.join(tmpDir, 'club-metadata.json');
+    const outputFile = path.join(tmpDir, 'club-metadata-output.json');
+    const reviewOutputFile = path.join(tmpDir, 'club-assets-review.json');
+    const cacheFile = path.join(tmpDir, 'club-assets-cache.json');
+
+    fs.writeFileSync(
+      inputFile,
+      JSON.stringify({
+        clubs: {
+          'example fc': {
+            clubId: 'example-fc',
+            canonicalName: 'Example FC',
+          },
+          'other fc': {
+            clubId: 'other-fc',
+            canonicalName: 'Other FC',
+          },
+        },
+      })
+    );
+    fs.writeFileSync(
+      cacheFile,
+      JSON.stringify({
+        clubs: {
+          'example fc': {
+            crest: {
+              status: 'missing',
+            },
+          },
+        },
+      })
+    );
+
+    const result = await generateClubAssets({
+      input: inputFile,
+      output: outputFile,
+      reviewOutput: reviewOutputFile,
+      cache: cacheFile,
+      clubKeys: ['example fc'],
+      requestDelayMs: 0,
+      cwd: process.cwd(),
+    });
+    const output = JSON.parse(fs.readFileSync(outputFile, 'utf8'));
+    const review = JSON.parse(fs.readFileSync(reviewOutputFile, 'utf8'));
+
+    expect(result.processedClubCount).toBe(1);
+    expect(output.clubs['example fc'].assets.crest.status).toBe('missing');
+    expect(output.clubs['other fc'].assets).toBeUndefined();
+    expect(review.clubCount).toBe(1);
+  });
+
   test('reclassifies cached crest bundles with current verification rules', async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'club-assets-test-'));
     tmpDirs.push(tmpDir);

--- a/wikipedia/__tests__/generate-output-files.test.js
+++ b/wikipedia/__tests__/generate-output-files.test.js
@@ -437,6 +437,94 @@ describe('createFootballData', () => {
       ],
     });
   });
+
+  test('normalises club asset metadata records', () => {
+    const dataset = createFootballData({
+      clubs: {
+        'example fc': {
+          canonicalName: 'Example FC',
+          assets: {
+            crest: {
+              preferred: 'wikimedia:Example_FC_crest.svg',
+              status: 'usable',
+              candidates: [
+                {
+                  assetId: 'wikimedia:Example_FC_crest.svg',
+                  kind: 'crest',
+                  status: 'usable',
+                  priority: '1',
+                  source: 'wikipedia-pageimage-free',
+                  sourceUrl: 'https://en.wikipedia.org/wiki/Example_F.C.',
+                  imageUrl: 'https://upload.wikimedia.org/example.svg',
+                  fileTitle: 'File:Example_FC_crest.svg',
+                  mimeType: 'image/svg+xml',
+                  width: '512',
+                  height: '512',
+                  license: {
+                    shortName: 'PD',
+                    usageTerms: 'Public domain',
+                    copyrighted: false,
+                    attribution: 'Example FC',
+                  },
+                  verification: {
+                    identityMatch: 'strong',
+                    licenseCheck: 'pass',
+                    httpCheck: 'pass',
+                    needsManualReview: false,
+                    reviewReasons: ['license-restricted', 'license-restricted'],
+                    checkedAt: '2026-06-20T00:00:00.000Z',
+                  },
+                },
+                {
+                  assetId: '',
+                  kind: 'crest',
+                  status: 'usable',
+                  source: 'wikipedia-pageimage-free',
+                },
+              ],
+            },
+          },
+        },
+      },
+      seasons: {},
+    });
+
+    expect(dataset.clubs['example fc'].assets).toEqual({
+      crest: {
+        preferred: 'wikimedia:Example_FC_crest.svg',
+        status: 'usable',
+        candidates: [
+          {
+            assetId: 'wikimedia:Example_FC_crest.svg',
+            kind: 'crest',
+            status: 'usable',
+            priority: 1,
+            source: 'wikipedia-pageimage-free',
+            sourceUrl: 'https://en.wikipedia.org/wiki/Example_F.C.',
+            imageUrl: 'https://upload.wikimedia.org/example.svg',
+            fileTitle: 'File:Example_FC_crest.svg',
+            mimeType: 'image/svg+xml',
+            width: 512,
+            height: 512,
+            license: {
+              shortName: 'PD',
+              usageTerms: 'Public domain',
+              copyrighted: false,
+              attribution: 'Example FC',
+            },
+            verification: {
+              identityMatch: 'strong',
+              licenseCheck: 'pass',
+              httpCheck: 'pass',
+              needsManualReview: false,
+              reviewReasons: ['license-restricted'],
+              checkedAt: '2026-06-20T00:00:00.000Z',
+            },
+          },
+        ],
+      },
+    });
+  });
 });
 
 describe('updateFootballDataFile', () => {

--- a/wikipedia/__tests__/verify-json-schemas.test.js
+++ b/wikipedia/__tests__/verify-json-schemas.test.js
@@ -106,6 +106,40 @@ function buildClubMetadataFixture() {
           tierSeasons: [{ tierKey: 'tier1', seasons: [1900] }],
           coverageGaps: [],
         },
+        assets: {
+          crest: {
+            preferred: 'wikipedia-pageimage-free:Example_FC_crest.svg',
+            status: 'usable',
+            candidates: [
+              {
+                assetId: 'wikipedia-pageimage-free:Example_FC_crest.svg',
+                kind: 'crest',
+                status: 'usable',
+                priority: 1,
+                source: 'wikipedia-pageimage-free',
+                sourceUrl: 'https://en.wikipedia.org/wiki/Example_F.C.',
+                imageUrl: 'https://upload.wikimedia.org/example.svg',
+                fileTitle: 'File:Example_FC_crest.svg',
+                mimeType: 'image/svg+xml',
+                width: 512,
+                height: 512,
+                license: {
+                  shortName: 'PD',
+                  usageTerms: 'Public domain',
+                  copyrighted: false,
+                  attribution: 'Example FC',
+                },
+                verification: {
+                  identityMatch: 'strong',
+                  licenseCheck: 'pass',
+                  httpCheck: 'pass',
+                  needsManualReview: false,
+                  checkedAt: '2026-06-20T00:00:00.000Z',
+                },
+              },
+            ],
+          },
+        },
       },
     },
   };

--- a/wikipedia/data/assets/club-assets.js
+++ b/wikipedia/data/assets/club-assets.js
@@ -1,0 +1,500 @@
+// @ts-check
+
+import https from 'node:https';
+
+export const CLUB_ASSET_SOURCE_IDS = Object.freeze({
+  wikidataLogo: 'wikidata-logo',
+  wikipediaPageImageFree: 'wikipedia-pageimage-free',
+  wikipediaPageImageAny: 'wikipedia-pageimage-any',
+});
+
+const USER_AGENT = 'footy-data-kit/club-assets (https://github.com/dills122/footy-data-kit)';
+const CREST_FILE_TOKENS = Object.freeze(['badge', 'crest', 'logo', 'emblem', 'seal']);
+const FREE_LICENSE_TOKENS = Object.freeze([
+  'cc by',
+  'cc-by',
+  'cc0',
+  'creative commons attribution',
+  'creative commons zero',
+  'public domain',
+  'pd',
+]);
+const RESTRICTED_LICENSE_TOKENS = Object.freeze([
+  'fair use',
+  'non-free',
+  'copyrighted',
+  'trademark',
+  'logo rationale',
+]);
+
+function compactObject(value) {
+  return Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => {
+      if (entry == null) return false;
+      if (Array.isArray(entry)) return entry.length > 0;
+      if (typeof entry === 'object') return Object.keys(entry).length > 0;
+      return true;
+    })
+  );
+}
+
+function toText(value) {
+  if (value == null) return null;
+  const text = String(value).trim();
+  return text.length ? text : null;
+}
+
+function stripHtml(value) {
+  const text = toText(value);
+  if (!text) return null;
+  return text
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function normalizeTokenText(value) {
+  return String(value || '')
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/f\.?c\.?/g, ' ')
+    .replace(/football club/g, ' ')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function significantTokens(value) {
+  return normalizeTokenText(value)
+    .split(/\s+/)
+    .filter((token) => token.length > 2 && !['the', 'and', 'club', 'football'].includes(token));
+}
+
+function fileNameFromTitle(fileTitle) {
+  return String(fileTitle || '')
+    .replace(/^File:/i, '')
+    .replace(/[_-]+/g, ' ');
+}
+
+function hasCrestFileToken(fileTitle) {
+  const normalized = normalizeTokenText(fileNameFromTitle(fileTitle));
+  return CREST_FILE_TOKENS.some((token) => normalized.includes(token));
+}
+
+function buildAssetId(source, fileTitle, fallbackUrl) {
+  const idPart = toText(fileTitle) || toText(fallbackUrl) || 'unknown';
+  return `${source}:${idPart.replace(/^File:/i, '')}`;
+}
+
+function normalizeUrl(value) {
+  const text = toText(value);
+  if (!text) return null;
+  if (text.startsWith('//')) return `https:${text}`;
+  return text;
+}
+
+function imagePageUrl(fileTitle) {
+  const title = toText(fileTitle);
+  if (!title) return null;
+  const normalizedTitle = title.startsWith('File:') ? title : `File:${title}`;
+  return `https://en.wikipedia.org/wiki/${encodeURIComponent(normalizedTitle).replace(/%20/g, '_')}`;
+}
+
+export function classifyAssetLicense(license = {}) {
+  const shortName = normalizeTokenText(license.shortName);
+  const usageTerms = normalizeTokenText(license.usageTerms);
+  const joined = `${shortName} ${usageTerms}`;
+
+  if (license.copyrighted === false) return 'pass';
+  if (RESTRICTED_LICENSE_TOKENS.some((token) => joined.includes(token))) return 'restricted';
+  if (FREE_LICENSE_TOKENS.some((token) => joined.includes(token))) return 'pass';
+  if (license.copyrighted === true) return 'restricted';
+  return 'unknown';
+}
+
+export function classifyAssetIdentity(candidate, club) {
+  const fileTokens = significantTokens(candidate.fileTitle || candidate.imageUrl || '');
+  const clubTokens = significantTokens(club?.canonicalName || club?.clubId || '');
+  const aliasTokens = (club?.derived?.aliases || []).flatMap(significantTokens);
+  const expectedTokens = new Set([...clubTokens, ...aliasTokens]);
+
+  if (!fileTokens.length || !expectedTokens.size) return 'weak';
+
+  const matches = fileTokens.filter((token) => expectedTokens.has(token));
+  if (matches.length >= Math.min(2, clubTokens.length || 2) && hasCrestFileToken(candidate.fileTitle)) {
+    return 'strong';
+  }
+  if (matches.length > 0 && hasCrestFileToken(candidate.fileTitle)) return 'possible';
+  if (matches.length > 0) return 'weak';
+  return 'none';
+}
+
+export function classifyClubAssetCandidate(candidate, club, { checkedAt = null } = {}) {
+  const licenseCheck = classifyAssetLicense(candidate.license || {});
+  const identityMatch = classifyAssetIdentity(candidate, club);
+  const reviewReasons = [];
+
+  if (licenseCheck === 'restricted') reviewReasons.push('license-restricted');
+  if (licenseCheck === 'unknown') reviewReasons.push('license-unknown');
+  if (!['strong', 'possible'].includes(identityMatch)) reviewReasons.push('identity-uncertain');
+  if (!hasCrestFileToken(candidate.fileTitle)) reviewReasons.push('non-crest-filename');
+  if (!candidate.imageUrl) reviewReasons.push('image-url-missing');
+
+  let status = 'needs-review';
+  if (!candidate.imageUrl) {
+    status = 'failed';
+  } else if (licenseCheck === 'restricted') {
+    status = 'restricted';
+  } else if (licenseCheck === 'pass' && ['strong', 'possible'].includes(identityMatch)) {
+    status = 'usable';
+  }
+
+  return {
+    ...candidate,
+    status,
+    verification: compactObject({
+      ...(candidate.verification || {}),
+      identityMatch,
+      licenseCheck,
+      httpCheck: candidate.imageUrl ? 'pass' : 'fail',
+      needsManualReview: status !== 'usable',
+      reviewReasons,
+      checkedAt,
+    }),
+  };
+}
+
+function statusRank(status) {
+  if (status === 'usable') return 0;
+  if (status === 'restricted') return 1;
+  if (status === 'needs-review') return 2;
+  if (status === 'failed') return 4;
+  return 3;
+}
+
+function sourceRank(source) {
+  if (source === CLUB_ASSET_SOURCE_IDS.wikidataLogo) return 0;
+  if (source === CLUB_ASSET_SOURCE_IDS.wikipediaPageImageFree) return 1;
+  if (source === CLUB_ASSET_SOURCE_IDS.wikipediaPageImageAny) return 2;
+  return 3;
+}
+
+export function rankClubAssetCandidates(candidates, limit = 5) {
+  const seen = new Set();
+  const deduped = [];
+  for (const candidate of candidates || []) {
+    if (!candidate?.assetId) continue;
+    if (seen.has(candidate.assetId)) continue;
+    seen.add(candidate.assetId);
+    deduped.push(candidate);
+  }
+
+  return deduped
+    .sort((left, right) => {
+      const statusDelta = statusRank(left.status) - statusRank(right.status);
+      if (statusDelta) return statusDelta;
+      const sourceDelta = sourceRank(left.source) - sourceRank(right.source);
+      if (sourceDelta) return sourceDelta;
+      const leftCrest = hasCrestFileToken(left.fileTitle) ? 0 : 1;
+      const rightCrest = hasCrestFileToken(right.fileTitle) ? 0 : 1;
+      if (leftCrest !== rightCrest) return leftCrest - rightCrest;
+      return String(left.assetId).localeCompare(String(right.assetId));
+    })
+    .slice(0, limit)
+    .map((candidate, index) => ({ ...candidate, priority: index + 1 }));
+}
+
+export function buildClubAssetBundle(candidates, { limit = 5 } = {}) {
+  const rankedCandidates = rankClubAssetCandidates(candidates, limit);
+  const preferredCandidate = rankedCandidates.find((candidate) => candidate.status === 'usable');
+  const status = preferredCandidate
+    ? 'usable'
+    : rankedCandidates[0]?.status || 'missing';
+
+  return compactObject({
+    preferred: preferredCandidate?.assetId || null,
+    status,
+    candidates: rankedCandidates,
+  });
+}
+
+export function buildClubAssetReviewIssues(clubKey, club, bundle) {
+  const baseIssue = {
+    clubKey,
+    clubId: club?.clubId || null,
+    canonicalName: club?.canonicalName || clubKey,
+    assetKind: 'crest',
+  };
+  const candidates = bundle?.candidates || [];
+  const issues = [];
+
+  if (!candidates.length) {
+    issues.push({
+      type: 'club-asset-missing',
+      ...baseIssue,
+      message: `${baseIssue.canonicalName} has no crest asset candidates`,
+    });
+    return issues;
+  }
+
+  for (const candidate of candidates) {
+    if (candidate.status === 'restricted') {
+      issues.push({
+        type: 'club-asset-license-restricted',
+        ...baseIssue,
+        assetId: candidate.assetId,
+        source: candidate.source,
+        message: `${baseIssue.canonicalName} crest candidate is license restricted`,
+      });
+    }
+    if (candidate.status === 'failed') {
+      issues.push({
+        type: 'club-asset-url-failed',
+        ...baseIssue,
+        assetId: candidate.assetId,
+        source: candidate.source,
+        message: `${baseIssue.canonicalName} crest candidate failed URL verification`,
+      });
+    }
+    if (candidate.verification?.reviewReasons?.includes('identity-uncertain')) {
+      issues.push({
+        type: 'club-asset-identity-uncertain',
+        ...baseIssue,
+        assetId: candidate.assetId,
+        source: candidate.source,
+        message: `${baseIssue.canonicalName} crest candidate identity is uncertain`,
+      });
+    }
+    if (candidate.verification?.reviewReasons?.includes('non-crest-filename')) {
+      issues.push({
+        type: 'club-asset-non-crest-candidate',
+        ...baseIssue,
+        assetId: candidate.assetId,
+        source: candidate.source,
+        message: `${baseIssue.canonicalName} crest candidate does not look like a crest/logo filename`,
+      });
+    }
+  }
+
+  if (!bundle?.preferred && candidates.some((candidate) => candidate.status !== 'failed')) {
+    issues.push({
+      type: 'club-asset-multiple-review-candidates',
+      ...baseIssue,
+      candidateCount: candidates.length,
+      message: `${baseIssue.canonicalName} has crest candidates but no usable preferred asset`,
+    });
+  }
+
+  return issues;
+}
+
+async function fetchJson(url) {
+  return new Promise((resolve, reject) => {
+    https
+      .get(url, { headers: { 'user-agent': USER_AGENT } }, (response) => {
+        let body = '';
+        response.on('data', (chunk) => {
+          body += chunk;
+        });
+        response.on('end', () => {
+          if ((response.statusCode || 0) < 200 || (response.statusCode || 0) >= 300) {
+            reject(new Error(`Request failed ${response.statusCode}: ${body.slice(0, 200)}`));
+            return;
+          }
+          try {
+            resolve(JSON.parse(body));
+          } catch (error) {
+            reject(error);
+          }
+        });
+      })
+      .on('error', reject);
+  });
+}
+
+function wikipediaArticleTitle(club) {
+  const sourceUrl =
+    club?.derived?.identitySources?.find((source) =>
+      String(source.sourceUrl || '').startsWith('https://en.wikipedia.org/wiki/')
+    )?.sourceUrl ||
+    club?.status?.sourceRefs?.find((source) =>
+      String(source.sourceUrl || '').startsWith('https://en.wikipedia.org/wiki/')
+    )?.sourceUrl;
+  if (sourceUrl) {
+    const pageTitle = decodeURIComponent(sourceUrl.split('/wiki/')[1] || '').replace(/_/g, ' ');
+    if (pageTitle) return pageTitle;
+  }
+
+  const canonicalName = toText(club?.canonicalName);
+  if (!canonicalName) return null;
+  return /\bF\.?C\.?$/i.test(canonicalName) ? canonicalName : `${canonicalName} F.C.`;
+}
+
+function pageImagesApiUrl(articleTitle, license) {
+  const params = new URLSearchParams({
+    action: 'query',
+    format: 'json',
+    redirects: '1',
+    prop: 'pageimages|pageprops',
+    piprop: 'name|original',
+    pilicense: license,
+    titles: articleTitle,
+  });
+  return `https://en.wikipedia.org/w/api.php?${params.toString()}`;
+}
+
+function imageInfoApiUrl(fileTitles) {
+  const params = new URLSearchParams({
+    action: 'query',
+    format: 'json',
+    prop: 'imageinfo',
+    iiprop: 'url|mime|size|extmetadata',
+    iiextmetadatafilter:
+      'LicenseShortName|UsageTerms|Attribution|Copyrighted|Credit|Artist|LicenseUrl',
+    titles: fileTitles.map((title) => (title.startsWith('File:') ? title : `File:${title}`)).join('|'),
+  });
+  return `https://en.wikipedia.org/w/api.php?${params.toString()}`;
+}
+
+function wikidataEntitiesApiUrl(ids) {
+  const params = new URLSearchParams({
+    action: 'wbgetentities',
+    format: 'json',
+    props: 'claims|labels',
+    languages: 'en',
+    ids: ids.join('|'),
+  });
+  return `https://www.wikidata.org/w/api.php?${params.toString()}`;
+}
+
+function candidateFromPageImage(page, source) {
+  if (!page?.pageimage && !page?.original?.source) return null;
+  const fileTitle = page.pageimage ? `File:${page.pageimage}` : null;
+  return compactObject({
+    assetId: buildAssetId(source, fileTitle, page.original?.source),
+    kind: 'crest',
+    status: 'needs-review',
+    source,
+    sourceUrl: `https://en.wikipedia.org/wiki/${encodeURIComponent(page.title || '').replace(/%20/g, '_')}`,
+    imageUrl: normalizeUrl(page.original?.source),
+    pageUrl: imagePageUrl(fileTitle),
+    fileTitle,
+  });
+}
+
+function licenseFromExtMetadata(extmetadata = {}) {
+  const valueFor = (key) => stripHtml(extmetadata[key]?.value);
+  const copyrighted = valueFor('Copyrighted');
+  return compactObject({
+    shortName: valueFor('LicenseShortName'),
+    usageTerms: valueFor('UsageTerms'),
+    licenseUrl: normalizeUrl(valueFor('LicenseUrl')),
+    copyrighted:
+      copyrighted == null
+        ? null
+        : String(copyrighted).toLowerCase() === 'true'
+          ? true
+          : String(copyrighted).toLowerCase() === 'false'
+            ? false
+            : null,
+    attribution: valueFor('Attribution'),
+    credit: valueFor('Credit'),
+    artist: valueFor('Artist'),
+  });
+}
+
+function mergeImageInfo(candidate, imageInfoPage) {
+  const imageInfo = imageInfoPage?.imageinfo?.[0] || {};
+  return compactObject({
+    ...candidate,
+    imageUrl: normalizeUrl(imageInfo.url) || candidate.imageUrl,
+    pageUrl: normalizeUrl(imageInfo.descriptionurl) || candidate.pageUrl,
+    fileTitle: imageInfoPage?.title || candidate.fileTitle,
+    mimeType: toText(imageInfo.mime),
+    width: Number.isInteger(imageInfo.width) ? imageInfo.width : null,
+    height: Number.isInteger(imageInfo.height) ? imageInfo.height : null,
+    license: licenseFromExtMetadata(imageInfo.extmetadata),
+  });
+}
+
+async function enrichCandidatesWithImageInfo(candidates) {
+  const fileTitles = candidates.map((candidate) => candidate.fileTitle).filter(Boolean);
+  if (!fileTitles.length) return candidates;
+  const response = await fetchJson(imageInfoApiUrl(fileTitles));
+  const pages = Object.values(response?.query?.pages || {});
+  const byTitle = new Map(pages.map((page) => [String(page.title || ''), page]));
+
+  return candidates.map((candidate) => {
+    const title = candidate.fileTitle?.startsWith('File:')
+      ? candidate.fileTitle
+      : `File:${candidate.fileTitle}`;
+    return mergeImageInfo(candidate, byTitle.get(title));
+  });
+}
+
+async function discoverWikipediaPageImageCandidate(articleTitle, license) {
+  const response = await fetchJson(pageImagesApiUrl(articleTitle, license));
+  const page = Object.values(response?.query?.pages || {})[0];
+  const source =
+    license === 'free'
+      ? CLUB_ASSET_SOURCE_IDS.wikipediaPageImageFree
+      : CLUB_ASSET_SOURCE_IDS.wikipediaPageImageAny;
+  const candidate = candidateFromPageImage(page, source);
+  return candidate ? [candidate] : [];
+}
+
+async function discoverWikidataLogoCandidates(articleTitle) {
+  const pageResponse = await fetchJson(pageImagesApiUrl(articleTitle, 'any'));
+  const page = Object.values(pageResponse?.query?.pages || {})[0];
+  const wikibaseItem = page?.pageprops?.wikibase_item;
+  if (!wikibaseItem) return [];
+
+  const entityResponse = await fetchJson(wikidataEntitiesApiUrl([wikibaseItem]));
+  const entity = entityResponse?.entities?.[wikibaseItem];
+  const logos = entity?.claims?.P154 || [];
+  return logos
+    .map((claim) => claim?.mainsnak?.datavalue?.value)
+    .filter(Boolean)
+    .map((fileName) =>
+      compactObject({
+        assetId: buildAssetId(CLUB_ASSET_SOURCE_IDS.wikidataLogo, `File:${fileName}`, null),
+        kind: 'crest',
+        status: 'needs-review',
+        source: CLUB_ASSET_SOURCE_IDS.wikidataLogo,
+        sourceUrl: `https://www.wikidata.org/wiki/${wikibaseItem}`,
+        pageUrl: imagePageUrl(`File:${fileName}`),
+        fileTitle: `File:${fileName}`,
+      })
+    );
+}
+
+export async function discoverClubCrestBundle(club, options = {}) {
+  const articleTitle = wikipediaArticleTitle(club);
+  if (!articleTitle) return buildClubAssetBundle([]);
+
+  const checkedAt = options.checkedAt || new Date().toISOString();
+  const rawCandidates = [];
+  const discoverySteps = [
+    () => discoverWikipediaPageImageCandidate(articleTitle, 'free'),
+    () => discoverWikidataLogoCandidates(articleTitle),
+    () => discoverWikipediaPageImageCandidate(articleTitle, 'any'),
+  ];
+
+  for (const step of discoverySteps) {
+    try {
+      rawCandidates.push(...(await step()));
+    } catch (error) {
+      if (options.throwOnSourceError) throw error;
+    }
+  }
+
+  const enrichedCandidates = await enrichCandidatesWithImageInfo(rawCandidates);
+  const classifiedCandidates = enrichedCandidates.map((candidate) =>
+    classifyClubAssetCandidate(candidate, club, { checkedAt })
+  );
+  return buildClubAssetBundle(classifiedCandidates, { limit: options.limit || 5 });
+}

--- a/wikipedia/data/assets/club-assets.js
+++ b/wikipedia/data/assets/club-assets.js
@@ -27,6 +27,12 @@ const RESTRICTED_LICENSE_TOKENS = Object.freeze([
   'logo rationale',
 ]);
 
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 function compactObject(value) {
   return Object.fromEntries(
     Object.entries(value).filter(([, entry]) => {
@@ -80,9 +86,25 @@ function fileNameFromTitle(fileTitle) {
     .replace(/[_-]+/g, ' ');
 }
 
+function normalizedFileTitleKey(fileTitle) {
+  const title = String(fileTitle || '').startsWith('File:')
+    ? String(fileTitle || '')
+    : `File:${fileTitle || ''}`;
+  return title.replace(/_/g, ' ').trim().toLowerCase();
+}
+
 function hasCrestFileToken(fileTitle) {
   const normalized = normalizeTokenText(fileNameFromTitle(fileTitle));
   return CREST_FILE_TOKENS.some((token) => normalized.includes(token));
+}
+
+function normalizedCompactText(value) {
+  return normalizeTokenText(value).replace(/\s+/g, '');
+}
+
+function fileExtension(fileTitle) {
+  const match = String(fileTitle || '').match(/\.([a-z0-9]+)$/i);
+  return match ? match[1].toLowerCase() : '';
 }
 
 function buildAssetId(source, fileTitle, fallbackUrl) {
@@ -121,6 +143,14 @@ export function classifyAssetIdentity(candidate, club) {
   const clubTokens = significantTokens(club?.canonicalName || club?.clubId || '');
   const aliasTokens = (club?.derived?.aliases || []).flatMap(significantTokens);
   const expectedTokens = new Set([...clubTokens, ...aliasTokens]);
+  const compactFile = normalizedCompactText(candidate.fileTitle || candidate.imageUrl || '');
+  const compactNames = [club?.canonicalName, club?.clubId, ...(club?.derived?.aliases || [])]
+    .map(normalizedCompactText)
+    .filter(Boolean);
+
+  if (compactNames.some((name) => name.length > 2 && compactFile.includes(name))) {
+    return hasCrestFileToken(candidate.fileTitle) ? 'strong' : 'possible';
+  }
 
   if (!fileTokens.length || !expectedTokens.size) return 'weak';
 
@@ -128,20 +158,32 @@ export function classifyAssetIdentity(candidate, club) {
   if (matches.length >= Math.min(2, clubTokens.length || 2) && hasCrestFileToken(candidate.fileTitle)) {
     return 'strong';
   }
+  if (matches.length >= Math.min(2, clubTokens.length || 2)) return 'possible';
   if (matches.length > 0 && hasCrestFileToken(candidate.fileTitle)) return 'possible';
   if (matches.length > 0) return 'weak';
   return 'none';
 }
 
+function isLikelyCrestCandidate(candidate, identityMatch) {
+  if (hasCrestFileToken(candidate.fileTitle)) return true;
+  const extension = fileExtension(candidate.fileTitle || candidate.imageUrl);
+  return (
+    candidate.source === CLUB_ASSET_SOURCE_IDS.wikipediaPageImageAny &&
+    ['possible', 'strong'].includes(identityMatch) &&
+    ['svg', 'png'].includes(extension)
+  );
+}
+
 export function classifyClubAssetCandidate(candidate, club, { checkedAt = null } = {}) {
   const licenseCheck = classifyAssetLicense(candidate.license || {});
   const identityMatch = classifyAssetIdentity(candidate, club);
+  const likelyCrestCandidate = isLikelyCrestCandidate(candidate, identityMatch);
   const reviewReasons = [];
 
   if (licenseCheck === 'restricted') reviewReasons.push('license-restricted');
   if (licenseCheck === 'unknown') reviewReasons.push('license-unknown');
   if (!['strong', 'possible'].includes(identityMatch)) reviewReasons.push('identity-uncertain');
-  if (!hasCrestFileToken(candidate.fileTitle)) reviewReasons.push('non-crest-filename');
+  if (!likelyCrestCandidate) reviewReasons.push('non-crest-filename');
   if (!candidate.imageUrl) reviewReasons.push('image-url-missing');
 
   let status = 'needs-review';
@@ -280,7 +322,11 @@ export function buildClubAssetReviewIssues(clubKey, club, bundle) {
     }
   }
 
-  if (!bundle?.preferred && candidates.some((candidate) => candidate.status !== 'failed')) {
+  if (
+    !bundle?.preferred &&
+    candidates.length > 1 &&
+    candidates.some((candidate) => candidate.status !== 'failed')
+  ) {
     issues.push({
       type: 'club-asset-multiple-review-candidates',
       ...baseIssue,
@@ -292,28 +338,42 @@ export function buildClubAssetReviewIssues(clubKey, club, bundle) {
   return issues;
 }
 
-async function fetchJson(url) {
-  return new Promise((resolve, reject) => {
-    https
-      .get(url, { headers: { 'user-agent': USER_AGENT } }, (response) => {
-        let body = '';
-        response.on('data', (chunk) => {
-          body += chunk;
-        });
-        response.on('end', () => {
-          if ((response.statusCode || 0) < 200 || (response.statusCode || 0) >= 300) {
-            reject(new Error(`Request failed ${response.statusCode}: ${body.slice(0, 200)}`));
-            return;
-          }
-          try {
-            resolve(JSON.parse(body));
-          } catch (error) {
-            reject(error);
-          }
-        });
-      })
-      .on('error', reject);
-  });
+async function fetchJson(url, { retries = 2, retryDelayMs = 1000 } = {}) {
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      return await new Promise((resolve, reject) => {
+        https
+          .get(url, { headers: { 'user-agent': USER_AGENT } }, (response) => {
+            let body = '';
+            response.on('data', (chunk) => {
+              body += chunk;
+            });
+            response.on('end', () => {
+              if ((response.statusCode || 0) < 200 || (response.statusCode || 0) >= 300) {
+                const error = new Error(
+                  `Request failed ${response.statusCode}: ${body.slice(0, 200)}`
+                );
+                error.statusCode = response.statusCode;
+                reject(error);
+                return;
+              }
+              try {
+                resolve(JSON.parse(body));
+              } catch (error) {
+                reject(error);
+              }
+            });
+          })
+          .on('error', reject);
+      });
+    } catch (error) {
+      const retryableStatus = [429, 500, 502, 503, 504].includes(Number(error.statusCode));
+      if (attempt >= retries || !retryableStatus) throw error;
+      await sleep(retryDelayMs * (attempt + 1));
+    }
+  }
+
+  throw new Error('Unreachable fetch retry state');
 }
 
 function wikipediaArticleTitle(club) {
@@ -426,13 +486,10 @@ async function enrichCandidatesWithImageInfo(candidates) {
   if (!fileTitles.length) return candidates;
   const response = await fetchJson(imageInfoApiUrl(fileTitles));
   const pages = Object.values(response?.query?.pages || {});
-  const byTitle = new Map(pages.map((page) => [String(page.title || ''), page]));
+  const byTitle = new Map(pages.map((page) => [normalizedFileTitleKey(page.title), page]));
 
   return candidates.map((candidate) => {
-    const title = candidate.fileTitle?.startsWith('File:')
-      ? candidate.fileTitle
-      : `File:${candidate.fileTitle}`;
-    return mergeImageInfo(candidate, byTitle.get(title));
+    return mergeImageInfo(candidate, byTitle.get(normalizedFileTitleKey(candidate.fileTitle)));
   });
 }
 
@@ -492,7 +549,12 @@ export async function discoverClubCrestBundle(club, options = {}) {
     }
   }
 
-  const enrichedCandidates = await enrichCandidatesWithImageInfo(rawCandidates);
+  let enrichedCandidates = rawCandidates;
+  try {
+    enrichedCandidates = await enrichCandidatesWithImageInfo(rawCandidates);
+  } catch (error) {
+    if (options.throwOnSourceError) throw error;
+  }
   const classifiedCandidates = enrichedCandidates.map((candidate) =>
     classifyClubAssetCandidate(candidate, club, { checkedAt })
   );

--- a/wikipedia/data/assets/club-assets.js
+++ b/wikipedia/data/assets/club-assets.js
@@ -191,7 +191,11 @@ export function classifyClubAssetCandidate(candidate, club, { checkedAt = null }
     status = 'failed';
   } else if (licenseCheck === 'restricted') {
     status = 'restricted';
-  } else if (licenseCheck === 'pass' && ['strong', 'possible'].includes(identityMatch)) {
+  } else if (
+    licenseCheck === 'pass' &&
+    ['strong', 'possible'].includes(identityMatch) &&
+    likelyCrestCandidate
+  ) {
     status = 'usable';
   }
 
@@ -226,16 +230,8 @@ function sourceRank(source) {
 }
 
 export function rankClubAssetCandidates(candidates, limit = 5) {
-  const seen = new Set();
-  const deduped = [];
-  for (const candidate of candidates || []) {
-    if (!candidate?.assetId) continue;
-    if (seen.has(candidate.assetId)) continue;
-    seen.add(candidate.assetId);
-    deduped.push(candidate);
-  }
-
-  return deduped
+  const sortedCandidates = (candidates || [])
+    .filter((candidate) => candidate?.assetId)
     .sort((left, right) => {
       const statusDelta = statusRank(left.status) - statusRank(right.status);
       if (statusDelta) return statusDelta;
@@ -245,7 +241,18 @@ export function rankClubAssetCandidates(candidates, limit = 5) {
       const rightCrest = hasCrestFileToken(right.fileTitle) ? 0 : 1;
       if (leftCrest !== rightCrest) return leftCrest - rightCrest;
       return String(left.assetId).localeCompare(String(right.assetId));
-    })
+    });
+  const seen = new Set();
+  const deduped = [];
+  for (const candidate of sortedCandidates) {
+    const dedupeKey =
+      candidate.imageUrl || normalizedFileTitleKey(candidate.fileTitle) || candidate.assetId;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    deduped.push(candidate);
+  }
+
+  return deduped
     .slice(0, limit)
     .map((candidate, index) => ({ ...candidate, priority: index + 1 }));
 }

--- a/wikipedia/data/assets/club-assets.js
+++ b/wikipedia/data/assets/club-assets.js
@@ -383,22 +383,64 @@ async function fetchJson(url, { retries = 2, retryDelayMs = 1000 } = {}) {
   throw new Error('Unreachable fetch retry state');
 }
 
-function wikipediaArticleTitle(club) {
-  const sourceUrl =
-    club?.derived?.identitySources?.find((source) =>
-      String(source.sourceUrl || '').startsWith('https://en.wikipedia.org/wiki/')
-    )?.sourceUrl ||
-    club?.status?.sourceRefs?.find((source) =>
-      String(source.sourceUrl || '').startsWith('https://en.wikipedia.org/wiki/')
-    )?.sourceUrl;
-  if (sourceUrl) {
-    const pageTitle = decodeURIComponent(sourceUrl.split('/wiki/')[1] || '').replace(/_/g, ' ');
-    if (pageTitle) return pageTitle;
+function wikipediaPageTitleFromUrl(sourceUrl) {
+  const url = String(sourceUrl || '');
+  if (!url.startsWith('https://en.wikipedia.org/wiki/')) return null;
+  const pageTitle = decodeURIComponent(url.split('/wiki/')[1] || '').replace(/_/g, ' ');
+  return toText(pageTitle);
+}
+
+function pushUniqueTitle(titles, title) {
+  const normalizedTitle = toText(title);
+  if (!normalizedTitle) return;
+  const dedupeKey = normalizedTitle.toLowerCase();
+  if (titles.some((entry) => entry.toLowerCase() === dedupeKey)) return;
+  titles.push(normalizedTitle);
+}
+
+function buildTitleGuesses(name) {
+  const title = toText(name);
+  if (!title) return [];
+  const guesses = [title];
+  if (/^AFC\s+/i.test(title)) {
+    guesses.push(title.replace(/^AFC\s+/i, 'A.F.C. '));
+  }
+  if (/^FC\s+/i.test(title)) {
+    guesses.push(title.replace(/^FC\s+/i, 'F.C. '));
+  }
+  if (!/\b(A\.?F\.?C\.?|F\.?C\.?)$/i.test(title)) {
+    guesses.push(`${title} F.C.`);
+    guesses.push(`${title} A.F.C.`);
+  }
+  return guesses;
+}
+
+export function buildWikipediaArticleTitles(club) {
+  const titles = [];
+  const identitySources = [
+    ...(club?.derived?.identitySources || []),
+    ...(club?.status?.sourceRefs || []),
+  ];
+  const clubPageSources = identitySources.filter(
+    (source) => source.type === 'wikipedia-club-page'
+  );
+  const otherWikiSources = identitySources.filter(
+    (source) => source.type !== 'wikipedia-club-page'
+  );
+
+  for (const source of clubPageSources) {
+    pushUniqueTitle(titles, wikipediaPageTitleFromUrl(source.sourceUrl));
+  }
+  for (const name of [club?.canonicalName, ...(club?.derived?.aliases || [])]) {
+    for (const guess of buildTitleGuesses(name)) {
+      pushUniqueTitle(titles, guess);
+    }
+  }
+  for (const source of otherWikiSources) {
+    pushUniqueTitle(titles, wikipediaPageTitleFromUrl(source.sourceUrl));
   }
 
-  const canonicalName = toText(club?.canonicalName);
-  if (!canonicalName) return null;
-  return /\bF\.?C\.?$/i.test(canonicalName) ? canonicalName : `${canonicalName} F.C.`;
+  return titles.slice(0, 8);
 }
 
 function pageImagesApiUrl(articleTitle, license) {
@@ -537,22 +579,24 @@ async function discoverWikidataLogoCandidates(articleTitle) {
 }
 
 export async function discoverClubCrestBundle(club, options = {}) {
-  const articleTitle = wikipediaArticleTitle(club);
-  if (!articleTitle) return buildClubAssetBundle([]);
+  const articleTitles = buildWikipediaArticleTitles(club);
+  if (!articleTitles.length) return buildClubAssetBundle([]);
 
   const checkedAt = options.checkedAt || new Date().toISOString();
   const rawCandidates = [];
-  const discoverySteps = [
-    () => discoverWikipediaPageImageCandidate(articleTitle, 'free'),
-    () => discoverWikidataLogoCandidates(articleTitle),
-    () => discoverWikipediaPageImageCandidate(articleTitle, 'any'),
-  ];
+  for (const articleTitle of articleTitles) {
+    const discoverySteps = [
+      () => discoverWikipediaPageImageCandidate(articleTitle, 'free'),
+      () => discoverWikidataLogoCandidates(articleTitle),
+      () => discoverWikipediaPageImageCandidate(articleTitle, 'any'),
+    ];
 
-  for (const step of discoverySteps) {
-    try {
-      rawCandidates.push(...(await step()));
-    } catch (error) {
-      if (options.throwOnSourceError) throw error;
+    for (const step of discoverySteps) {
+      try {
+        rawCandidates.push(...(await step()));
+      } catch (error) {
+        if (options.throwOnSourceError) throw error;
+      }
     }
   }
 

--- a/wikipedia/data/assets/club-assets.js
+++ b/wikipedia/data/assets/club-assets.js
@@ -3,6 +3,7 @@
 import https from 'node:https';
 
 export const CLUB_ASSET_SOURCE_IDS = Object.freeze({
+  generatedPlaceholder: 'generated-placeholder',
   wikidataLogo: 'wikidata-logo',
   wikidataCoatOfArms: 'wikidata-coat-of-arms',
   wikidataImage: 'wikidata-image',
@@ -34,6 +35,74 @@ const WIKIDATA_MEDIA_PROPERTIES = Object.freeze([
   { property: 'P18', source: CLUB_ASSET_SOURCE_IDS.wikidataImage },
 ]);
 const TRUSTED_WIKIDATA_CREST_SOURCES = Object.freeze([CLUB_ASSET_SOURCE_IDS.wikidataCoatOfArms]);
+const GENERATED_PLACEHOLDER_LICENSE = Object.freeze({
+  shortName: 'CC0-1.0',
+  usageTerms: 'Creative Commons Zero v1.0 Universal',
+  licenseUrl: 'https://creativecommons.org/publicdomain/zero/1.0/',
+  copyrighted: false,
+  attribution: 'footy-data-kit generated placeholder',
+});
+const HISTORICAL_PLACEHOLDER_CRESTS = Object.freeze({
+  'birmingham-st-georges': {
+    colors: [
+      { role: 'primary', hex: '#FFFFFF' },
+      { role: 'secondary', hex: '#000000' },
+    ],
+  },
+  'burton-swifts': {
+    colors: [
+      { role: 'primary', hex: '#FF0000' },
+      { role: 'secondary', hex: '#FFFFFF' },
+      { role: 'accent', hex: '#000099' },
+    ],
+  },
+  'burton-united': {
+    colors: [
+      { role: 'primary', hex: '#663300' },
+      { role: 'secondary', hex: '#87CEEB' },
+      { role: 'accent', hex: '#FFFFFF' },
+    ],
+  },
+  'burton-wanderers': {
+    colors: [
+      { role: 'primary', hex: '#FFFFFF' },
+      { role: 'secondary', hex: '#0057B8' },
+      { role: 'accent', hex: '#333333' },
+    ],
+  },
+  'middlesbrough-ironopolis': {
+    colors: [
+      { role: 'primary', hex: '#CC0033' },
+      { role: 'secondary', hex: '#000000' },
+      { role: 'accent', hex: '#FFFFFF' },
+    ],
+  },
+  'oswestry-town': {
+    colors: [
+      { role: 'primary', hex: '#0000FF' },
+      { role: 'secondary', hex: '#FFFFFF' },
+    ],
+  },
+  'redbridge-forest': {
+    colors: [
+      { role: 'primary', hex: '#FF0000' },
+      { role: 'secondary', hex: '#0000FF' },
+      { role: 'accent', hex: '#FFFFFF' },
+    ],
+  },
+  'rotherham-town': {
+    colors: [
+      { role: 'primary', hex: '#FF0000' },
+      { role: 'secondary', hex: '#1C1271' },
+    ],
+  },
+  'sunderland-albion': {
+    colors: [
+      { role: 'primary', hex: '#000066' },
+      { role: 'secondary', hex: '#FFFFFF' },
+    ],
+  },
+});
 
 function sleep(ms) {
   return new Promise((resolve) => {
@@ -118,6 +187,79 @@ function fileExtension(fileTitle) {
 function buildAssetId(source, fileTitle, fallbackUrl) {
   const idPart = toText(fileTitle) || toText(fallbackUrl) || 'unknown';
   return `${source}:${idPart.replace(/^File:/i, '')}`;
+}
+
+function slugify(value) {
+  return normalizeTokenText(value).replace(/\s+/g, '-');
+}
+
+function escapeXml(value) {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function normalizeHexColor(value, fallback) {
+  const text = String(value || '').trim();
+  const normalized = text.startsWith('#') ? text : `#${text}`;
+  return /^#[0-9a-f]{6}$/i.test(normalized) ? normalized.toUpperCase() : fallback;
+}
+
+function hexColorChannels(value) {
+  const normalized = normalizeHexColor(value, '#000000').slice(1);
+  return {
+    red: Number.parseInt(normalized.slice(0, 2), 16),
+    green: Number.parseInt(normalized.slice(2, 4), 16),
+    blue: Number.parseInt(normalized.slice(4, 6), 16),
+  };
+}
+
+function contrastTextColor(backgroundColor) {
+  const { red, green, blue } = hexColorChannels(backgroundColor);
+  const brightness = (red * 299 + green * 587 + blue * 114) / 1000;
+  return brightness > 155 ? '#111111' : '#FFFFFF';
+}
+
+function clubInitials(club) {
+  const tokens = significantTokens(club?.canonicalName || club?.clubId || '');
+  return tokens
+    .slice(0, 3)
+    .map((token) => token[0]?.toUpperCase())
+    .join('');
+}
+
+function firstWikipediaClubPageUrl(club) {
+  return [
+    ...(club?.derived?.identitySources || []),
+    ...(club?.status?.sourceRefs || []),
+  ].find((source) => source.type === 'wikipedia-club-page')?.sourceUrl;
+}
+
+function svgDataUrl(svg) {
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+function buildPlaceholderSvg(club, colors) {
+  const primary = normalizeHexColor(colors[0]?.hex, '#555555');
+  const secondary = normalizeHexColor(colors[1]?.hex, '#EEEEEE');
+  const accent = normalizeHexColor(colors[2]?.hex, secondary);
+  const textFill = contrastTextColor(primary);
+  const textStroke = textFill === '#FFFFFF' ? '#111111' : '#FFFFFF';
+  const title = `${club?.canonicalName || 'Club'} generated placeholder crest`;
+  const initials = clubInitials(club) || 'FC';
+
+  return [
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img">',
+    `<title>${escapeXml(title)}</title>`,
+    `<path d="M128 14 220 48v68c0 58-36 103-92 126-56-23-92-68-92-126V48l92-34Z" fill="${primary}" stroke="${accent}" stroke-width="10"/>`,
+    `<path d="M128 26 210 56v58c0 49-30 88-82 110V26Z" fill="${secondary}" opacity="0.92"/>`,
+    `<path d="M50 84h156v30H50z" fill="${accent}" opacity="0.9"/>`,
+    `<text x="128" y="154" text-anchor="middle" font-family="Arial, Helvetica, sans-serif" font-size="58" font-weight="700" fill="${textFill}" stroke="${textStroke}" stroke-width="3" paint-order="stroke">${escapeXml(initials)}</text>`,
+    '</svg>',
+  ].join('');
 }
 
 function normalizeUrl(value) {
@@ -230,6 +372,7 @@ export function classifyClubAssetCandidate(candidate, club, { checkedAt = null }
 
 function statusRank(status) {
   if (status === 'usable') return 0;
+  if (status === 'placeholder') return 1;
   if (status === 'restricted') return 1;
   if (status === 'needs-review') return 2;
   if (status === 'failed') return 4;
@@ -237,6 +380,7 @@ function statusRank(status) {
 }
 
 function sourceRank(source) {
+  if (source === CLUB_ASSET_SOURCE_IDS.generatedPlaceholder) return 0;
   if (source === CLUB_ASSET_SOURCE_IDS.wikidataLogo) return 0;
   if (source === CLUB_ASSET_SOURCE_IDS.wikidataCoatOfArms) return 1;
   if (source === CLUB_ASSET_SOURCE_IDS.wikipediaPageImageFree) return 2;
@@ -275,16 +419,61 @@ export function rankClubAssetCandidates(candidates, limit = 5) {
 
 export function buildClubAssetBundle(candidates, { limit = 5 } = {}) {
   const rankedCandidates = rankClubAssetCandidates(candidates, limit);
-  const preferredCandidate = rankedCandidates.find((candidate) => candidate.status === 'usable');
-  const status = preferredCandidate
-    ? 'usable'
-    : rankedCandidates[0]?.status || 'missing';
+  const preferredCandidate =
+    rankedCandidates.find((candidate) => candidate.status === 'usable') ||
+    rankedCandidates.find((candidate) => candidate.status === 'placeholder');
+  const status = preferredCandidate?.status || rankedCandidates[0]?.status || 'missing';
 
   return compactObject({
     preferred: preferredCandidate?.assetId || null,
     status,
     candidates: rankedCandidates,
   });
+}
+
+export function buildGeneratedPlaceholderCrestCandidate(club, { checkedAt = null } = {}) {
+  const placeholderConfig = HISTORICAL_PLACEHOLDER_CRESTS[club?.clubId];
+  if (!placeholderConfig) return null;
+
+  const slug = slugify(club?.clubId || club?.canonicalName || 'club');
+  const fileTitle = `Generated:${slug}-placeholder-crest.svg`;
+  const colors = placeholderConfig.colors.map((color) => ({
+    role: color.role,
+    hex: normalizeHexColor(color.hex, '#555555'),
+  }));
+  const imageUrl = svgDataUrl(buildPlaceholderSvg(club, colors));
+
+  return compactObject({
+    assetId: buildAssetId(CLUB_ASSET_SOURCE_IDS.generatedPlaceholder, fileTitle, null),
+    kind: 'crest',
+    status: 'placeholder',
+    source: CLUB_ASSET_SOURCE_IDS.generatedPlaceholder,
+    placeholder: true,
+    sourceUrl: firstWikipediaClubPageUrl(club) || null,
+    imageUrl,
+    fileTitle,
+    mimeType: 'image/svg+xml',
+    width: 256,
+    height: 256,
+    colors,
+    license: GENERATED_PLACEHOLDER_LICENSE,
+    verification: compactObject({
+      identityMatch: 'generated-placeholder',
+      licenseCheck: 'pass',
+      httpCheck: 'pass',
+      needsManualReview: false,
+      checkedAt,
+    }),
+    notes:
+      'Generated placeholder shield from source-backed club colours; not an official or historical club crest.',
+  });
+}
+
+export function addGeneratedPlaceholderFallback(club, bundle, { checkedAt = null, limit = 5 } = {}) {
+  if (bundle?.candidates?.length) return bundle;
+  const placeholderCandidate = buildGeneratedPlaceholderCrestCandidate(club, { checkedAt });
+  if (!placeholderCandidate) return bundle;
+  return buildClubAssetBundle([placeholderCandidate], { limit });
 }
 
 export function buildClubAssetReviewIssues(clubKey, club, bundle) {

--- a/wikipedia/data/assets/club-assets.js
+++ b/wikipedia/data/assets/club-assets.js
@@ -4,6 +4,8 @@ import https from 'node:https';
 
 export const CLUB_ASSET_SOURCE_IDS = Object.freeze({
   wikidataLogo: 'wikidata-logo',
+  wikidataCoatOfArms: 'wikidata-coat-of-arms',
+  wikidataImage: 'wikidata-image',
   wikipediaPageImageFree: 'wikipedia-pageimage-free',
   wikipediaPageImageAny: 'wikipedia-pageimage-any',
 });
@@ -26,6 +28,12 @@ const RESTRICTED_LICENSE_TOKENS = Object.freeze([
   'trademark',
   'logo rationale',
 ]);
+const WIKIDATA_MEDIA_PROPERTIES = Object.freeze([
+  { property: 'P154', source: CLUB_ASSET_SOURCE_IDS.wikidataLogo },
+  { property: 'P94', source: CLUB_ASSET_SOURCE_IDS.wikidataCoatOfArms },
+  { property: 'P18', source: CLUB_ASSET_SOURCE_IDS.wikidataImage },
+]);
+const TRUSTED_WIKIDATA_CREST_SOURCES = Object.freeze([CLUB_ASSET_SOURCE_IDS.wikidataCoatOfArms]);
 
 function sleep(ms) {
   return new Promise((resolve) => {
@@ -166,6 +174,12 @@ export function classifyAssetIdentity(candidate, club) {
 
 function isLikelyCrestCandidate(candidate, identityMatch) {
   if (hasCrestFileToken(candidate.fileTitle)) return true;
+  if (
+    TRUSTED_WIKIDATA_CREST_SOURCES.includes(candidate.source) &&
+    ['possible', 'strong'].includes(identityMatch)
+  ) {
+    return true;
+  }
   const extension = fileExtension(candidate.fileTitle || candidate.imageUrl);
   return (
     candidate.source === CLUB_ASSET_SOURCE_IDS.wikipediaPageImageAny &&
@@ -224,9 +238,11 @@ function statusRank(status) {
 
 function sourceRank(source) {
   if (source === CLUB_ASSET_SOURCE_IDS.wikidataLogo) return 0;
-  if (source === CLUB_ASSET_SOURCE_IDS.wikipediaPageImageFree) return 1;
-  if (source === CLUB_ASSET_SOURCE_IDS.wikipediaPageImageAny) return 2;
-  return 3;
+  if (source === CLUB_ASSET_SOURCE_IDS.wikidataCoatOfArms) return 1;
+  if (source === CLUB_ASSET_SOURCE_IDS.wikipediaPageImageFree) return 2;
+  if (source === CLUB_ASSET_SOURCE_IDS.wikidataImage) return 3;
+  if (source === CLUB_ASSET_SOURCE_IDS.wikipediaPageImageAny) return 4;
+  return 5;
 }
 
 export function rankClubAssetCandidates(candidates, limit = 5) {
@@ -553,7 +569,7 @@ async function discoverWikipediaPageImageCandidate(articleTitle, license) {
   return candidate ? [candidate] : [];
 }
 
-async function discoverWikidataLogoCandidates(articleTitle) {
+async function discoverWikidataMediaCandidates(articleTitle) {
   const pageResponse = await fetchJson(pageImagesApiUrl(articleTitle, 'any'));
   const page = Object.values(pageResponse?.query?.pages || {})[0];
   const wikibaseItem = page?.pageprops?.wikibase_item;
@@ -561,21 +577,25 @@ async function discoverWikidataLogoCandidates(articleTitle) {
 
   const entityResponse = await fetchJson(wikidataEntitiesApiUrl([wikibaseItem]));
   const entity = entityResponse?.entities?.[wikibaseItem];
-  const logos = entity?.claims?.P154 || [];
-  return logos
-    .map((claim) => claim?.mainsnak?.datavalue?.value)
-    .filter(Boolean)
-    .map((fileName) =>
-      compactObject({
-        assetId: buildAssetId(CLUB_ASSET_SOURCE_IDS.wikidataLogo, `File:${fileName}`, null),
-        kind: 'crest',
-        status: 'needs-review',
-        source: CLUB_ASSET_SOURCE_IDS.wikidataLogo,
-        sourceUrl: `https://www.wikidata.org/wiki/${wikibaseItem}`,
-        pageUrl: imagePageUrl(`File:${fileName}`),
-        fileTitle: `File:${fileName}`,
-      })
-    );
+  const candidates = [];
+  for (const mediaProperty of WIKIDATA_MEDIA_PROPERTIES) {
+    for (const claim of entity?.claims?.[mediaProperty.property] || []) {
+      const fileName = claim?.mainsnak?.datavalue?.value;
+      if (!fileName) continue;
+      candidates.push(
+        compactObject({
+          assetId: buildAssetId(mediaProperty.source, `File:${fileName}`, null),
+          kind: 'crest',
+          status: 'needs-review',
+          source: mediaProperty.source,
+          sourceUrl: `https://www.wikidata.org/wiki/${wikibaseItem}`,
+          pageUrl: imagePageUrl(`File:${fileName}`),
+          fileTitle: `File:${fileName}`,
+        })
+      );
+    }
+  }
+  return candidates;
 }
 
 export async function discoverClubCrestBundle(club, options = {}) {
@@ -587,7 +607,7 @@ export async function discoverClubCrestBundle(club, options = {}) {
   for (const articleTitle of articleTitles) {
     const discoverySteps = [
       () => discoverWikipediaPageImageCandidate(articleTitle, 'free'),
-      () => discoverWikidataLogoCandidates(articleTitle),
+      () => discoverWikidataMediaCandidates(articleTitle),
       () => discoverWikipediaPageImageCandidate(articleTitle, 'any'),
     ];
 

--- a/wikipedia/data/assets/club-assets.js
+++ b/wikipedia/data/assets/club-assets.js
@@ -35,6 +35,61 @@ const WIKIDATA_MEDIA_PROPERTIES = Object.freeze([
   { property: 'P18', source: CLUB_ASSET_SOURCE_IDS.wikidataImage },
 ]);
 const TRUSTED_WIKIDATA_CREST_SOURCES = Object.freeze([CLUB_ASSET_SOURCE_IDS.wikidataCoatOfArms]);
+const REJECTED_ASSET_IDS = Object.freeze(
+  new Set([
+    'wikidata-image:Andover-2008-Squad.jpg',
+    'wikidata-image:DovervStaines.jpg',
+    'wikidata-image:Shepshed Ground 001 Small.jpg',
+    'wikidata-image:Trowbridge Town F.C..jpg',
+    'wikipedia-pageimage-any:Epsom_and_Ewell_UK_locator_map.svg',
+    'wikipedia-pageimage-any:Folkestone_Harbour_with_Viaduct_and_Swing_Bridge.png',
+    'wikipedia-pageimage-free:Altrincham_Town_Square_-_2024.jpg',
+    'wikipedia-pageimage-free:Angel_of_the_North,_Gateshead,_United_Kingdom.jpg',
+    'wikipedia-pageimage-free:Atherstone_Town_FC_2009.jpg',
+    'wikipedia-pageimage-free:Beam_valley_park_and_turbine_1.jpg',
+    'wikipedia-pageimage-free:Bishop_Auckland_Town_Hall.jpg',
+    'wikipedia-pageimage-free:Bootle_Town_Hall_2020-1.jpg',
+    'wikipedia-pageimage-free:BroadLaneWivenhoeTown21Jan2017.jpg',
+    'wikipedia-pageimage-free:Bromley_-_geograph.org.uk_-_4623007.jpg',
+    'wikipedia-pageimage-free:Bromley_FC_League_Performance.svg',
+    'wikipedia-pageimage-free:Centre_of_Hereford_-_geograph.org.uk_-_4306743.jpg',
+    'wikipedia-pageimage-free:Chester_-_Shops_in_city_centre_-_2005-10-09.jpg',
+    'wikipedia-pageimage-free:Citadel-1.jpg',
+    'wikipedia-pageimage-free:Clevedon_Town_2007.jpg',
+    'wikipedia-pageimage-free:Crown_Ground_sign-geograph-1761360.jpg',
+    'wikipedia-pageimage-free:Darlington_clock_tower_and_market_hall_(geograph_6299652).jpg',
+    'wikipedia-pageimage-free:DrippingPan.jpg',
+    'wikipedia-pageimage-free:Exeter_City_match.JPG',
+    'wikipedia-pageimage-free:Glossop_-_geograph.org.uk_-_7292918.jpg',
+    'wikipedia-pageimage-free:Hendon_Town_Hall_in_December_2011.JPG',
+    'wikipedia-pageimage-free:Hereford_United_League_Performance.svg',
+    'wikipedia-pageimage-free:High_Street_Dunstable_-_geograph.org.uk_-_6524692.jpg',
+    'wikipedia-pageimage-free:Hounslow_High_Street.1.JPG',
+    'wikipedia-pageimage-free:H\u00F4tel_ville_South_Shields_South_Tyneside_28.jpg',
+    'wikipedia-pageimage-free:Lewes-udsigt.jpg',
+    'wikipedia-pageimage-free:LeytonCentre.JPG',
+    'wikipedia-pageimage-free:London_Thames_Sunset_panorama_-_Feb_2008.jpg',
+    'wikipedia-pageimage-free:Maidenhead_v_Barnet_022.jpg',
+    'wikipedia-pageimage-free:Middlesborough_Town_Hall_image_by_Robert_Eva.jpg',
+    'wikipedia-pageimage-free:New_Brighton_Tower.jpg',
+    'wikipedia-pageimage-free:New_North_Bank.jpg',
+    'wikipedia-pageimage-free:Old_Town_Hall_Eastleigh.JPG',
+    'wikipedia-pageimage-free:Peterborough_Sports_vs_Guiseley_FC_-_FA_Cup_3rd_qualifying_round_2019.jpg',
+    'wikipedia-pageimage-free:Ryan_Valentine_scores.jpg',
+    'wikipedia-pageimage-free:Silver_Jubilee_Bridge,_Runcorn,_night,_2024.jpg',
+    'wikipedia-pageimage-free:St_Paul,_Addlestone_-_geograph.org.uk_-_1517212.jpg',
+    'wikipedia-pageimage-free:The_Main_Stand_at_Court_Place_Farm_-_geograph.org.uk_-_1245335.jpg',
+    'wikipedia-pageimage-free:Town_Hall_-_Market_Place_(geograph_2938168).jpg',
+  ])
+);
+const CURATED_ASSET_DECISIONS = Object.freeze({
+  'wikipedia-pageimage-free:Leeds_old_arms.png': {
+    clubIds: ['leeds-city'],
+    status: 'usable',
+    identityMatch: 'curated',
+    notes: 'Curated as an acceptable Leeds City historical crest/arms candidate.',
+  },
+});
 const GENERATED_PLACEHOLDER_LICENSE = Object.freeze({
   shortName: 'CC0-1.0',
   usageTerms: 'Creative Commons Zero v1.0 Universal',
@@ -81,13 +136,6 @@ const HISTORICAL_PLACEHOLDER_CRESTS = Object.freeze({
     colors: [
       { role: 'primary', hex: '#0000FF' },
       { role: 'secondary', hex: '#FFFFFF' },
-    ],
-  },
-  'redbridge-forest': {
-    colors: [
-      { role: 'primary', hex: '#FF0000' },
-      { role: 'secondary', hex: '#0000FF' },
-      { role: 'accent', hex: '#FFFFFF' },
     ],
   },
   'rotherham-town': {
@@ -330,10 +378,43 @@ function isLikelyCrestCandidate(candidate, identityMatch) {
   );
 }
 
+function curatedAssetDecision(candidate, club) {
+  const decision = CURATED_ASSET_DECISIONS[candidate.assetId];
+  if (!decision) return null;
+  const clubId = slugify(club?.clubId || club?.canonicalName || '');
+  if (decision.clubIds && !decision.clubIds.includes(clubId)) return null;
+  return decision;
+}
+
+export function isRejectedClubAssetCandidate(candidate) {
+  return REJECTED_ASSET_IDS.has(candidate?.assetId);
+}
+
 export function classifyClubAssetCandidate(candidate, club, { checkedAt = null } = {}) {
   const licenseCheck = classifyAssetLicense(candidate.license || {});
+  const isGeneratedPlaceholder =
+    candidate.placeholder || candidate.source === CLUB_ASSET_SOURCE_IDS.generatedPlaceholder;
+  if (isGeneratedPlaceholder) {
+    const reviewReasons = candidate.imageUrl ? [] : ['image-url-missing'];
+    const status = candidate.imageUrl ? 'placeholder' : 'failed';
+    return {
+      ...candidate,
+      status,
+      verification: compactObject({
+        ...(candidate.verification || {}),
+        identityMatch: 'generated-placeholder',
+        licenseCheck,
+        httpCheck: candidate.imageUrl ? 'pass' : 'fail',
+        needsManualReview: status !== 'placeholder',
+        reviewReasons,
+        checkedAt,
+      }),
+    };
+  }
+
   const identityMatch = classifyAssetIdentity(candidate, club);
   const likelyCrestCandidate = isLikelyCrestCandidate(candidate, identityMatch);
+  const curatedDecision = curatedAssetDecision(candidate, club);
   const reviewReasons = [];
 
   if (licenseCheck === 'restricted') reviewReasons.push('license-restricted');
@@ -354,13 +435,18 @@ export function classifyClubAssetCandidate(candidate, club, { checkedAt = null }
   ) {
     status = 'usable';
   }
+  if (curatedDecision?.status === 'usable' && licenseCheck === 'pass' && candidate.imageUrl) {
+    status = 'usable';
+    reviewReasons.length = 0;
+  }
 
   return {
     ...candidate,
     status,
+    notes: candidate.notes || curatedDecision?.notes,
     verification: compactObject({
       ...(candidate.verification || {}),
-      identityMatch,
+      identityMatch: curatedDecision?.identityMatch || identityMatch,
       licenseCheck,
       httpCheck: candidate.imageUrl ? 'pass' : 'fail',
       needsManualReview: status !== 'usable',
@@ -422,7 +508,7 @@ export function buildClubAssetBundle(candidates, { limit = 5 } = {}) {
   const preferredCandidate =
     rankedCandidates.find((candidate) => candidate.status === 'usable') ||
     rankedCandidates.find((candidate) => candidate.status === 'placeholder');
-  const status = preferredCandidate?.status || rankedCandidates[0]?.status || 'missing';
+  const status = preferredCandidate?.status || rankedCandidates[0]?.status || 'needs-more-research';
 
   return compactObject({
     preferred: preferredCandidate?.assetId || null,
@@ -488,9 +574,9 @@ export function buildClubAssetReviewIssues(clubKey, club, bundle) {
 
   if (!candidates.length) {
     issues.push({
-      type: 'club-asset-missing',
+      type: 'club-asset-needs-more-research',
       ...baseIssue,
-      message: `${baseIssue.canonicalName} has no crest asset candidates`,
+      message: `${baseIssue.canonicalName} needs more crest asset research`,
     });
     return issues;
   }
@@ -815,7 +901,10 @@ export async function discoverClubCrestBundle(club, options = {}) {
   } catch (error) {
     if (options.throwOnSourceError) throw error;
   }
-  const classifiedCandidates = enrichedCandidates.map((candidate) =>
+  const filteredCandidates = enrichedCandidates.filter(
+    (candidate) => !isRejectedClubAssetCandidate(candidate)
+  );
+  const classifiedCandidates = filteredCandidates.map((candidate) =>
     classifyClubAssetCandidate(candidate, club, { checkedAt })
   );
   return buildClubAssetBundle(classifiedCandidates, { limit: options.limit || 5 });

--- a/wikipedia/data/generate-club-assets.js
+++ b/wikipedia/data/generate-club-assets.js
@@ -6,6 +6,7 @@ import * as fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  addGeneratedPlaceholderFallback,
   buildClubAssetBundle,
   buildClubAssetReviewIssues,
   classifyClubAssetCandidate,
@@ -135,10 +136,11 @@ export async function generateClubAssets({
 
   for (const [index, [clubKey, club]] of selectedEntries.entries()) {
     const cachedCrest = cachedAssets[clubKey]?.crest;
-    const crest =
+    const discoveredCrest =
       cachedCrest && !refreshAssets
         ? reclassifyCachedCrestBundle(club, cachedCrest, limit)
         : await discoverClubCrestBundle(club, { limit });
+    const crest = addGeneratedPlaceholderFallback(club, discoveredCrest, { limit });
     enrichedClubs[clubKey] = {
       ...club,
       assets: {

--- a/wikipedia/data/generate-club-assets.js
+++ b/wikipedia/data/generate-club-assets.js
@@ -18,6 +18,12 @@ const DEFAULT_REVIEW_OUTPUT_FILE = './data/club-assets-review.json';
 const GENERATOR_ID = 'club-assets';
 const REVIEW_GENERATOR_ID = 'club-assets-review';
 
+function sleep(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
 function readJson(filePath) {
   return JSON.parse(fs.readFileSync(filePath, 'utf8'));
 }
@@ -30,6 +36,28 @@ function writeJson(filePath, value, spacing) {
 function unwrapClubMetadata(value) {
   if (value?.clubs && typeof value.clubs === 'object') return value.clubs;
   return value;
+}
+
+function readAssetCache(cachePath) {
+  if (!cachePath || !fs.existsSync(cachePath)) return {};
+  const cache = readJson(cachePath);
+  return cache?.clubs && typeof cache.clubs === 'object' ? cache.clubs : {};
+}
+
+function writeAssetCache(cachePath, clubs, spacing) {
+  if (!cachePath) return;
+  writeJson(
+    cachePath,
+    {
+      metadata: buildDatasetMetadata({
+        generator: `${GENERATOR_ID}-cache`,
+        sourceFiles: [],
+        buildOptions: {},
+      }),
+      clubs,
+    },
+    spacing
+  );
 }
 
 function buildReviewReport(clubs, { sourceFiles, input, output }) {
@@ -66,19 +94,26 @@ export async function generateClubAssets({
   compact = false,
   limit = 5,
   clubLimit = null,
+  cache = null,
+  refreshAssets = false,
+  requestDelayMs = 100,
   cwd = ROOT_DIR,
 } = {}) {
   const inputPath = path.resolve(cwd, input);
   const outputPath = path.resolve(cwd, output);
   const reviewOutputPath = reviewOutput ? path.resolve(cwd, reviewOutput) : null;
+  const cachePath = cache ? path.resolve(cwd, cache) : null;
   const inputData = readJson(inputPath);
   const sourceClubs = normaliseClubsMap(unwrapClubMetadata(inputData)) || {};
   const entries = Object.entries(sourceClubs);
   const selectedEntries = Number.isInteger(clubLimit) ? entries.slice(0, clubLimit) : entries;
   const enrichedClubs = { ...sourceClubs };
+  const cachedAssets = readAssetCache(cachePath);
 
-  for (const [clubKey, club] of selectedEntries) {
-    const crest = await discoverClubCrestBundle(club, { limit });
+  for (const [index, [clubKey, club]] of selectedEntries.entries()) {
+    const cachedCrest = cachedAssets[clubKey]?.crest;
+    const crest =
+      cachedCrest && !refreshAssets ? cachedCrest : await discoverClubCrestBundle(club, { limit });
     enrichedClubs[clubKey] = {
       ...club,
       assets: {
@@ -86,6 +121,14 @@ export async function generateClubAssets({
         crest,
       },
     };
+    cachedAssets[clubKey] = {
+      ...(cachedAssets[clubKey] || {}),
+      crest,
+    };
+    writeAssetCache(cachePath, cachedAssets, compact ? 0 : 2);
+    if (requestDelayMs > 0 && index < selectedEntries.length - 1) {
+      await sleep(requestDelayMs);
+    }
   }
 
   const spacing = compact ? 0 : 2;
@@ -93,7 +136,7 @@ export async function generateClubAssets({
     metadata: buildDatasetMetadata({
       generator: GENERATOR_ID,
       sourceFiles: [inputPath],
-      buildOptions: { input, limit, clubLimit },
+      buildOptions: { input, limit, clubLimit, cache, refreshAssets, requestDelayMs },
     }),
     clubs: enrichedClubs,
   };
@@ -138,6 +181,14 @@ export async function runCli(argv = process.argv) {
       (value) => Number.parseInt(value, 10),
       null
     )
+    .option('--cache <file>', 'Path to a resumable asset discovery cache')
+    .option('--refresh-assets', 'Ignore cached asset bundles and refresh source lookups', false)
+    .option(
+      '--request-delay-ms <count>',
+      'Delay between club lookups to avoid source rate limits',
+      (value) => Number.parseInt(value, 10),
+      100
+    )
     .option('--compact', 'Write compact JSON', false);
 
   program.parse(argv);
@@ -148,6 +199,9 @@ export async function runCli(argv = process.argv) {
     reviewOutput: options.reviewOutput,
     limit: options.limit,
     clubLimit: Number.isInteger(options.clubLimit) ? options.clubLimit : null,
+    cache: options.cache || null,
+    refreshAssets: options.refreshAssets,
+    requestDelayMs: Number.isInteger(options.requestDelayMs) ? options.requestDelayMs : 100,
     compact: options.compact,
   });
 

--- a/wikipedia/data/generate-club-assets.js
+++ b/wikipedia/data/generate-club-assets.js
@@ -6,7 +6,9 @@ import * as fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
+  buildClubAssetBundle,
   buildClubAssetReviewIssues,
+  classifyClubAssetCandidate,
   discoverClubCrestBundle,
 } from './assets/club-assets.js';
 import { buildDatasetMetadata, normaliseClubsMap } from './generate-output-files.ts';
@@ -58,6 +60,16 @@ function writeAssetCache(cachePath, clubs, spacing) {
     },
     spacing
   );
+}
+
+function reclassifyCachedCrestBundle(club, cachedCrest, limit) {
+  if (!cachedCrest?.candidates?.length) return cachedCrest;
+  const candidates = cachedCrest.candidates.map((candidate) =>
+    classifyClubAssetCandidate(candidate, club, {
+      checkedAt: candidate.verification?.checkedAt || null,
+    })
+  );
+  return buildClubAssetBundle(candidates, { limit });
 }
 
 function buildReviewReport(clubs, { sourceFiles, input, output }) {
@@ -113,7 +125,9 @@ export async function generateClubAssets({
   for (const [index, [clubKey, club]] of selectedEntries.entries()) {
     const cachedCrest = cachedAssets[clubKey]?.crest;
     const crest =
-      cachedCrest && !refreshAssets ? cachedCrest : await discoverClubCrestBundle(club, { limit });
+      cachedCrest && !refreshAssets
+        ? reclassifyCachedCrestBundle(club, cachedCrest, limit)
+        : await discoverClubCrestBundle(club, { limit });
     enrichedClubs[clubKey] = {
       ...club,
       assets: {

--- a/wikipedia/data/generate-club-assets.js
+++ b/wikipedia/data/generate-club-assets.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// @ts-check
+
+import { Command } from 'commander';
+import * as fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  buildClubAssetReviewIssues,
+  discoverClubCrestBundle,
+} from './assets/club-assets.js';
+import { buildDatasetMetadata, normaliseClubsMap } from './generate-output-files.ts';
+
+const ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const DEFAULT_INPUT_FILE = './data/club-metadata.json';
+const DEFAULT_OUTPUT_FILE = './data/club-metadata.json';
+const DEFAULT_REVIEW_OUTPUT_FILE = './data/club-assets-review.json';
+const GENERATOR_ID = 'club-assets';
+const REVIEW_GENERATOR_ID = 'club-assets-review';
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function writeJson(filePath, value, spacing) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, `${JSON.stringify(value, null, spacing)}\n`);
+}
+
+function unwrapClubMetadata(value) {
+  if (value?.clubs && typeof value.clubs === 'object') return value.clubs;
+  return value;
+}
+
+function buildReviewReport(clubs, { sourceFiles, input, output }) {
+  const issues = [];
+  for (const [clubKey, club] of Object.entries(clubs || {})) {
+    issues.push(...buildClubAssetReviewIssues(clubKey, club, club?.assets?.crest));
+  }
+  issues.sort((left, right) => {
+    if (left.type !== right.type) return left.type.localeCompare(right.type);
+    if (left.clubKey !== right.clubKey) return left.clubKey.localeCompare(right.clubKey);
+    return String(left.assetId || '').localeCompare(String(right.assetId || ''));
+  });
+
+  return {
+    metadata: buildDatasetMetadata({
+      generator: REVIEW_GENERATOR_ID,
+      sourceFiles,
+      buildOptions: { input, output },
+    }),
+    clubCount: Object.keys(clubs || {}).length,
+    issueCount: issues.length,
+    issueCounts: issues.reduce((counts, issue) => {
+      counts[issue.type] = (counts[issue.type] || 0) + 1;
+      return counts;
+    }, {}),
+    issues,
+  };
+}
+
+export async function generateClubAssets({
+  input = DEFAULT_INPUT_FILE,
+  output = DEFAULT_OUTPUT_FILE,
+  reviewOutput = DEFAULT_REVIEW_OUTPUT_FILE,
+  compact = false,
+  limit = 5,
+  clubLimit = null,
+  cwd = ROOT_DIR,
+} = {}) {
+  const inputPath = path.resolve(cwd, input);
+  const outputPath = path.resolve(cwd, output);
+  const reviewOutputPath = reviewOutput ? path.resolve(cwd, reviewOutput) : null;
+  const inputData = readJson(inputPath);
+  const sourceClubs = normaliseClubsMap(unwrapClubMetadata(inputData)) || {};
+  const entries = Object.entries(sourceClubs);
+  const selectedEntries = Number.isInteger(clubLimit) ? entries.slice(0, clubLimit) : entries;
+  const enrichedClubs = { ...sourceClubs };
+
+  for (const [clubKey, club] of selectedEntries) {
+    const crest = await discoverClubCrestBundle(club, { limit });
+    enrichedClubs[clubKey] = {
+      ...club,
+      assets: {
+        ...(club.assets || {}),
+        crest,
+      },
+    };
+  }
+
+  const spacing = compact ? 0 : 2;
+  const outputData = {
+    metadata: buildDatasetMetadata({
+      generator: GENERATOR_ID,
+      sourceFiles: [inputPath],
+      buildOptions: { input, limit, clubLimit },
+    }),
+    clubs: enrichedClubs,
+  };
+  writeJson(outputPath, outputData, spacing);
+
+  const reviewClubs = Number.isInteger(clubLimit)
+    ? Object.fromEntries(selectedEntries.map(([clubKey]) => [clubKey, enrichedClubs[clubKey]]))
+    : enrichedClubs;
+  const reviewReport = reviewOutputPath
+    ? buildReviewReport(reviewClubs, {
+        sourceFiles: [inputPath],
+        input,
+        output,
+      })
+    : null;
+  if (reviewOutputPath && reviewReport) {
+    writeJson(reviewOutputPath, reviewReport, spacing);
+  }
+
+  return {
+    inputPath,
+    outputPath,
+    reviewOutputPath,
+    clubCount: Object.keys(enrichedClubs).length,
+    processedClubCount: selectedEntries.length,
+    reviewReport,
+  };
+}
+
+export async function runCli(argv = process.argv) {
+  const program = new Command();
+  program
+    .name('generate-club-assets')
+    .description('Discover and verify club crest assets for club metadata records.')
+    .argument('[input]', 'Path to club-metadata.json', DEFAULT_INPUT_FILE)
+    .option('-o, --output <file>', 'Path to write enriched club metadata', DEFAULT_OUTPUT_FILE)
+    .option('--review-output <file>', 'Path to write asset review report', DEFAULT_REVIEW_OUTPUT_FILE)
+    .option('--limit <count>', 'Maximum candidates per asset kind', (value) => Number.parseInt(value, 10), 5)
+    .option(
+      '--club-limit <count>',
+      'Process only the first N clubs; useful for smoke tests',
+      (value) => Number.parseInt(value, 10),
+      null
+    )
+    .option('--compact', 'Write compact JSON', false);
+
+  program.parse(argv);
+  const options = program.opts();
+  const result = await generateClubAssets({
+    input: program.args[0] || DEFAULT_INPUT_FILE,
+    output: options.output,
+    reviewOutput: options.reviewOutput,
+    limit: options.limit,
+    clubLimit: Number.isInteger(options.clubLimit) ? options.clubLimit : null,
+    compact: options.compact,
+  });
+
+  console.log(
+    `Generated crest assets for ${result.processedClubCount}/${result.clubCount} clubs -> ${result.outputPath}`
+  );
+  if (result.reviewOutputPath && result.reviewReport) {
+    console.log(
+      `Generated ${result.reviewReport.issueCount} club asset review issues -> ${result.reviewOutputPath}`
+    );
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  runCli().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/wikipedia/data/generate-club-assets.js
+++ b/wikipedia/data/generate-club-assets.js
@@ -110,6 +110,7 @@ export async function generateClubAssets({
   compact = false,
   limit = 5,
   clubLimit = null,
+  clubKeys = [],
   cache = null,
   refreshAssets = false,
   requestDelayMs = 100,
@@ -122,7 +123,13 @@ export async function generateClubAssets({
   const inputData = readJson(inputPath);
   const sourceClubs = normaliseClubsMap(unwrapClubMetadata(inputData)) || {};
   const entries = Object.entries(sourceClubs);
-  const selectedEntries = Number.isInteger(clubLimit) ? entries.slice(0, clubLimit) : entries;
+  const clubKeyFilter = new Set((clubKeys || []).filter(Boolean));
+  const candidateEntries = clubKeyFilter.size
+    ? entries.filter(([clubKey]) => clubKeyFilter.has(clubKey))
+    : entries;
+  const selectedEntries = Number.isInteger(clubLimit)
+    ? candidateEntries.slice(0, clubLimit)
+    : candidateEntries;
   const enrichedClubs = { ...sourceClubs };
   const cachedAssets = readAssetCache(cachePath);
 
@@ -158,6 +165,7 @@ export async function generateClubAssets({
         input,
         limit,
         clubLimit,
+        clubKeys: clubKeys?.length || null,
         cache: Boolean(cache),
         refreshAssets,
         requestDelayMs,
@@ -168,7 +176,7 @@ export async function generateClubAssets({
   };
   writeJson(outputPath, outputData, spacing);
 
-  const reviewClubs = Number.isInteger(clubLimit)
+  const reviewClubs = Number.isInteger(clubLimit) || clubKeyFilter.size
     ? Object.fromEntries(selectedEntries.map(([clubKey]) => [clubKey, enrichedClubs[clubKey]]))
     : enrichedClubs;
   const reviewReport = reviewOutputPath
@@ -207,6 +215,12 @@ export async function runCli(argv = process.argv) {
       (value) => Number.parseInt(value, 10),
       null
     )
+    .option(
+      '--club-key <key>',
+      'Process only the selected club key. Repeatable.',
+      (value, previous) => [...previous, value],
+      []
+    )
     .option('--cache <file>', 'Path to a resumable asset discovery cache')
     .option('--refresh-assets', 'Ignore cached asset bundles and refresh source lookups', false)
     .option(
@@ -225,6 +239,7 @@ export async function runCli(argv = process.argv) {
     reviewOutput: options.reviewOutput,
     limit: options.limit,
     clubLimit: Number.isInteger(options.clubLimit) ? options.clubLimit : null,
+    clubKeys: options.clubKey,
     cache: options.cache || null,
     refreshAssets: options.refreshAssets,
     requestDelayMs: Number.isInteger(options.requestDelayMs) ? options.requestDelayMs : 100,

--- a/wikipedia/data/generate-club-assets.js
+++ b/wikipedia/data/generate-club-assets.js
@@ -40,6 +40,10 @@ function unwrapClubMetadata(value) {
   return value;
 }
 
+function buildSourceFiles(inputData, inputPath) {
+  return Array.from(new Set([...(inputData?.metadata?.sourceFiles || []), inputPath]));
+}
+
 function readAssetCache(cachePath) {
   if (!cachePath || !fs.existsSync(cachePath)) return {};
   const cache = readJson(cachePath);
@@ -149,8 +153,16 @@ export async function generateClubAssets({
   const outputData = {
     metadata: buildDatasetMetadata({
       generator: GENERATOR_ID,
-      sourceFiles: [inputPath],
-      buildOptions: { input, limit, clubLimit, cache, refreshAssets, requestDelayMs },
+      sourceFiles: buildSourceFiles(inputData, inputPath),
+      buildOptions: {
+        input,
+        limit,
+        clubLimit,
+        cache: Boolean(cache),
+        refreshAssets,
+        requestDelayMs,
+        inputGenerator: inputData?.metadata?.generator || null,
+      },
     }),
     clubs: enrichedClubs,
   };

--- a/wikipedia/data/generate-club-assets.js
+++ b/wikipedia/data/generate-club-assets.js
@@ -8,9 +8,11 @@ import { fileURLToPath } from 'node:url';
 import {
   addGeneratedPlaceholderFallback,
   buildClubAssetBundle,
+  buildGeneratedPlaceholderCrestCandidate,
   buildClubAssetReviewIssues,
   classifyClubAssetCandidate,
   discoverClubCrestBundle,
+  isRejectedClubAssetCandidate,
 } from './assets/club-assets.js';
 import { buildDatasetMetadata, normaliseClubsMap } from './generate-output-files.ts';
 
@@ -68,12 +70,19 @@ function writeAssetCache(cachePath, clubs, spacing) {
 }
 
 function reclassifyCachedCrestBundle(club, cachedCrest, limit) {
-  if (!cachedCrest?.candidates?.length) return cachedCrest;
-  const candidates = cachedCrest.candidates.map((candidate) =>
-    classifyClubAssetCandidate(candidate, club, {
-      checkedAt: candidate.verification?.checkedAt || null,
+  if (!cachedCrest?.candidates?.length) return buildClubAssetBundle([], { limit });
+  const generatedPlaceholder = buildGeneratedPlaceholderCrestCandidate(club);
+  const candidates = cachedCrest.candidates
+    .filter((candidate) => {
+      if (isRejectedClubAssetCandidate(candidate)) return false;
+      if (!candidate.placeholder && candidate.source !== 'generated-placeholder') return true;
+      return candidate.assetId === generatedPlaceholder?.assetId;
     })
-  );
+    .map((candidate) =>
+      classifyClubAssetCandidate(candidate, club, {
+        checkedAt: candidate.verification?.checkedAt || null,
+      })
+    );
   return buildClubAssetBundle(candidates, { limit });
 }
 

--- a/wikipedia/data/generate-output-files.ts
+++ b/wikipedia/data/generate-output-files.ts
@@ -635,12 +635,13 @@ function normaliseAssetBundle(value: any, kind: string): AnyRecord | undefined {
   const candidates = normaliseAssetCandidates(value.candidates, kind);
   const bundle = {
     preferred: toStringValue(value.preferred),
-    status: toStringValue(value.status) || (candidates.length ? 'needs-review' : 'missing'),
+    status:
+      toStringValue(value.status) || (candidates.length ? 'needs-review' : 'needs-more-research'),
     candidates,
   };
   const cleaned = Object.fromEntries(
     Object.entries(bundle).filter(([key, entry]) => {
-      if (key === 'preferred') return entry != null || bundle.status === 'missing';
+      if (key === 'preferred') return entry != null || bundle.status === 'needs-more-research';
       if (Array.isArray(entry)) return entry.length > 0;
       return entry != null;
     })

--- a/wikipedia/data/generate-output-files.ts
+++ b/wikipedia/data/generate-output-files.ts
@@ -532,6 +532,136 @@ function normaliseClubDerivedMetadata(value: any): AnyRecord | undefined {
   return Object.keys(cleaned).length ? cleaned : undefined;
 }
 
+function toIntegerOrNull(value: unknown): number | null {
+  if (value == null || value === '') return null;
+  const parsed = Number.parseInt(String(value), 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function toBooleanOrNull(value: unknown): boolean | null {
+  if (typeof value === 'boolean') return value;
+  return null;
+}
+
+function normaliseAssetLicense(value: any): AnyRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const license = {
+    shortName: toStringValue(value.shortName),
+    usageTerms: toStringValue(value.usageTerms),
+    licenseUrl: toStringValue(value.licenseUrl),
+    copyrighted: toBooleanOrNull(value.copyrighted),
+    attribution: toStringValue(value.attribution),
+    credit: toStringValue(value.credit),
+    artist: toStringValue(value.artist),
+  };
+  const cleaned = Object.fromEntries(Object.entries(license).filter(([, entry]) => entry != null));
+  return Object.keys(cleaned).length ? cleaned : undefined;
+}
+
+function normaliseAssetVerification(value: any): AnyRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const verification = {
+    identityMatch: toStringValue(value.identityMatch),
+    licenseCheck: toStringValue(value.licenseCheck),
+    httpCheck: toStringValue(value.httpCheck),
+    needsManualReview: toBooleanOrNull(value.needsManualReview),
+    reviewReasons: normalizeStringArray(value.reviewReasons).sort(),
+    checkedAt: toStringValue(value.checkedAt),
+  };
+  const cleaned = Object.fromEntries(
+    Object.entries(verification).filter(([, entry]) => {
+      if (entry == null) return false;
+      if (Array.isArray(entry)) return entry.length > 0;
+      return true;
+    })
+  );
+  return Object.keys(cleaned).length ? cleaned : undefined;
+}
+
+function normaliseAssetCandidates(value: any, kind: string): AnyRecord[] {
+  if (!Array.isArray(value)) return [];
+  const candidates: AnyRecord[] = [];
+  const seen = new Set();
+
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+    const assetId = toStringValue(item.assetId);
+    const source = toStringValue(item.source);
+    const status = toStringValue(item.status);
+    if (!assetId || !source || !status) continue;
+
+    const normalizedItem = {
+      assetId,
+      kind: toStringValue(item.kind) || kind,
+      status,
+      priority: toIntegerOrNull(item.priority),
+      source,
+      sourceUrl: toStringValue(item.sourceUrl),
+      imageUrl: toStringValue(item.imageUrl),
+      pageUrl: toStringValue(item.pageUrl),
+      fileTitle: toStringValue(item.fileTitle),
+      mimeType: toStringValue(item.mimeType),
+      width: toIntegerOrNull(item.width),
+      height: toIntegerOrNull(item.height),
+      license: normaliseAssetLicense(item.license),
+      verification: normaliseAssetVerification(item.verification),
+      notes: toStringValue(item.notes),
+    };
+    const cleaned = Object.fromEntries(
+      Object.entries(normalizedItem).filter(([, entry]) => {
+        if (entry == null) return false;
+        if (typeof entry === 'object' && !Array.isArray(entry)) return Object.keys(entry).length > 0;
+        return true;
+      })
+    );
+    const dedupeKey = JSON.stringify(cleaned);
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    candidates.push(cleaned);
+  }
+
+  return candidates
+    .sort((a, b) => {
+      const leftPriority = a.priority ?? Number.MAX_SAFE_INTEGER;
+      const rightPriority = b.priority ?? Number.MAX_SAFE_INTEGER;
+      if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+      return String(a.assetId).localeCompare(String(b.assetId));
+    })
+    .slice(0, 5);
+}
+
+function normaliseAssetBundle(value: any, kind: string): AnyRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const candidates = normaliseAssetCandidates(value.candidates, kind);
+  const bundle = {
+    preferred: toStringValue(value.preferred),
+    status: toStringValue(value.status) || (candidates.length ? 'needs-review' : 'missing'),
+    candidates,
+  };
+  const cleaned = Object.fromEntries(
+    Object.entries(bundle).filter(([key, entry]) => {
+      if (key === 'preferred') return entry != null || bundle.status === 'missing';
+      if (Array.isArray(entry)) return entry.length > 0;
+      return entry != null;
+    })
+  );
+  return Object.keys(cleaned).length ? cleaned : undefined;
+}
+
+function normaliseMetadataAssets(value: any): AnyRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const assets: AnyRecord = {};
+
+  for (const [kind, bundle] of Object.entries(value)) {
+    const assetKind = toStringValue(kind);
+    if (!assetKind) continue;
+    const normalizedBundle = normaliseAssetBundle(bundle, assetKind);
+    if (normalizedBundle) assets[assetKind] = normalizedBundle;
+  }
+
+  return Object.keys(assets).length ? assets : undefined;
+}
+
 /**
  * @param {unknown} value
  * @param {string} fallbackKey
@@ -565,6 +695,7 @@ function normaliseClubRecord(value: any, fallbackKey: string): ClubMetadata | nu
     status: normaliseClubStatus(value.status),
     history,
     derived: normaliseClubDerivedMetadata(value.derived),
+    assets: normaliseMetadataAssets(value.assets),
     founded: toStringValue(value.founded),
     dissolved: toStringValue(value.dissolved),
     nameHistory: normaliseClubNameHistory(value.nameHistory),
@@ -645,6 +776,7 @@ export function mergeClubsMap(
     merged[clubKey] = /** @type {ClubMetadata} */ ({
       canonicalName: incomingClub.canonicalName || existingClub.canonicalName || clubKey,
       derived: incomingClub.derived ?? existingClub.derived,
+      assets: incomingClub.assets ?? existingClub.assets,
       founded: incomingClub.founded ?? existingClub.founded ?? null,
       dissolved: incomingClub.dissolved ?? existingClub.dissolved ?? null,
       notes: incomingClub.notes ?? existingClub.notes ?? null,

--- a/wikipedia/models/output-file.ts
+++ b/wikipedia/models/output-file.ts
@@ -250,7 +250,14 @@ export interface ClubDerivedMetadata {
   coverageGaps?: ClubCoverageGap[];
 }
 
-export type AssetStatus = 'usable' | 'restricted' | 'needs-review' | 'missing' | 'failed' | string;
+export type AssetStatus =
+  | 'usable'
+  | 'placeholder'
+  | 'restricted'
+  | 'needs-review'
+  | 'needs-more-research'
+  | 'failed'
+  | string;
 
 export interface MetadataAssetLicense {
   shortName?: string | null;

--- a/wikipedia/models/output-file.ts
+++ b/wikipedia/models/output-file.ts
@@ -250,12 +250,63 @@ export interface ClubDerivedMetadata {
   coverageGaps?: ClubCoverageGap[];
 }
 
+export type AssetStatus = 'usable' | 'restricted' | 'needs-review' | 'missing' | 'failed' | string;
+
+export interface MetadataAssetLicense {
+  shortName?: string | null;
+  usageTerms?: string | null;
+  licenseUrl?: string | null;
+  copyrighted?: boolean | null;
+  attribution?: string | null;
+  credit?: string | null;
+  artist?: string | null;
+}
+
+export interface MetadataAssetVerification {
+  identityMatch?: 'strong' | 'possible' | 'weak' | 'none' | string | null;
+  licenseCheck?: 'pass' | 'restricted' | 'unknown' | 'fail' | string | null;
+  httpCheck?: 'pass' | 'unknown' | 'fail' | string | null;
+  needsManualReview?: boolean;
+  reviewReasons?: string[];
+  checkedAt?: string | null;
+}
+
+export interface MetadataAssetCandidate {
+  assetId: string;
+  kind: string;
+  status: AssetStatus;
+  priority?: number | null;
+  source: string;
+  sourceUrl?: string | null;
+  imageUrl?: string | null;
+  pageUrl?: string | null;
+  fileTitle?: string | null;
+  mimeType?: string | null;
+  width?: number | null;
+  height?: number | null;
+  license?: MetadataAssetLicense;
+  verification?: MetadataAssetVerification;
+  notes?: string | null;
+}
+
+export interface MetadataAssetBundle {
+  preferred?: string | null;
+  status: AssetStatus;
+  candidates?: MetadataAssetCandidate[];
+}
+
+export interface MetadataAssets {
+  crest?: MetadataAssetBundle;
+  [kind: string]: MetadataAssetBundle | undefined;
+}
+
 export interface ClubMetadata {
   clubId?: string;
   canonicalName: string;
   status?: ClubStatus;
   history?: ClubHistory;
   derived?: ClubDerivedMetadata;
+  assets?: MetadataAssets;
   founded?: string | null;
   dissolved?: string | null;
   nameHistory?: ClubNamePeriod[];


### PR DESCRIPTION
## Summary
- Adds club crest asset metadata support with discovered, curated, restricted, placeholder, and needs-more-research states.
- Adds a temporary static review page for auditing club crest candidates and exporting flagged images.
- Removes flagged non-club/non-crest images from ingestion and normalizes unresolved clubs to `needs-more-research`.

## What Changed
- Added club crest discovery, classification, cache reclassification, generated placeholder support, and review issue reporting.
- Added rejected asset filtering so flagged images are not re-ingested.
- Added generated historical placeholder crests for selected clubs with known colors.
- Added docs review UI at `docs/club-assets-review.html`.
- Updated club metadata schema/docs and regenerated `data/club-metadata.json` plus `data/club-assets-review.json`.
- Added focused Jest coverage for asset classification, generation, rejected candidates, placeholders, and schema verification.

## Validation
- `fnm exec --using=22.22.1 -- pnpm test -- --runTestsByPath wikipedia/__tests__/club-assets.test.js wikipedia/__tests__/generate-club-assets.test.js wikipedia/__tests__/verify-json-schemas.test.js`
- `fnm exec --using=22.22.1 -- pnpm -s schema:verify`
- `fnm exec --using=22.22.1 -- pnpm -s docs:check`
- `fnm exec --using=22.22.1 -- node --check docs/club-assets-review.js`
- `fnm exec --using=22.22.1 -- pnpm -s lint`
- `curl -I http://127.0.0.1:4174/docs/club-assets-review.html`

## Scope Notes
- This PR only handles club crest/image assets; league assets are schema-compatible future work.
- `needs-more-research` now covers unresolved/missing crest cases that should receive a generated color placeholder once colors are sourced.
- Restricted assets remain linked with licensing warnings for downstream consumers to filter as needed.