### PR TITLE
Prepare v1.1.0 pre-release

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -107,7 +107,7 @@
 
         <div class="release-pin">
           <span class="release-label">latest</span>
-          <strong>v1.0.0</strong>
+          <strong>v1.1.0</strong>
           <span>1888-2025. 138 seasons. 375 club metadata records.</span>
           <span class="release-actions">
             <a
@@ -117,13 +117,29 @@
             >
             <a
               class="compact-link"
-              href="https://github.com/dills122/footy-data-kit/releases/latest/download/footy-data-kit-v1.0.0-data.zip"
+              href="https://github.com/dills122/footy-data-kit/releases/latest/download/footy-data-kit-v1.1.0-data.zip"
               >data zip</a
             >
           </span>
         </div>
 
         <div class="release-rows" aria-label="historic releases">
+          <div class="release-row">
+            <span>v1.0.0</span>
+            <span>previous data release</span>
+            <span class="release-actions">
+              <a
+                class="compact-link"
+                href="https://github.com/dills122/footy-data-kit/releases/tag/v1.0.0"
+                >notes</a
+              >
+              <a
+                class="compact-link"
+                href="https://github.com/dills122/footy-data-kit/releases/download/v1.0.0/footy-data-kit-v1.0.0-data.zip"
+                >data zip</a
+              >
+            </span>
+          </div>
           <div class="release-row">
             <span>v0.9.1</span>
             <span>previous data release</span>

--- a/docs/next-release-data-review.md
+++ b/docs/next-release-data-review.md
@@ -1,0 +1,193 @@
+# Next Release Data Review
+
+This note summarizes the data-facing work completed after `v1.0.0` and before
+the next release. Use it as release-note source material and as a checklist for
+the final merge/release review.
+
+## Since `v1.0.0`
+
+The post-`v1.0.0` branch work has three main data themes:
+
+1. Expanded and validated tier 5/level 6 generated data.
+2. Tightened club metadata over the expanded generated season scope.
+3. Added club crest asset metadata, review tooling, and consumer guidance.
+
+## Dataset Coverage
+
+The season range remains unchanged: `1888-2025`, with 138 generated season
+records.
+
+Tier coverage changed materially:
+
+| Area            | `v1.0.0` | Current branch | Notes                                                      |
+| --------------- | -------: | -------------: | ---------------------------------------------------------- |
+| `tier1` seasons |      127 |            127 | unchanged                                                  |
+| `tier2` seasons |      125 |            125 | unchanged                                                  |
+| `tier3` seasons |       99 |             99 | unchanged                                                  |
+| `tier4` seasons |       68 |             68 | unchanged                                                  |
+| `tier5` seasons |       14 |             47 | expanded to the modern lower-tier slice                    |
+| `tier6` seasons |        5 |             47 | expanded with parallel divisions under `tier6.divisions[]` |
+
+The main release note should call out that the release does not change the top
+four tier contract, but it substantially broadens generated lower-tier coverage
+from 1979 through 2025.
+
+## Club Metadata
+
+Club metadata grew from 232 records at `v1.0.0` to 375 records on this branch.
+That growth is expected because the expanded tier 5/6 generated data surfaces
+more clubs in the maintained dataset.
+
+Current high-level club status counts:
+
+| `status.current` | Count |
+| ---------------- | ----: |
+| `active`         |   290 |
+| `defunct`        |    60 |
+| `merged`         |    18 |
+| `historical`     |     6 |
+| `relocated`      |     1 |
+
+`data/club-metadata-review.json` is clean on this branch:
+
+- `issueCount`: 0
+- `issueCounts`: `{}`
+
+Consumer-facing reminder for release notes:
+
+- `trackedFromSeason` and `trackedToSeason` are observed generated-data bounds,
+  not founded/dissolved dates.
+- `status.current` is the current high-level metadata status, not a season-row
+  outcome.
+- `history` contains source-backed facts; `derived` contains generated audit and
+  navigation fields.
+
+## Club Crest Assets
+
+This branch adds `assets.crest` bundles to `data/club-metadata.json`.
+
+The pipeline stores image URLs and provenance only. It does not download or
+commit image binaries.
+
+Current crest status counts:
+
+| `assets.crest.status` | Count | Meaning                                                                               |
+| --------------------- | ----: | ------------------------------------------------------------------------------------- |
+| `restricted`          |   339 | A candidate exists, but the best available club mark is license/trademark restricted. |
+| `usable`              |    18 | A source-discovered or curated candidate has a passing license check.                 |
+| `placeholder`         |    17 | Generated fallback crest from source-backed colors; not official artwork.             |
+| `needs-more-research` |     1 | No acceptable image or source-backed color fallback yet.                              |
+
+Current asset review issue counts:
+
+| Issue                            | Count | Release interpretation                                                                                                   |
+| -------------------------------- | ----: | ------------------------------------------------------------------------------------------------------------------------ |
+| `club-asset-license-restricted`  |   350 | Expected for club marks; consumers must opt in to using restricted artwork.                                              |
+| `club-asset-needs-more-research` |     1 | `Hounslow` remains the only true missing crest/color case.                                                               |
+| `club-asset-quality-review`      |     3 | `Bridgend Town`, `Bromsgrove Rovers`, and `Solihull Borough` have club-related candidates that need better replacements. |
+
+The noisy review buckets are currently clear:
+
+- `club-asset-identity-uncertain`: 0
+- `club-asset-non-crest-candidate`: 0
+- `club-asset-multiple-review-candidates`: 0
+
+Consumer-facing asset guidance for release notes:
+
+- Use `usable` for assets with passing license checks.
+- Include `placeholder` if generated fallback shields are acceptable.
+- Include `restricted` only if the consuming app/service can handle club mark
+  licensing and trademark restrictions.
+- Treat `needs-review`, `needs-more-research`, and `failed` as non-display
+  states unless the consumer has its own review workflow.
+
+## Tooling And Docs
+
+New or expanded support around this data:
+
+- `wikipedia/data/generate-club-assets.js` discovers and classifies crest
+  candidates.
+- `data/club-assets-review.json` summarizes manual review issues.
+- `docs/club-assets-review.html` provides a temporary local audit UI.
+- `docs/club-assets.md` documents statuses, sources, review rules, and consumer
+  filtering.
+- The docs site now links to the asset review UI and schema docs.
+- JSON Hero release-link helper docs and scripts were added for release data
+  inspection.
+
+## Validation Run During Branch Work
+
+Focused checks run during the branch work included:
+
+- asset Jest tests
+- club asset generation tests
+- JSON Schema verification tests
+- `pnpm -s schema:verify`
+- `pnpm format:check`
+- `pnpm -s docs:check`
+- `pnpm -s lint`
+
+## Release Readiness Pass
+
+The release-readiness pass on June 21, 2026 completed the local data/docs gate
+for this branch:
+
+- `pnpm test`
+- `pnpm test:integration`
+- `pnpm typecheck`
+- `pnpm -s verify:data`
+- `pnpm -s schema:verify`
+- `pnpm format:check`
+- `pnpm -s docs:check`
+- `pnpm -s lint`
+- `pnpm -s release:dry-run-data`
+
+The live integration and release dry-run commands require network access for
+Wikipedia source pages. The release dry-run rebuilt the full `1888-2025` range
+into a temporary directory, produced 138 season records and 375 club metadata
+records, and passed data verification, club continuity verification, and JSON
+Schema verification against the dry-run output.
+
+Package version changes, generated release-note pages, and final release-note
+validation are intentionally left for the dedicated pre-release branch.
+
+## Final Release Gate Still Recommended Before Tagging
+
+On the pre-release branch, repeat the full release-level gate from a clean tree
+after applying the package version and release-note changes:
+
+```bash
+pnpm test
+pnpm test:integration
+pnpm typecheck
+pnpm -s verify:data
+pnpm -s schema:verify
+pnpm format:check
+pnpm -s docs:check
+pnpm -s lint
+pnpm -s release-notes:check
+pnpm -s release-notes:check:all
+```
+
+Also rerun the release dry-run if the release process expects regenerated data:
+
+```bash
+pnpm -s release:dry-run-data
+```
+
+## Release Note Draft Points
+
+Recommended user-facing points for the next release note:
+
+- Expanded generated lower-tier data: tier 5 and level 6 now cover 1979-2025
+  where source pages expose usable tables.
+- Club metadata now covers 375 records and reflects the expanded lower-tier
+  generated scope.
+- Club metadata now includes `assets.crest` candidate bundles with provenance,
+  license checks, generated placeholders, and manual-review flags.
+- Club crest URLs are links/provenance only; the package does not redistribute
+  image binaries.
+- Most club marks are license/trademark restricted. Consumers should filter by
+  status according to their app's rights model.
+- Known remaining non-license asset review items are limited to Hounslow
+  missing research and three quality-review candidates.

--- a/docs/next-work.md
+++ b/docs/next-work.md
@@ -5,17 +5,17 @@ release plan and source of truth.
 
 ## Active Focus
 
-1. Finish review and release preparation for the crest asset metadata branch.
-   The sidecar now includes crest candidate bundles, restricted-license backups,
-   curated official/Wikimedia candidates, and generated placeholders for
-   researched clubs with no usable crest source.
+1. Open and merge the `v1.1.0` pre-release branch after CI passes. The sidecar
+   now includes crest candidate bundles, restricted-license backups, curated
+   official/Wikimedia candidates, and generated placeholders for researched
+   clubs with no usable crest source.
 2. Treat the current club asset review baseline as expected unless new source
    evidence appears: one true `needs-more-research` club (`Hounslow`), three
    quality-review candidates (`Bridgend Town`, `Bromsgrove Rovers`,
    `Solihull Borough`), and high-volume restricted-license club marks.
-3. Push/open the crest asset branch PR, run full CI-equivalent checks, and
-   include the asset metadata/consumer-filtering notes in the next release
-   notes.
+3. Use the completed release-readiness pass in
+   [next-release-data-review.md](/Users/dsteele/repos/footy-data-kit/docs/next-release-data-review.md)
+   as the current release-note source pass.
 4. Continue TypeScript migration with the next implementation slice: convert
    shared config/season-rule boundaries or the parser/builder boundary before
    parser-heavy rewrites.
@@ -46,3 +46,4 @@ release plan and source of truth.
 - [cloudflare-r2-release-archive-plan.md](/Users/dsteele/repos/footy-data-kit/docs/cloudflare-r2-release-archive-plan.md)
 - [jsonhero-release-links.md](/Users/dsteele/repos/footy-data-kit/docs/jsonhero-release-links.md)
 - [post-v1-phase-0-3-plan.md](/Users/dsteele/repos/footy-data-kit/docs/post-v1-phase-0-3-plan.md)
+- [next-release-data-review.md](/Users/dsteele/repos/footy-data-kit/docs/next-release-data-review.md)

--- a/docs/release-notes/releases.json
+++ b/docs/release-notes/releases.json
@@ -1,5 +1,13 @@
 [
   {
+    "tag": "v1.1.0",
+    "title": "Lower-tier expansion and club crest metadata",
+    "date": "2026-06-21",
+    "type": "data",
+    "schemaCompatibility": "compatible",
+    "summary": "Expands generated tier 5 and level 6 coverage from 1979 through 2025, grows club metadata to 375 records, and adds crest asset candidate metadata with provenance, license status, placeholders, and review guidance."
+  },
+  {
     "tag": "v1.0.0",
     "title": "Source-of-truth readiness",
     "date": "2026-06-19",

--- a/docs/release-notes/v1.1.0.md
+++ b/docs/release-notes/v1.1.0.md
@@ -1,0 +1,40 @@
+# v1.1.0
+
+## Summary
+
+- Expands generated lower-tier data while preserving the top-four-tier contract: tier 5 and level 6 now cover the modern 1979-2025 lower-tier slice where source pages expose usable tables.
+- Grows generated club metadata from 232 to 375 records, reflecting the broader maintained dataset scope.
+- Adds club crest asset metadata with candidate provenance, license classification, generated placeholders, and review flags so consumers can choose an asset policy that matches their rights model.
+
+## Breaking Changes
+
+None.
+
+## Data Changes
+
+- Keeps `tier1` through `tier4` season coverage unchanged from `v1.0.0`.
+- Expands generated `tier5` coverage from 14 to 47 seasons.
+- Expands generated level-six coverage from 5 to 47 seasons, using `tier6.divisions[]` for parallel divisions.
+- Adds `assets.crest` bundles to `data/club-metadata.json`. The package stores URLs and provenance only; it does not download or redistribute image binaries.
+- Classifies crest records as `usable`, `restricted`, `placeholder`, or `needs-more-research`, with review issues captured in `data/club-assets-review.json`.
+- Leaves `Hounslow` as the only true `needs-more-research` crest/color case, with `Bridgend Town`, `Bromsgrove Rovers`, and `Solihull Borough` still marked for quality review.
+
+## Validation
+
+- Full local release-readiness checks passed before the pre-release branch: `pnpm test`, `pnpm test:integration`, `pnpm typecheck`, `pnpm -s verify:data`, `pnpm -s schema:verify`, `pnpm format:check`, `pnpm -s docs:check`, `pnpm -s lint`, and `pnpm -s release:dry-run-data`.
+- The release dry-run rebuilt the full 1888-2025 generated range into a temporary directory, produced 138 season records and 375 club metadata records, and passed data verification, club-continuity verification, and JSON Schema verification.
+- `data/club-metadata-review.json` is clean with `issueCount: 0`.
+- Known club asset review issues are limited to expected restricted-license club marks, one missing research case, and three quality-review candidates.
+
+## Consumer Notes
+
+- `trackedFromSeason` and `trackedToSeason` remain observed generated-data bounds, not founded or dissolved dates.
+- `status.current` remains a current high-level metadata status, not a season-row outcome.
+- Consumers should use `usable` crest assets by default, include `placeholder` only when generated fallback shields are acceptable, and include `restricted` only when their product can handle club mark licensing and trademark restrictions.
+- Treat `needs-review`, `needs-more-research`, and `failed` crest states as non-display states unless the consuming app has its own review workflow.
+
+## Known Limitations
+
+- The lower-tier expansion substantially broadens generated coverage, but it is still constrained by Wikipedia source page availability and structure.
+- Most discovered club marks are license or trademark restricted, so the new crest metadata is a provenance and filtering layer rather than a blanket permission grant.
+- The remaining non-license asset review items are intentionally carried forward rather than filled with weak assertions.

--- a/docs/releases/index.html
+++ b/docs/releases/index.html
@@ -19,6 +19,22 @@
         <h2>Release Notes</h2>
         <div class="release-rows" aria-label="release notes">
           <div class="release-row">
+            <span>v1.1.0</span>
+            <span
+              >Expands generated tier 5 and level 6 coverage from 1979 through 2025, grows club
+              metadata to 375 records, and adds crest asset candidate metadata with provenance,
+              license status, placeholders, and review guidance.</span
+            >
+            <span class="release-actions">
+              <a class="compact-link" href="./v1.1.0.html">notes</a>
+              <a
+                class="compact-link"
+                href="https://github.com/dills122/footy-data-kit/releases/tag/v1.1.0"
+                >github</a
+              >
+            </span>
+          </div>
+          <div class="release-row">
             <span>v1.0.0</span>
             <span
               >Marks the Wikipedia overview pipeline as v1-ready with fail-closed release gates,

--- a/docs/releases/v1.1.0.html
+++ b/docs/releases/v1.1.0.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>v1.1.0 release notes | footy-data-kit</title>
+    <meta
+      name="description"
+      content="Expands generated tier 5 and level 6 coverage from 1979 through 2025, grows club metadata to 375 records, and adds crest asset candidate metadata with provenance, license status, placeholders, and review guidance."
+    />
+    <link rel="stylesheet" href="../styles.css" />
+  </head>
+  <body>
+    <main class="page-shell">
+      <header class="site-header">
+        <p class="eyebrow">release notes</p>
+        <h1>v1.1.0</h1>
+        <p class="lede">
+          Expands generated tier 5 and level 6 coverage from 1979 through 2025, grows club metadata
+          to 375 records, and adds crest asset candidate metadata with provenance, license status,
+          placeholders, and review guidance.
+        </p>
+      </header>
+
+      <section class="panel">
+        <h2>Release</h2>
+        <ul class="release-meta">
+          <li><span>title</span><strong>Lower-tier expansion and club crest metadata</strong></li>
+          <li><span>date</span><strong>2026-06-21</strong></li>
+          <li><span>type</span><strong>data</strong></li>
+          <li><span>schema</span><strong>compatible</strong></li>
+        </ul>
+      </section>
+
+      <section class="panel release-notes-body">
+        <h2>Summary</h2>
+        <ul>
+          <li>
+            Expands generated lower-tier data while preserving the top-four-tier contract: tier 5
+            and level 6 now cover the modern 1979-2025 lower-tier slice where source pages expose
+            usable tables.
+          </li>
+          <li>
+            Grows generated club metadata from 232 to 375 records, reflecting the broader maintained
+            dataset scope.
+          </li>
+          <li>
+            Adds club crest asset metadata with candidate provenance, license classification,
+            generated placeholders, and review flags so consumers can choose an asset policy that
+            matches their rights model.
+          </li>
+        </ul>
+        <h2>Breaking Changes</h2>
+        <p>None.</p>
+        <h2>Data Changes</h2>
+        <ul>
+          <li>
+            Keeps <code>tier1</code> through <code>tier4</code> season coverage unchanged from
+            <code>v1.0.0</code>.
+          </li>
+          <li>Expands generated <code>tier5</code> coverage from 14 to 47 seasons.</li>
+          <li>
+            Expands generated level-six coverage from 5 to 47 seasons, using
+            <code>tier6.divisions[]</code> for parallel divisions.
+          </li>
+          <li>
+            Adds <code>assets.crest</code> bundles to <code>data/club-metadata.json</code>. The
+            package stores URLs and provenance only; it does not download or redistribute image
+            binaries.
+          </li>
+          <li>
+            Classifies crest records as <code>usable</code>, <code>restricted</code>,
+            <code>placeholder</code>, or <code>needs-more-research</code>, with review issues
+            captured in <code>data/club-assets-review.json</code>.
+          </li>
+          <li>
+            Leaves <code>Hounslow</code> as the only true
+            <code>needs-more-research</code> crest/color case, with <code>Bridgend Town</code>,
+            <code>Bromsgrove Rovers</code>, and <code>Solihull Borough</code> still marked for
+            quality review.
+          </li>
+        </ul>
+        <h2>Validation</h2>
+        <ul>
+          <li>
+            Full local release-readiness checks passed before the pre-release branch:
+            <code>pnpm test</code>, <code>pnpm test:integration</code>, <code>pnpm typecheck</code>,
+            <code>pnpm -s verify:data</code>, <code>pnpm -s schema:verify</code>,
+            <code>pnpm format:check</code>, <code>pnpm -s docs:check</code>,
+            <code>pnpm -s lint</code>, and <code>pnpm -s release:dry-run-data</code>.
+          </li>
+          <li>
+            The release dry-run rebuilt the full 1888-2025 generated range into a temporary
+            directory, produced 138 season records and 375 club metadata records, and passed data
+            verification, club-continuity verification, and JSON Schema verification.
+          </li>
+          <li>
+            <code>data/club-metadata-review.json</code> is clean with <code>issueCount: 0</code>.
+          </li>
+          <li>
+            Known club asset review issues are limited to expected restricted-license club marks,
+            one missing research case, and three quality-review candidates.
+          </li>
+        </ul>
+        <h2>Consumer Notes</h2>
+        <ul>
+          <li>
+            <code>trackedFromSeason</code> and <code>trackedToSeason</code> remain observed
+            generated-data bounds, not founded or dissolved dates.
+          </li>
+          <li>
+            <code>status.current</code> remains a current high-level metadata status, not a
+            season-row outcome.
+          </li>
+          <li>
+            Consumers should use <code>usable</code> crest assets by default, include
+            <code>placeholder</code> only when generated fallback shields are acceptable, and
+            include <code>restricted</code> only when their product can handle club mark licensing
+            and trademark restrictions.
+          </li>
+          <li>
+            Treat <code>needs-review</code>, <code>needs-more-research</code>, and
+            <code>failed</code> crest states as non-display states unless the consuming app has its
+            own review workflow.
+          </li>
+        </ul>
+        <h2>Known Limitations</h2>
+        <ul>
+          <li>
+            The lower-tier expansion substantially broadens generated coverage, but it is still
+            constrained by Wikipedia source page availability and structure.
+          </li>
+          <li>
+            Most discovered club marks are license or trademark restricted, so the new crest
+            metadata is a provenance and filtering layer rather than a blanket permission grant.
+          </li>
+          <li>
+            The remaining non-license asset review items are intentionally carried forward rather
+            than filled with weak assertions.
+          </li>
+        </ul>
+      </section>
+
+      <section class="panel">
+        <h2>Links</h2>
+        <nav class="link-grid" aria-label="release links">
+          <a class="button-link button-link--secondary" href="./index.html">release history</a>
+          <a class="button-link button-link--secondary" href="../index.html">docs home</a>
+          <a
+            class="button-link button-link--secondary"
+            href="https://github.com/dills122/footy-data-kit/releases/tag/v1.1.0"
+            >github release</a
+          >
+          <a
+            class="button-link button-link--primary"
+            href="https://github.com/dills122/footy-data-kit/releases/download/v1.1.0/footy-data-kit-v1.1.0-data.zip"
+            >data zip</a
+          >
+        </nav>
+      </section>
+
+      <footer>
+        <span>v1.1.0</span>
+        <a href="./index.html">release history</a>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/docs/site-data.json
+++ b/docs/site-data.json
@@ -82,12 +82,18 @@
     }
   ],
   "latestRelease": {
-    "tag": "v1.0.0",
+    "tag": "v1.1.0",
     "summary": "1888-2025. 138 seasons. 375 club metadata records.",
     "notesUrl": "https://github.com/dills122/footy-data-kit/releases/latest",
-    "zipUrl": "https://github.com/dills122/footy-data-kit/releases/latest/download/footy-data-kit-v1.0.0-data.zip"
+    "zipUrl": "https://github.com/dills122/footy-data-kit/releases/latest/download/footy-data-kit-v1.1.0-data.zip"
   },
   "historicReleases": [
+    {
+      "tag": "v1.0.0",
+      "summary": "previous data release",
+      "notesUrl": "https://github.com/dills122/footy-data-kit/releases/tag/v1.0.0",
+      "zipUrl": "https://github.com/dills122/footy-data-kit/releases/download/v1.0.0/footy-data-kit-v1.0.0-data.zip"
+    },
     {
       "tag": "v0.9.1",
       "summary": "previous data release",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "footy-data-kit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Generate and clean your footy data for your next project.",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- Prepares the `v1.1.0` pre-release branch for the lower-tier expansion and club crest metadata release.
- Updates release metadata, curated release notes, generated docs pages, and package version.

## What Changed
- Bumped `package.json` from `1.0.0` to `1.1.0`.
- Added `docs/release-notes/v1.1.0.md` with user-facing release notes.
- Added `v1.1.0` to `docs/release-notes/releases.json`.
- Regenerated docs release pages and site data for `v1.1.0`.
- Added `docs/next-release-data-review.md` as release-readiness source material.
- Updated `docs/next-work.md` to point at the `v1.1.0` pre-release flow.

## Validation
- `pnpm test`
- `pnpm test:integration`
- `pnpm typecheck`
- `pnpm -s verify:data`
- `pnpm -s schema:verify`
- `pnpm format:check`
- `pnpm -s docs:check`
- `pnpm -s release-notes:check`
- `pnpm -s release-notes:check:all`
- `pnpm -s release:dry-run-data`
- Pre-commit hook passed.
- Pre-push hook passed.

## Scope Notes
- Branch is pushed and tracking `origin/pre-release/1.1.0`.
- Working tree is clean.
- Release automation expects the `pre-release/1.1.0` branch name.